### PR TITLE
Add createSeekAttachmentMiddleware

### DIFF
--- a/be/README.md
+++ b/be/README.md
@@ -2,6 +2,29 @@
 
 ## Node.js API
 
+### `createSeekAttachmentMiddleware`
+
+```typescript
+import { GetPartnerToken, createSeekAttachmentMiddleware } from 'wingman-be';
+
+const getPartnerToken: GetPartnerToken = (request) => {
+  if (request.authorization !== 'SUPER_SECRET') {
+    throw new Error('oh no!');
+  }
+
+  return getPartnerTokenFromSecretStore();
+};
+
+const createApp = () => {
+  const middleware = createSeekAttachmentMiddleware({
+    getPartnerToken,
+    userAgent: 'my-service/1.2.3',
+  });
+
+  return new Koa().use(middleware);
+};
+```
+
 ### `createSeekGraphMiddleware`
 
 ```typescript
@@ -11,22 +34,22 @@ import {
   createSeekGraphMiddleware,
 } from 'wingman-be';
 
-const getPartnerToken: GetPartnerToken = (context) => {
-  if (context.request.headers.authorization !== 'SUPER_SECRET') {
-    throw AuthenticationError('oh no!');
+const getPartnerToken: GetPartnerToken = (request) => {
+  if (request.authorization !== 'SUPER_SECRET') {
+    throw new AuthenticationError('oh no!');
   }
 
   return getPartnerTokenFromSecretStore();
 };
 
 const createApp = async () => {
-  const seekGraphMiddleware = await createSeekGraphMiddleware({
+  const middleware = await createSeekGraphMiddleware({
     debug: false,
     getPartnerToken,
     path: '/seek-graphql',
     userAgent: 'my-service/1.2.3',
   });
 
-  return new Koa().use(seekGraphMiddleware);
+  return new Koa().use(middleware);
 };
 ```

--- a/be/src/getPartnerToken.ts
+++ b/be/src/getPartnerToken.ts
@@ -1,0 +1,11 @@
+/**
+ * Function that verifies that the incoming request is authorised to act on
+ * behalf of a partner and provides a partner token in response.
+ */
+export type GetPartnerToken = (
+  request: GetPartnerTokenRequest,
+) => Promise<string>;
+
+export interface GetPartnerTokenRequest {
+  authorization?: string;
+}

--- a/be/src/index.ts
+++ b/be/src/index.ts
@@ -5,5 +5,8 @@ export {
   UserInputError,
 } from 'apollo-server-koa';
 
+export { GetPartnerToken } from './getPartnerToken';
+export { createSeekAttachmentMiddleware } from './seekAttachment/middleware';
+export { SeekAttachmentMiddlewareOptions } from './seekAttachment/types';
 export { createSeekGraphMiddleware } from './seekGraph/middleware';
-export { GetPartnerToken, SeekGraphMiddlewareOptions } from './seekGraph/types';
+export { SeekGraphMiddlewareOptions } from './seekGraph/types';

--- a/be/src/seekAttachment/headers.test.ts
+++ b/be/src/seekAttachment/headers.test.ts
@@ -1,0 +1,44 @@
+import { Headers } from 'node-fetch';
+
+import { filterHeaders } from './headers';
+
+describe('filterHeaders', () => {
+  it.each([
+    [
+      'adds defaults on empty input',
+      new Headers(),
+      {
+        'Content-Disposition': 'attachment',
+        'Content-Type': 'application/octet-stream',
+      },
+    ],
+    [
+      'drops other input headers',
+      new Headers({
+        'User-Agent': 'my-service/1.2.3',
+        'X-Deprecate-X': 'foo',
+      }),
+      {
+        'Content-Disposition': 'attachment',
+        'Content-Type': 'application/octet-stream',
+      },
+    ],
+    [
+      'overrides defaults with input headers',
+      new Headers({
+        'Content-Disposition': 'attachment; filename="cool.html"',
+        'content-length': '123',
+        'cOnTeNt-TyPe': 'text/html; charset=utf-8',
+        'LAST-MODIFIED': 'Wed, 21 Oct 2015 07:28:00 GMT',
+      }),
+      {
+        'Content-Disposition': 'attachment; filename="cool.html"',
+        'Content-Length': '123',
+        'Content-Type': 'text/html; charset=utf-8',
+        'Last-Modified': 'Wed, 21 Oct 2015 07:28:00 GMT',
+      },
+    ],
+  ] as const)('%s', (_, input, output) =>
+    expect(filterHeaders(input)).toEqual(output),
+  );
+});

--- a/be/src/seekAttachment/headers.ts
+++ b/be/src/seekAttachment/headers.ts
@@ -1,0 +1,22 @@
+import { Headers } from 'node-fetch';
+
+const HEADERS_TO_FORWARD = {
+  'Content-Disposition': 'attachment',
+  'Content-Length': undefined,
+  'Content-Type': 'application/octet-stream',
+  'Last-Modified': undefined,
+} as const;
+
+export const filterHeaders = (headers: Headers) =>
+  Object.entries(HEADERS_TO_FORWARD).reduce<Record<string, string>>(
+    (subset, [name, defaultValue]) => {
+      const value = headers.get(name) ?? defaultValue;
+
+      if (typeof value !== 'undefined') {
+        subset[name] = value;
+      }
+
+      return subset;
+    },
+    {},
+  );

--- a/be/src/seekAttachment/middleware.test.ts
+++ b/be/src/seekAttachment/middleware.test.ts
@@ -1,0 +1,85 @@
+import Koa from 'koa';
+import nock from 'nock';
+
+import { SEEK_API_BASE_URL } from '../constants';
+import { createAgent } from '../testing/http';
+import { getPartnerToken } from '../testing/mock';
+
+import { createSeekAttachmentMiddleware } from './middleware';
+
+describe('createSeekAttachmentMiddleware', () => {
+  const agent = createAgent(() => {
+    const middleware = createSeekAttachmentMiddleware({
+      getPartnerToken,
+      userAgent: 'abc/1.2.3',
+    });
+
+    return new Koa().use(middleware);
+  });
+
+  beforeAll(agent.setup);
+
+  beforeEach(() =>
+    getPartnerToken.mockImplementation((ctx) =>
+      Promise.resolve(ctx.authorization === 'in' ? 'out' : ''),
+    ),
+  );
+
+  afterEach(jest.clearAllMocks);
+
+  afterAll(agent.teardown);
+
+  const attachmentUrl = (origin: string) =>
+    `/attachment?url=${encodeURIComponent(`${origin}/custom`)}`;
+
+  it('proxies a 200 response', async () => {
+    nock(SEEK_API_BASE_URL).get('/custom').reply(200, Buffer.from('# My CV'), {
+      'content-disposition': 'attachment; filename="cv.md"',
+      'content-length': '7',
+      'content-type': 'text/markdown; charset=utf-8',
+      'last-modified': 'Tue, 01 Oct 2019 01:02:03 GMT',
+    });
+
+    const response = await agent()
+      .get(attachmentUrl(SEEK_API_BASE_URL))
+      .set('aUtHoRiZaTiOn', 'in')
+      .expect(200, '# My CV');
+
+    expect(response.header).toMatchObject({
+      'content-disposition': 'attachment; filename="cv.md"',
+      'content-type': 'text/markdown; charset=utf-8',
+      'last-modified': 'Tue, 01 Oct 2019 01:02:03 GMT',
+    });
+  });
+
+  it('proxies a 500 response', () => {
+    nock(SEEK_API_BASE_URL).get('/custom').reply(500, 'External Server Error');
+
+    return agent()
+      .get(attachmentUrl(SEEK_API_BASE_URL))
+      .set('aUtHoRiZaTiOn', 'in')
+      .expect(500)
+      .expect(Buffer.from('External Server Error'));
+  });
+
+  it('blocks an SSRF attempt', () =>
+    agent()
+      .get(attachmentUrl('https://haveibeenpwned.com'))
+      .set('aUtHoRiZaTiOn', 'in')
+      .expect(400, "Query parameter 'url' must point to the SEEK API"));
+
+  it('blocks a request with the wrong query parameter', () =>
+    agent()
+      .get('/attachment?uri=x')
+      .set('aUtHoRiZaTiOn', 'in')
+      .expect(400, "Query parameter 'url' must be a string"));
+
+  it('blocks an unauthorised request', () => {
+    getPartnerToken.mockRejectedValue(new Error('Help me'));
+
+    return agent()
+      .get(attachmentUrl(SEEK_API_BASE_URL))
+      .set('Authorization', 'Email insecure@example.com')
+      .expect(401, 'Help me');
+  });
+});

--- a/be/src/seekAttachment/middleware.test.ts
+++ b/be/src/seekAttachment/middleware.test.ts
@@ -32,7 +32,7 @@ describe('createSeekAttachmentMiddleware', () => {
   const attachmentUrl = (origin: string) =>
     `/attachment?url=${encodeURIComponent(`${origin}/custom`)}`;
 
-  it('proxies a 200 response', async () => {
+  it('proxies a 200 response with headers', async () => {
     nock(SEEK_API_BASE_URL).get('/custom').reply(200, Buffer.from('# My CV'), {
       'content-disposition': 'attachment; filename="cv.md"',
       'content-length': '7',
@@ -47,8 +47,24 @@ describe('createSeekAttachmentMiddleware', () => {
 
     expect(response.header).toMatchObject({
       'content-disposition': 'attachment; filename="cv.md"',
+      'content-length': '7',
       'content-type': 'text/markdown; charset=utf-8',
       'last-modified': 'Tue, 01 Oct 2019 01:02:03 GMT',
+    });
+  });
+
+  it('proxies a 200 response without headers', async () => {
+    nock(SEEK_API_BASE_URL).get('/custom').reply(200, Buffer.from('# My CV'));
+
+    const response = await agent()
+      .get(attachmentUrl(SEEK_API_BASE_URL))
+      .set('aUtHoRiZaTiOn', 'in')
+      .expect(200)
+      .expect(Buffer.from('# My CV'));
+
+    expect(response.header).toMatchObject({
+      'content-disposition': 'attachment',
+      'content-type': 'application/octet-stream',
     });
   });
 

--- a/be/src/seekAttachment/middleware.ts
+++ b/be/src/seekAttachment/middleware.ts
@@ -1,0 +1,79 @@
+import { Context, Middleware } from 'koa';
+import fetch from 'node-fetch';
+
+import { SEEK_API_BASE_URL } from '../constants';
+import { GetPartnerToken } from '../getPartnerToken';
+
+import { filterHeaders } from './headers';
+import { SeekAttachmentEvent, SeekAttachmentMiddlewareOptions } from './types';
+
+const wrapRetriever = async (
+  ctx: Context,
+  getPartnerToken: GetPartnerToken,
+) => {
+  const request = {
+    authorization: ctx.get('Authorization') || undefined,
+  };
+
+  try {
+    return await getPartnerToken(request);
+  } catch (err) {
+    // This is a bit of a hack. Consider either exposing the full Koa context to
+    // `getPartnerToken`, or standardising error behaviour so that we don’t
+    // handle unexpected errors and expose internal workings to the client.
+    return ctx.throw(401, err);
+  }
+};
+
+const parseUrlParameter = (ctx: Context) => {
+  const { url } = ctx.query as Record<string, unknown>;
+
+  if (typeof url !== 'string') {
+    return ctx.throw(400, "Query parameter 'url' must be a string");
+  }
+
+  const { origin } = new URL(url);
+
+  if (origin !== SEEK_API_BASE_URL) {
+    return ctx.throw(400, "Query parameter 'url' must point to the SEEK API");
+  }
+
+  return url;
+};
+
+export const createSeekAttachmentMiddleware = ({
+  callback,
+  getPartnerToken,
+  userAgent,
+}: SeekAttachmentMiddlewareOptions): Middleware =>
+  async function seekAttachmentMiddleware(ctx) {
+    const partnerToken = await wrapRetriever(ctx, getPartnerToken);
+
+    const url = parseUrlParameter(ctx);
+
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${partnerToken}`,
+        'User-Agent': userAgent,
+      },
+      method: 'GET',
+    });
+
+    ctx.body = response.body;
+
+    ctx.set(filterHeaders(response.headers));
+
+    ctx.status = response.status;
+
+    if (typeof callback === 'undefined') {
+      return;
+    }
+
+    const event: SeekAttachmentEvent = {
+      type: 'RETRIEVED',
+      status: response.status,
+      url,
+    };
+
+    return callback(ctx, event);
+  };

--- a/be/src/seekAttachment/types.ts
+++ b/be/src/seekAttachment/types.ts
@@ -1,0 +1,15 @@
+import { Context } from 'koa';
+
+import { GetPartnerToken } from '../getPartnerToken';
+
+export type SeekAttachmentEvent = {
+  type: 'RETRIEVED';
+  status: number;
+  url: string;
+};
+
+export interface SeekAttachmentMiddlewareOptions {
+  callback?: (ctx: Context, event: SeekAttachmentEvent) => void | Promise<void>;
+  getPartnerToken: GetPartnerToken;
+  userAgent: string;
+}

--- a/be/src/seekGraph/context.ts
+++ b/be/src/seekGraph/context.ts
@@ -2,7 +2,7 @@
 
 import * as t from 'runtypes';
 
-import { SeekGraphContext } from './types';
+import { GetPartnerTokenRequest } from '../getPartnerToken';
 
 const IncomingContext = t.Record({
   ctx: t.Record({
@@ -16,7 +16,7 @@ const IncomingContext = t.Record({
 
 type IncomingContext = t.Static<typeof IncomingContext>;
 
-export const createContext = (context: unknown): SeekGraphContext => {
+export const createContext = (context: unknown): GetPartnerTokenRequest => {
   const result = IncomingContext.validate(context);
 
   return {

--- a/be/src/seekGraph/schema.ts
+++ b/be/src/seekGraph/schema.ts
@@ -4,8 +4,9 @@ import { GraphQLSchema, print } from 'graphql';
 import fetch from 'node-fetch';
 
 import { SEEK_API_URL } from '../constants';
+import { GetPartnerTokenRequest } from '../getPartnerToken';
 
-import { SeekGraphContext, SeekGraphMiddlewareOptions } from './types';
+import { SeekGraphMiddlewareOptions } from './types';
 
 type Options = Pick<
   SeekGraphMiddlewareOptions,
@@ -21,7 +22,7 @@ const createExecutor = ({
   const partnerToken =
     typeof context === 'undefined'
       ? undefined
-      : await getPartnerToken(context as SeekGraphContext);
+      : await getPartnerToken(context as GetPartnerTokenRequest);
 
   const authHeaders: Record<string, string> =
     typeof partnerToken === 'undefined'

--- a/be/src/seekGraph/types.ts
+++ b/be/src/seekGraph/types.ts
@@ -1,14 +1,4 @@
-/**
- * Function that verifies that the incoming request is authorised to act on
- * behalf of a partner and provides a partner token in response.
- */
-export type GetPartnerToken = (
-  context: SeekGraphContext,
-) => Promise<string | undefined>;
-
-export interface SeekGraphContext {
-  authorization?: string;
-}
+import { GetPartnerToken } from '../getPartnerToken';
 
 export interface SeekGraphMiddlewareOptions {
   debug: boolean;

--- a/be/src/testing/mock.ts
+++ b/be/src/testing/mock.ts
@@ -1,0 +1,6 @@
+import { GetPartnerTokenRequest } from '../getPartnerToken';
+
+export const getPartnerToken = jest.fn<
+  Promise<string>,
+  [GetPartnerTokenRequest]
+>();


### PR DESCRIPTION
This configures a proxy handler for attachment downloads. The major difference compared to the original implementation is that this has been rebased on `node-fetch` and passes a readable stream through to Koa.

I’ve tried to reuse the same `GetPartnerToken` definition here but I think the cracks are starting to show. Once the middlewares have settled a little, we can revisit its signature.