### PR TITLE
Ignore explicit-module-boundary-types on frontend

### DIFF
--- a/fe/sku.config.js
+++ b/fe/sku.config.js
@@ -7,4 +7,12 @@ module.exports = {
   sites: [{ name: 'seekUnifiedBeta', host: 'dev.seekunifiedbeta.com' }],
 
   orderImports: true,
+
+  dangerouslySetESLintConfig: (skuEslintConfig) => ({
+    ...skuEslintConfig,
+    rules: {
+      ...skuEslintConfig.rules,
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+    },
+  }),
 };


### PR DESCRIPTION
No, I’m not going to type everything as JSX.Element.