### PR TITLE
Add createPartnerWebhookMiddleware stub

### DIFF
--- a/be/README.md
+++ b/be/README.md
@@ -37,7 +37,56 @@ Content-Type: application/json
 }
 ```
 
+### /webhook
+
+```http
+POST http://localhost:9090/webhook/abc HTTP/1.1
+Content-Type: application/json
+
+{
+  "events": [
+    {
+      "createDateTime": "foo",
+      "id": "foo",
+      "type": "CandidateApplicationCreated",
+      "candidateApplicationProfileId": "foo",
+      "candidateId": "foo"
+    }
+  ],
+  "subscriptionId": "foo"
+}
+```
+
+```http
+HTTP/1.1 204 OK
+```
+
 ## Node.js API
+
+## `createPartnerWebhookMiddleware`
+
+```typescript
+import { GetSigningSecret, createPartnerWebhookMiddleware } from 'wingman-be';
+
+const getSigningSecret: GetSigningSecret = (subscriptionId) => {
+  switch (subscriptionId) {
+    case 'fully seekret':
+      return getSigningSecretFromSecretStore();
+    case 'risky business':
+      return null;
+    default:
+      throw new Error('Invalid request');
+  }
+};
+
+const createApp = () => {
+  const middleware = createSeekAttachmentMiddleware({
+    getSigningSecret,
+  });
+
+  return new Koa().use(middleware);
+};
+```
 
 ### `createSeekAttachmentMiddleware`
 

--- a/be/example/src/api/attachment.ts
+++ b/be/example/src/api/attachment.ts
@@ -1,24 +1,9 @@
-import cors from '@koa/cors';
-import Router from '@koa/router';
-
 import { createSeekAttachmentMiddleware } from '../../../src';
-import { FE_ORIGIN, USER_AGENT, getPartnerToken } from '../config';
+import { USER_AGENT, getPartnerToken } from '../config';
 
-const corsMiddleware = cors({
-  // Needed for attachment downloads
-  exposeHeaders: ['Content-Disposition'],
-
-  // Allow frontend local development server
-  origin: FE_ORIGIN,
-});
-
-const seekAttachmentMiddleware = createSeekAttachmentMiddleware({
+export const seekAttachmentMiddleware = createSeekAttachmentMiddleware({
   /* eslint-disable-next-line no-console */
   callback: (_, event) => console.debug('attachment', event),
   getPartnerToken,
   userAgent: USER_AGENT,
 });
-
-export const attachmentRouter = new Router()
-  .use(corsMiddleware)
-  .get('downloadAttachment', '/', seekAttachmentMiddleware);

--- a/be/example/src/api/cors.ts
+++ b/be/example/src/api/cors.ts
@@ -1,0 +1,11 @@
+import cors from '@koa/cors';
+
+import { FE_ORIGIN } from '../config';
+
+export const corsMiddleware = cors({
+  // Needed for attachment downloads
+  exposeHeaders: ['Content-Disposition'],
+
+  // Allow frontend local development server
+  origin: FE_ORIGIN,
+});

--- a/be/example/src/api/index.ts
+++ b/be/example/src/api/index.ts
@@ -18,8 +18,8 @@ export const createMiddleware = async (): Promise<Middleware> => {
   });
 
   const router = new Router()
-    .use('/attachment', seekAttachmentMiddleware)
-    .use('/webhook/:endpoint', partnerWebhookMiddleware);
+    .get('/attachment', seekAttachmentMiddleware)
+    .post('/webhook/:endpoint', partnerWebhookMiddleware);
 
   // TODO: fix incompatibility with @koa/router context
   return compose<any>([

--- a/be/example/src/api/webhook.ts
+++ b/be/example/src/api/webhook.ts
@@ -1,0 +1,8 @@
+import { createPartnerWebhookMiddleware } from '../../../src';
+import { getSigningSecret } from '../config';
+
+export const partnerWebhookMiddleware = createPartnerWebhookMiddleware({
+  /* eslint-disable-next-line no-console */
+  callback: (_, event) => console.debug('webhook', event),
+  getSigningSecret,
+});

--- a/be/example/src/config.ts
+++ b/be/example/src/config.ts
@@ -4,9 +4,19 @@ export const FE_ORIGIN = 'http://dev.seekunifiedbeta.com:8080';
 
 export const USER_AGENT = 'wingman/local';
 
-// Take care when handling your token; it’s easy for environment variables to be
-// accessed by other processes, accidentally logged, or persisted to shell
-// history. We recommend wiring this up to a secret store like AWS Secrets
-// Manager.
+/**
+ * Take care when handling your token; it’s easy for environment variables to be
+ * accessed by other processes, accidentally logged, or persisted to shell
+ * history. We recommend wiring this up to a secret store like AWS Secrets
+ * Manager.
+ */
 export const getPartnerToken = () =>
   Promise.resolve(process.env.DANGEROUS_PLAYGROUND_TOKEN ?? '');
+
+/**
+ * This ignores signature verification for all incoming webhooks! Don’t do this
+ * in production. Store the signing secret against each subscription ID in a
+ * secure place that you can look up from your software, such as an encrypted
+ * database or secret store.
+ */
+export const getSigningSecret = () => Promise.resolve(null);

--- a/be/package.json
+++ b/be/package.json
@@ -5,6 +5,7 @@
     "apollo-server-koa": "^2.14.1",
     "graphql": "^15.0.0",
     "koa": "^2.12.0",
+    "koa-bodyparser": "^4.3.0",
     "koa-compose": "^4.1.0",
     "node-fetch": "^2.6.0",
     "runtypes": "^4.2.0"

--- a/be/src/index.ts
+++ b/be/src/index.ts
@@ -6,6 +6,11 @@ export {
 } from 'apollo-server-koa';
 
 export { GetPartnerToken } from './getPartnerToken';
+export { createPartnerWebhookMiddleware } from './partnerWebhook/middleware';
+export {
+  GetSigningSecret,
+  PartnerWebhookMiddlewareOptions,
+} from './partnerWebhook/types';
 export { createSeekAttachmentMiddleware } from './seekAttachment/middleware';
 export { SeekAttachmentMiddlewareOptions } from './seekAttachment/types';
 export { createSeekGraphMiddleware } from './seekGraph/middleware';

--- a/be/src/partnerWebhook/middleware.test.ts
+++ b/be/src/partnerWebhook/middleware.test.ts
@@ -1,0 +1,112 @@
+import Koa from 'koa';
+
+import {
+  INVALID_WEBHOOK_SIGNATURE,
+  SIGNED_WEBHOOK_BODY,
+  SIGNED_WEBHOOK_SECRET,
+  SIGNED_WEBHOOK_SIGNATURE,
+  SIGNED_WEBHOOK_SUBSCRIPTION_ID,
+  UNSIGNED_WEBHOOK_BODY,
+  UNSIGNED_WEBHOOK_SUBSCRIPTION_ID,
+} from '../testing/data';
+import { createAgent } from '../testing/http';
+import { getSigningSecret } from '../testing/mock';
+
+import { createPartnerWebhookMiddleware } from './middleware';
+
+describe('createPartnerWebhookMiddleware', () => {
+  const callback = jest.fn().mockResolvedValue(undefined);
+
+  const agent = createAgent(() => {
+    const middleware = createPartnerWebhookMiddleware({
+      callback,
+      getSigningSecret,
+    });
+
+    return new Koa().use(middleware);
+  });
+
+  beforeAll(agent.setup);
+
+  beforeEach(() =>
+    getSigningSecret.mockImplementation((subscriptionId) => {
+      switch (subscriptionId) {
+        case SIGNED_WEBHOOK_SUBSCRIPTION_ID:
+          return Promise.resolve(SIGNED_WEBHOOK_SECRET);
+        case UNSIGNED_WEBHOOK_SUBSCRIPTION_ID:
+          return Promise.resolve(null);
+        default:
+          return Promise.reject(new Error('New webhook, who dis'));
+      }
+    }),
+  );
+
+  afterEach(jest.clearAllMocks);
+
+  afterAll(agent.teardown);
+
+  it('accepts a signed request', async () => {
+    await agent()
+      .post('/')
+      .set('Seek-Signature', SIGNED_WEBHOOK_SIGNATURE)
+      .send(SIGNED_WEBHOOK_BODY)
+      .expect(204);
+
+    expect(callback.mock.calls[0][1]).toEqual({
+      body: SIGNED_WEBHOOK_BODY,
+      signature: SIGNED_WEBHOOK_SIGNATURE,
+      type: 'RECEIVED',
+      valid: true,
+    });
+  });
+
+  it('accepts a request for which we have a null secret', async () => {
+    await agent()
+      .post('/')
+      .set('Seek-Signature', INVALID_WEBHOOK_SIGNATURE)
+      .send(UNSIGNED_WEBHOOK_BODY)
+      .expect(204);
+
+    expect(callback.mock.calls[0][1]).toEqual({
+      body: UNSIGNED_WEBHOOK_BODY,
+      signature: INVALID_WEBHOOK_SIGNATURE,
+      type: 'RECEIVED',
+      valid: true,
+    });
+  });
+
+  it('denies a request with a mismatched signature', async () => {
+    await agent()
+      .post('/')
+      .set('Seek-Signature', INVALID_WEBHOOK_SIGNATURE)
+      .send(SIGNED_WEBHOOK_BODY)
+      .expect(400, 'Invalid request');
+
+    expect(callback.mock.calls[0][1]).toEqual({
+      body: SIGNED_WEBHOOK_BODY,
+      signature: INVALID_WEBHOOK_SIGNATURE,
+      type: 'RECEIVED',
+      valid: false,
+    });
+  });
+
+  it('denies a request with an unknown subscription ID', async () => {
+    await agent()
+      .post('/')
+      .set('Seek-Signature', SIGNED_WEBHOOK_SIGNATURE)
+      .send({ ...SIGNED_WEBHOOK_BODY, subscriptionId: '???' })
+      .expect(400, 'New webhook, who dis');
+
+    expect(callback).not.toBeCalled();
+  });
+
+  it('denies a request with an invalid body', async () => {
+    await agent()
+      .post('/')
+      .set('Seek-Signature', SIGNED_WEBHOOK_SIGNATURE)
+      .send({})
+      .expect(400, 'Invalid request');
+
+    expect(callback).not.toBeCalled();
+  });
+});

--- a/be/src/partnerWebhook/middleware.ts
+++ b/be/src/partnerWebhook/middleware.ts
@@ -1,0 +1,82 @@
+import { Context, Middleware } from 'koa';
+import bodyParser from 'koa-bodyparser';
+import compose from 'koa-compose';
+
+import { validateWebhookSignature } from './signature';
+import {
+  GetSigningSecret,
+  PartnerWebhookEvent,
+  PartnerWebhookMiddlewareOptions,
+  WebhookBody,
+} from './types';
+
+const wrapRetriever = async (
+  ctx: Context,
+  promise: ReturnType<GetSigningSecret>,
+) => {
+  try {
+    return await promise;
+  } catch (err) {
+    // This is a bit of a hack. Consider either exposing the full Koa context to
+    // `getSigningSecret`, or standardising error behaviour so that we don’t
+    // handle unexpected errors and expose internal workings to the client.
+    return ctx.throw(400, err);
+  }
+};
+
+const _createPartnerWebhookMiddleware = ({
+  callback,
+  getSigningSecret,
+}: PartnerWebhookMiddlewareOptions): Middleware =>
+  async function PartnerWebhookMiddleware(ctx) {
+    const bodyResult = WebhookBody.validate(ctx.request.body);
+
+    if (!bodyResult.success) {
+      return ctx.throw(400, 'Invalid request');
+    }
+
+    const body = bodyResult.value;
+
+    const signature = ctx.get('Seek-Signature');
+
+    const secret = await wrapRetriever(
+      ctx,
+      getSigningSecret(body.subscriptionId),
+    );
+
+    const valid =
+      secret === null
+        ? true
+        : validateWebhookSignature({
+            body: ctx.request.rawBody,
+            signature,
+            secret,
+          });
+
+    if (typeof callback !== 'undefined') {
+      const event: PartnerWebhookEvent = {
+        type: 'RECEIVED',
+        body,
+        signature,
+        valid,
+      };
+
+      await callback(ctx, event);
+    }
+
+    if (!valid) {
+      return ctx.throw(400, 'Invalid request');
+    }
+
+    ctx.status = 204;
+
+    return;
+  };
+
+export const createPartnerWebhookMiddleware = (
+  options: PartnerWebhookMiddlewareOptions,
+): Middleware =>
+  compose([
+    bodyParser({ enableTypes: ['json'] }),
+    _createPartnerWebhookMiddleware(options),
+  ]);

--- a/be/src/partnerWebhook/signature.ts
+++ b/be/src/partnerWebhook/signature.ts
@@ -1,0 +1,27 @@
+/* eslint-disable new-cap */
+
+import crypto from 'crypto';
+
+interface ValidateWebhookBodyOptions {
+  body: string;
+  secret: string;
+  signature: string;
+}
+
+export const validateWebhookSignature = ({
+  body,
+  secret,
+  signature,
+}: ValidateWebhookBodyOptions) => {
+  const hmac = crypto.createHmac('sha512', secret);
+
+  const computedSignature = hmac.update(body).digest('hex');
+
+  return (
+    signature.length === computedSignature.length &&
+    crypto.timingSafeEqual(
+      Buffer.from(signature),
+      Buffer.from(computedSignature),
+    )
+  );
+};

--- a/be/src/partnerWebhook/types.ts
+++ b/be/src/partnerWebhook/types.ts
@@ -1,0 +1,57 @@
+/* eslint-disable new-cap */
+
+import { Context } from 'koa';
+import * as t from 'runtypes';
+
+/**
+ * Function that retrieves the shared secret used to sign the webhook bodies for
+ * a particular subscription ID.
+ *
+ * Return `null` if you wish to skip signature verification.
+ */
+export type GetSigningSecret = (
+  subscriptionId: string,
+) => Promise<string | null>;
+
+export type PartnerWebhookEvent = {
+  type: 'RECEIVED';
+  body: WebhookBody;
+  signature: string;
+  valid: boolean;
+};
+
+export interface PartnerWebhookMiddlewareOptions {
+  getSigningSecret: GetSigningSecret;
+  callback?: (ctx: Context, event: PartnerWebhookEvent) => void | Promise<void>;
+}
+
+const NonEmptyString = t.String.withConstraint(
+  (str) => str !== '' || 'string must not be empty',
+);
+
+const EVENT_FIELDS = {
+  id: NonEmptyString,
+  createDateTime: NonEmptyString,
+  type: t.Union(t.Literal('CandidateApplicationCreated')),
+} as const;
+
+const CandidateApplicationCreatedEvent = t.Record({
+  ...EVENT_FIELDS,
+  type: t.Literal('CandidateApplicationCreated'),
+
+  candidateApplicationProfileId: NonEmptyString,
+  candidateId: NonEmptyString,
+});
+
+const Event = CandidateApplicationCreatedEvent;
+
+export const WebhookBody = t.Record({
+  events: t
+    .Array(Event)
+    .withConstraint(
+      (events) => events.length > 0 || 'events must not be an empty array',
+    ),
+  subscriptionId: NonEmptyString,
+});
+
+export type WebhookBody = t.Static<typeof WebhookBody>;

--- a/be/src/testing/data.ts
+++ b/be/src/testing/data.ts
@@ -1,0 +1,37 @@
+import crypto from 'crypto';
+
+import { WebhookBody } from '../partnerWebhook/types';
+
+export const SIGNED_WEBHOOK_SUBSCRIPTION_ID = 'signed';
+
+export const UNSIGNED_WEBHOOK_SUBSCRIPTION_ID = 'unsigned';
+
+export const SIGNED_WEBHOOK_BODY: WebhookBody = {
+  events: [
+    {
+      createDateTime: 'foo',
+      id: 'foo',
+      type: 'CandidateApplicationCreated',
+
+      candidateApplicationProfileId: 'foo',
+      candidateId: 'foo',
+    },
+  ],
+
+  subscriptionId: SIGNED_WEBHOOK_SUBSCRIPTION_ID,
+};
+
+export const UNSIGNED_WEBHOOK_BODY: WebhookBody = {
+  ...SIGNED_WEBHOOK_BODY,
+
+  subscriptionId: UNSIGNED_WEBHOOK_SUBSCRIPTION_ID,
+};
+
+export const SIGNED_WEBHOOK_SECRET = 'Hi Richard!';
+
+export const SIGNED_WEBHOOK_SIGNATURE = crypto
+  .createHmac('sha512', SIGNED_WEBHOOK_SECRET)
+  .update(JSON.stringify(SIGNED_WEBHOOK_BODY))
+  .digest('hex');
+
+export const INVALID_WEBHOOK_SIGNATURE = 'this is totally not a HMAC';

--- a/be/src/testing/mock.ts
+++ b/be/src/testing/mock.ts
@@ -4,3 +4,5 @@ export const getPartnerToken = jest.fn<
   Promise<string>,
   [GetPartnerTokenRequest]
 >();
+
+export const getSigningSecret = jest.fn<Promise<string | null>, [string]>();

--- a/fe/example/src/App/HomePage.tsx
+++ b/fe/example/src/App/HomePage.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import { Attachments } from './Attachments';
 import { Version } from './Version';
+import { Webhook } from './Webhook';
 
 export const HomePage = () => (
   <ContentBlock>
@@ -14,6 +15,12 @@ export const HomePage = () => (
       </Hidden>
 
       <Version />
+
+      <Hidden above="tablet">
+        <Divider />
+      </Hidden>
+
+      <Webhook />
     </Stack>
   </ContentBlock>
 );

--- a/fe/example/src/App/Webhook.tsx
+++ b/fe/example/src/App/Webhook.tsx
@@ -1,0 +1,82 @@
+import {
+  Actions,
+  Button,
+  Card,
+  Heading,
+  Stack,
+  Text,
+  Alert,
+} from 'braid-design-system';
+import React, { useState } from 'react';
+
+import { postPartnerWebhook } from '../api/partnerWebhook';
+
+const HARDCODED_WEBHOOK_PAYLOAD = {
+  events: [
+    {
+      createDateTime: 'foo',
+      id: 'foo',
+      type: 'CandidateApplicationCreated',
+      candidateApplicationProfileId: 'foo',
+      candidateId: 'foo',
+    },
+  ],
+  subscriptionId: 'foo',
+};
+
+const HARDCODED_WEBHOOK_ENDPOINT = 'abc-123';
+
+export const Webhook = () => {
+  const [loading, setLoading] = useState(false);
+
+  const [response, setResponse] = useState<{
+    message: string;
+    tone: 'critical' | 'positive';
+  }>();
+
+  const onClick = async (event: React.MouseEvent) => {
+    event.preventDefault();
+
+    setLoading(true);
+    setResponse(undefined);
+
+    try {
+      const message = await postPartnerWebhook(
+        HARDCODED_WEBHOOK_PAYLOAD,
+        HARDCODED_WEBHOOK_ENDPOINT,
+      );
+
+      setResponse({
+        message,
+        tone: 'positive',
+      });
+    } catch (err) {
+      setResponse({
+        message: String(err),
+        tone: 'critical',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card>
+      <Stack dividers space="large">
+        <Heading level="3">Webhook</Heading>
+
+        <Stack space="medium">
+          <Actions>
+            <Button loading={loading} onClick={onClick}>
+              Send
+            </Button>
+          </Actions>
+
+          <Alert tone={response?.tone ?? 'info'}>
+            <Text>{response?.message ?? 'Waiting...'}</Text>
+          </Alert>
+        </Stack>
+      </Stack>
+    </Card>
+  );
+};

--- a/fe/example/src/api/partnerWebhook.ts
+++ b/fe/example/src/api/partnerWebhook.ts
@@ -1,0 +1,26 @@
+import { BE_BASE_URL } from './constants';
+
+const webhookUrl = (endpoint: string) => `${BE_BASE_URL}/webhook/${endpoint}`;
+
+/**
+ * You wouldn't have this in a real production system, but it's an easy way to
+ * seed data for demonstrative purposes without having to deploy a database,
+ * public webhook endpoint, etc.
+ */
+export const postPartnerWebhook = async (data: unknown, endpoint: string) => {
+  const response = await fetch(webhookUrl(endpoint), {
+    body: JSON.stringify(data),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    method: 'POST',
+  });
+
+  if (response.status === 204) {
+    return 'Received a 204!';
+  }
+
+  const body = await response.text();
+
+  throw Error(`${response.status} ${response.statusText}: ${body}`);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -10282,7 +10282,7 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-koa-bodyparser@^4.2.1:
+koa-bodyparser@^4.2.1, koa-bodyparser@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/koa-bodyparser/-/koa-bodyparser-4.3.0.tgz#274c778555ff48fa221ee7f36a9fbdbace22759a"
   integrity sha512-uyV8G29KAGwZc4q/0WUAjH+Tsmuv9ImfBUF2oZVyZtaeo0husInagyn/JH85xMSxM0hEk/mbCII5ubLDuqW/Rw==


### PR DESCRIPTION
This only formally covers input validation and signature verification, though storage could be implemented through the callback.

It also wires up the example frontend and backend with a new feature: the frontend can POST a fake webhook. If we can’t figure out a nice way to get the webhook interaction working in a self-contained manner, we may just support some form of seeding. This could be triggered at startup and/or by user interaction.

---

![Screen Shot 2020-06-03 at 23 56 41](https://user-images.githubusercontent.com/25572311/83645484-e40f4d00-a5f5-11ea-8af3-f2324a7f157a.png)
