### PR TITLE
Add createBrowserTokenMiddleware

### DIFF
--- a/.changeset/tender-dolphins-knock.md
+++ b/.changeset/tender-dolphins-knock.md
@@ -1,0 +1,9 @@
+---
+'wingman-be': patch
+---
+
+Add `createBrowserTokenMiddleware`
+
+Use this middleware to issue a hirer-scoped token for use directly in the browser.
+This is a recommended pattern for partners and we should encourage its use where possible.
+The proxying middleware will be kept around to demo partner-scoped interactions and for rapid prototyping.

--- a/be/README.md
+++ b/be/README.md
@@ -20,6 +20,25 @@ Content-Type: text/plain
 # My CV
 ```
 
+### /browser-token
+
+Provide a hirer-scoped browser token to the Wingman F.E.
+
+```http
+POST http://localhost:9090/browser-token HTTP/1.1
+Authorization: ...
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "authorization": "Bearer ey...",
+  "expiry": "1970-01-01T00:00:00.000Z"
+}
+```
+
 ### /seek-graphql
 
 Proxy requests from the Wingman F.E. to the SEEK API’s GraphQL endpoint.
@@ -73,6 +92,37 @@ HTTP/1.1 204 OK
 ```
 
 ## Node.js API
+
+## `createBrowserTokenMiddleware`
+
+```typescript
+import { GetPartnerToken, createBrowserTokenMiddleware } from 'wingman-be';
+
+const getPartnerToken: GetPartnerToken<{
+  hirerId: string;
+  partnerToken: string;
+}> = async (request) => {
+  if (request.authorization !== 'SUPER_SECRET') {
+    throw new Error('oh no!');
+  }
+
+  const partnerToken = await getPartnerTokenFromSecretStore();
+
+  return {
+    hirerId: 'seekAnzPublicTest:organization:seek:93WyyF1h',
+    partnerToken,
+  };
+};
+
+const createApp = () => {
+  const middleware = createBrowserTokenMiddleware({
+    getPartnerToken,
+    userAgent: 'my-service/1.2.3',
+  });
+
+  return new Koa().use(middleware);
+};
+```
 
 ## `createPartnerWebhookMiddleware`
 

--- a/be/package.json
+++ b/be/package.json
@@ -7,6 +7,7 @@
     "koa": "^2.12.0",
     "koa-bodyparser": "^4.3.0",
     "koa-compose": "^4.1.0",
+    "lru-cache": "^5.1.1",
     "node-fetch": "^2.6.0",
     "runtypes": "^4.2.0"
   },
@@ -15,6 +16,7 @@
     "@koa/router": "9.0.1",
     "@types/koa": "2.11.3",
     "@types/koa__router": "8.0.2",
+    "@types/lru-cache": "5.1.0",
     "@types/supertest": "2.0.9",
     "eslint": "7.1.0",
     "eslint-config-seek": "7.0.1",

--- a/be/src/browserToken/middleware.test.ts
+++ b/be/src/browserToken/middleware.test.ts
@@ -1,0 +1,125 @@
+import Koa from 'koa';
+import nock from 'nock';
+import * as fetchModule from 'node-fetch';
+
+import { SEEK_API_BASE_URL, SEEK_BROWSER_TOKEN_PATH } from '../constants';
+import { RetrieveRequest } from '../getPartnerToken';
+import { createAgent } from '../testing/http';
+import { errorHandler } from '../testing/koa';
+import {
+  DATE_ISO_REGEX,
+  INVALID_BROWSER_TOKEN_RESPONSE,
+  VALID_BROWSER_TOKEN_RESPONSE,
+  VALID_HIRER_ID,
+} from '../testing/tokens';
+
+import { createBrowserTokenMiddleware, resetTokenCache } from './middleware';
+
+describe('createBrowserTokenMiddleware', () => {
+  const getPartnerToken = jest.fn<
+    Promise<{ hirerId: string; partnerToken: string }>,
+    [RetrieveRequest]
+  >();
+
+  const agent = createAgent(() => {
+    const middleware = createBrowserTokenMiddleware({
+      getPartnerToken,
+      userAgent: 'abc/1.2.3',
+    });
+
+    return new Koa().use(errorHandler).use(middleware);
+  });
+
+  beforeAll(agent.setup);
+
+  beforeEach(() =>
+    getPartnerToken.mockImplementation(({ authorization }) => {
+      switch (authorization) {
+        case 'in':
+          return Promise.resolve({
+            hirerId: VALID_HIRER_ID,
+            partnerToken: 'out',
+          });
+
+        default:
+          throw new Error('Nice try');
+      }
+    }),
+  );
+
+  afterEach(jest.clearAllMocks);
+  afterEach(resetTokenCache);
+
+  afterAll(agent.teardown);
+
+  it('issues a browser token for a valid request', async () => {
+    nock(SEEK_API_BASE_URL)
+      .post(SEEK_BROWSER_TOKEN_PATH)
+      .matchHeader('user-agent', 'abc/1.2.3')
+      .reply(200, VALID_BROWSER_TOKEN_RESPONSE);
+
+    const response = await agent()
+      .post('/')
+      .set('aUtHoRiZaTiOn', 'in')
+      .send({ scope: 'arbitrary' })
+      .expect(200);
+
+    expect(response.body).toEqual({
+      authorization: `Bearer ${VALID_BROWSER_TOKEN_RESPONSE.access_token}`,
+      expiry: expect.stringMatching(DATE_ISO_REGEX),
+    });
+  });
+
+  it('caches a browser token', async () => {
+    const fetchSpy = jest.spyOn(fetchModule, 'default');
+
+    nock(SEEK_API_BASE_URL)
+      .post(SEEK_BROWSER_TOKEN_PATH)
+      .matchHeader('user-agent', 'abc/1.2.3')
+      .reply(200, VALID_BROWSER_TOKEN_RESPONSE);
+
+    await agent()
+      .post('/')
+      .set('aUtHoRiZaTiOn', 'in')
+      .send({ scope: 'arbitrary' })
+      .expect(200);
+
+    expect(fetchSpy).toBeCalledTimes(1);
+
+    await agent()
+      .post('/')
+      .set('aUtHoRiZaTiOn', 'in')
+      .send({ scope: 'arbitrary' })
+      .expect(200);
+
+    expect(fetchSpy).toBeCalledTimes(1);
+  });
+
+  it('blocks an invalid request', () =>
+    agent()
+      .post('/')
+      .set('aUtHoRiZaTiOn', 'in')
+      .send({ noscope: 720 })
+      .expect(400, 'scope: Expected string, but was undefined'));
+
+  it('blocks an unknown user', () =>
+    agent()
+      .post('/')
+      .set('aUtHoRiZaTiOn', 'hacker')
+      .send({ scope: 'arbitrary' })
+      .expect(401, 'Nice try'));
+
+  it('fails on invalid response from the SEEK API', () => {
+    nock.cleanAll();
+    nock(SEEK_API_BASE_URL)
+      .post(SEEK_BROWSER_TOKEN_PATH)
+      .matchHeader('user-agent', 'abc/1.2.3')
+      .reply(200, INVALID_BROWSER_TOKEN_RESPONSE);
+
+    return agent()
+      .post('/')
+      .set('aUtHoRiZaTiOn', 'in')
+      .send({ scope: 'arbitrary' })
+      .expect(500);
+  });
+});

--- a/be/src/browserToken/middleware.ts
+++ b/be/src/browserToken/middleware.ts
@@ -1,0 +1,93 @@
+import { Middleware } from 'koa';
+import bodyParser from 'koa-bodyparser';
+import compose from 'koa-compose';
+import LRU from 'lru-cache';
+import fetch from 'node-fetch';
+
+import { SEEK_BROWSER_TOKEN_URL } from '../constants';
+import { wrapRetriever } from '../getPartnerToken';
+
+import {
+  BrowserTokenMiddlewareOptions,
+  BrowserTokenRequest,
+  BrowserTokenResponse,
+  SeekApiBrowserTokenRequest,
+  SeekApiBrowserTokenResponse,
+} from './types';
+
+const tokenCache = new LRU<string, BrowserTokenResponse>();
+
+export const resetTokenCache = () => tokenCache.reset();
+
+const _createBrowserTokenMiddleware = ({
+  getPartnerToken,
+  userAgent,
+}: BrowserTokenMiddlewareOptions): Middleware =>
+  async function BrowserTokenMiddleware(ctx) {
+    const requestResult = BrowserTokenRequest.validate(ctx.request.body);
+
+    if (!requestResult.success) {
+      return ctx.throw(
+        400,
+        `${requestResult.key ?? 'Bad Request'}: ${requestResult.message}`,
+      );
+    }
+
+    const { scope } = requestResult.value;
+
+    const { hirerId, partnerToken } = await wrapRetriever(ctx, getPartnerToken);
+
+    const cachedToken = tokenCache.get(hirerId);
+
+    if (typeof cachedToken !== 'undefined') {
+      ctx.body = cachedToken;
+
+      return;
+    }
+
+    // We don't model our own user ID currently.
+    const seekApiRequest: SeekApiBrowserTokenRequest = {
+      hirerId,
+      scope,
+      userId: hirerId,
+    };
+
+    const response = await fetch(SEEK_BROWSER_TOKEN_URL, {
+      body: JSON.stringify(seekApiRequest),
+      headers: {
+        Authorization: `Bearer ${partnerToken}`,
+        'User-Agent': userAgent,
+      },
+      method: 'POST',
+    });
+
+    const responseBody = (await response.json()) as unknown;
+
+    const responseResult = SeekApiBrowserTokenResponse.validate(responseBody);
+
+    if (!responseResult.success) {
+      return ctx.throw(500, 'Unexpected response from browser token endpoint');
+    }
+
+    const expiresInMs = responseResult.value.expires_in * 1000;
+
+    const freshToken: BrowserTokenResponse = {
+      authorization: `Bearer ${responseResult.value.access_token}`,
+      expiry: new Date(Date.now() + expiresInMs).toISOString(),
+    };
+
+    // Write off the token at its half life. This is a bit mean.
+    tokenCache.set(hirerId, freshToken, expiresInMs / 2);
+
+    ctx.body = freshToken;
+
+    return;
+  };
+
+export const createBrowserTokenMiddleware = (
+  options: BrowserTokenMiddlewareOptions,
+): Middleware =>
+  compose([
+    bodyParser({ enableTypes: ['json'] }),
+    _createBrowserTokenMiddleware(options),
+  ]);

--- a/be/src/browserToken/types.ts
+++ b/be/src/browserToken/types.ts
@@ -1,0 +1,31 @@
+/* eslint-disable new-cap */
+
+import * as t from 'runtypes';
+
+import { GetPartnerToken } from '../getPartnerToken';
+
+export interface BrowserTokenMiddlewareOptions {
+  getPartnerToken: GetPartnerToken<{ hirerId: string; partnerToken: string }>;
+  userAgent: string;
+}
+
+export const BrowserTokenRequest = t.Record({
+  scope: t.String,
+});
+
+export interface BrowserTokenResponse {
+  authorization: string;
+  expiry: string;
+}
+
+export interface SeekApiBrowserTokenRequest {
+  hirerId: string;
+  scope: string;
+  userId: string;
+}
+
+export const SeekApiBrowserTokenResponse = t.Record({
+  access_token: t.String,
+  expires_in: t.Number,
+  token_type: t.Literal('Bearer'),
+});

--- a/be/src/constants.ts
+++ b/be/src/constants.ts
@@ -1,3 +1,7 @@
 export const SEEK_API_BASE_URL = 'https://graphql.seek.com';
+
 export const SEEK_API_PATH = '/graphql';
 export const SEEK_API_URL = `${SEEK_API_BASE_URL}${SEEK_API_PATH}`;
+
+export const SEEK_BROWSER_TOKEN_PATH = '/auth/token';
+export const SEEK_BROWSER_TOKEN_URL = `${SEEK_API_BASE_URL}${SEEK_BROWSER_TOKEN_PATH}`;

--- a/be/src/index.ts
+++ b/be/src/index.ts
@@ -5,6 +5,8 @@ export {
   UserInputError,
 } from 'apollo-server-koa';
 
+export { createBrowserTokenMiddleware } from './browserToken/middleware';
+export { BrowserTokenMiddlewareOptions } from './browserToken/types';
 export { GetPartnerToken } from './getPartnerToken';
 export { createPartnerWebhookMiddleware } from './partnerWebhook/middleware';
 export {

--- a/be/src/testing/koa.ts
+++ b/be/src/testing/koa.ts
@@ -1,0 +1,22 @@
+import { Middleware } from 'koa';
+
+const isRecord = (value: unknown): value is Record<PropertyKey, unknown> =>
+  typeof value === 'object' && value !== null;
+
+export const errorHandler: Middleware = async (ctx, next) => {
+  try {
+    /* eslint-disable-next-line @typescript-eslint/no-unsafe-return */
+    return await next();
+  } catch (anyErr) {
+    const err = anyErr as unknown;
+
+    if (!isRecord(err) || typeof err.status !== 'number') {
+      ctx.status = 500;
+      ctx.body = err;
+      return;
+    }
+
+    ctx.status = err.status ?? 500;
+    ctx.body = err.message ?? '';
+  }
+};

--- a/be/src/testing/tokens.ts
+++ b/be/src/testing/tokens.ts
@@ -1,0 +1,14 @@
+export const VALID_BROWSER_TOKEN_RESPONSE = {
+  access_token: 'hunter2',
+  expires_in: 60,
+  token_type: 'Bearer',
+} as const;
+
+export const INVALID_BROWSER_TOKEN_RESPONSE = {
+  ...VALID_BROWSER_TOKEN_RESPONSE,
+  token_type: 'Basic',
+};
+
+export const VALID_HIRER_ID = 'seekAnzPublicTest:organization:seek:93WyyF1h';
+
+export const DATE_ISO_REGEX = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2754,6 +2754,11 @@
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
   integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
 
+"@types/lru-cache@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.0.tgz#57f228f2b80c046b4a1bd5cac031f81f207f4f03"
+  integrity sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w==
+
 "@types/lz-string@^1.3.33":
   version "1.3.34"
   resolved "https://registry.yarnpkg.com/@types/lz-string/-/lz-string-1.3.34.tgz#69bfadde419314b4a374bf2c8e58659c035ed0a5"


### PR DESCRIPTION
This is better practice than using the SeekGraph proxy as the access is scoped to a hirer, as it would be in an actual third-party system. The interface is a bit rough but hopefully the core functionality is there; I'll follow this up with an actual implementation in the example frontend.