### PR TITLE
feat: Add SEEK graphql types

### DIFF
--- a/.changeset/eight-phones-camp.md
+++ b/.changeset/eight-phones-camp.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': minor
+---
+
+Exports SEEK graphql types for consumer use

--- a/codegen.yml
+++ b/codegen.yml
@@ -1,0 +1,20 @@
+generates:
+  ./types/seek.graphql.ts:
+    schema: ${SEEK_SCHEMA_PATH:https://graphql.seek.com/graphql}
+    plugins:
+      - typescript
+  ./types/seekFragmentTypes.ts:
+    schema: ${SEEK_SCHEMA_PATH:https://graphql.seek.com/graphql}
+    plugins:
+      - fragment-matcher
+    config:
+      module: es2015
+
+config:
+  scalars:
+    DateTime: string
+    Date: string
+    HistoryDate: string
+  declarationKind: 'interface'
+  namingConvention:
+    transformUnderscore: true

--- a/fe/lib/types/seekFragmentTypes.ts
+++ b/fe/lib/types/seekFragmentTypes.ts
@@ -1,0 +1,1 @@
+export * from '../../../types/seekFragmentTypes';

--- a/fe/lib/types/seekTypes.ts
+++ b/fe/lib/types/seekTypes.ts
@@ -1,0 +1,1 @@
+export * from '../../../types/seek.graphql';

--- a/package.json
+++ b/package.json
@@ -10,11 +10,17 @@
     "lint": "yarn workspaces run lint",
     "stage": "changeset version && yarn format",
     "release": "yarn be build && changeset publish",
-    "test": "yarn workspaces run test"
+    "test": "yarn workspaces run test",
+    "codegen": "graphql-codegen --config codegen.yml"
   },
   "workspaces": [
     "be",
     "fe"
   ],
-  "version": "0.0.0"
+  "version": "0.0.0",
+  "devDependencies": {
+    "@graphql-codegen/cli": "^1.15.1",
+    "@graphql-codegen/fragment-matcher": "^1.15.1",
+    "@graphql-codegen/typescript": "^1.15.1"
+  }
 }

--- a/types/seek.graphql.ts
+++ b/types/seek.graphql.ts
@@ -1,0 +1,2923 @@
+export type Maybe<T> = T | null;
+/** All built-in and custom scalars, mapped to their actual values */
+export interface Scalars {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+  /** A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar. */
+  DateTime: string;
+  /** A date string, such as 2007-12-03, compliant with the `full-date` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar. */
+  Date: string;
+  /**
+   * A date string compliant with the ISO 8601 "year", "year and month" or "complete date" formats.
+   * For example, `"2020"`, `"2020-05"` and `"2020-05-27"` are all valid for `HistoryDate`.
+   * 
+   * This is used for dates in a candidate's position & employment histories where the precise month or day may not have been provided.
+   */
+  HistoryDate: string;
+}
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface Query {
+  __typename?: 'Query';
+  /** The API version. */
+  version: Scalars['String'];
+  /**
+   * An application questionnaire with the given `id`.
+   * 
+   * Questionnaires can be associated with a `PositionProfile`.
+   * 
+   * This query accepts browser tokens that include the `query:application-questionnaires` scope.
+   */
+  applicationQuestionnaire?: Maybe<ApplicationQuestionnaire>;
+  /**
+   * An application questionnaire with the given `id`.
+   * @deprecated Use `applicationQuestionnaire`.
+   */
+  questionnaire?: Maybe<ApplicationQuestionnaire>;
+  /**
+   * Ad products available when creating an advertisement.
+   * @deprecated Use `seekAnzHirerAdvertisementCreationProducts`.
+   */
+  advertisementCreationProducts?: Maybe<Array<AdProduct>>;
+  /**
+   * Ad products available when updating an advertisement.
+   * @deprecated Use `seekAnzHirerAdvertisementModificationProducts`.
+   */
+  advertisementModificationProducts?: Maybe<Array<AdProduct>>;
+  /** Ad products available when creating an advertisement. */
+  seekAnzHirerAdvertisementCreationProducts?: Maybe<Array<SeekAnzAdProduct>>;
+  /** Ad products available when updating an advertisement. */
+  seekAnzHirerAdvertisementModificationProducts?: Maybe<Array<SeekAnzAdProduct>>;
+  /**
+   * The job category for the given `id`.
+   * 
+   * This query accepts browser tokens that include the `query:ontologies` scope.
+   */
+  jobCategory?: Maybe<JobCategory>;
+  /**
+   * A list of top-level job categories for the provided scheme.
+   * 
+   * This query accepts browser tokens that include the `query:ontologies` scope.
+   */
+  jobCategories: Array<JobCategory>;
+  /**
+   * An array of suggested job categories for the provided partial `PositionProfile`.
+   * 
+   * This query accepts browser tokens that include the `query:ontologies` scope.
+   */
+  jobCategorySuggestions: Array<JobCategorySuggestionChoice>;
+  /**
+   * A location node with the given location `id`.
+   * 
+   * This query accepts browser tokens that include the `query:ontologies` scope.
+   */
+  location?: Maybe<Location>;
+  /**
+   * An array of location nodes relevant to the text provided.
+   * 
+   * This query accepts browser tokens that include the `query:ontologies` scope.
+   */
+  locationSuggestions?: Maybe<Array<LocationSuggestion>>;
+  /**
+   * The hiring organization for the given `id`.
+   * 
+   * This query accepts browser tokens that include the `query:organizations` scope.
+   */
+  hiringOrganization?: Maybe<HiringOrganization>;
+  /**
+   * A hiring organization corresponding to the given SEEK ANZ advertiser ID.
+   * 
+   * This query accepts browser tokens that include the `query:organizations` scope.
+   */
+  seekAnzAdvertiser?: Maybe<HiringOrganization>;
+  /** A position opening with the given `id`. */
+  positionOpening?: Maybe<PositionOpening>;
+  /** A position profile with its position opening, given the position profile `id`. */
+  positionOpeningWithPositionProfile?: Maybe<PositionOpening>;
+  /** A position profile with the given `id`. */
+  positionProfile?: Maybe<PositionProfile>;
+  /** A page of position openings for the given `hirerId`. */
+  positionOpenings: PositionOpeningConnection;
+  /**
+   * A candidate with the given `applicationProfileId` with only that
+   * profile included.
+   * 
+   * This will include the candidate's personal details along with the
+   * profile they've elected to represent them for this application.
+   * @deprecated Use `candidateProfile` and select the `candidate` field.
+   */
+  candidateWithApplicationProfile?: Maybe<Candidate>;
+  /** The `CandidateProfile` for the given `id`. */
+  candidateProfile?: Maybe<CandidateProfile>;
+  /**
+   * The candidate for the given `id`.
+   * 
+   * This will include the candidate's personal details along with all
+   * application profiles for a single hirer.
+   */
+  candidate?: Maybe<Candidate>;
+  /**
+   * A page of webhook attempts matching the specified criteria generated by a selected subscription.
+   * 
+   * The result list is returned in ascending creation date & time order.
+   * It starts from the earliest known attempt if no pagination arguments are provided.
+   */
+  webhookAttemptsForSubscription: WebhookAttemptsConnection;
+  /**
+   * A page of webhook attempts matching the specified criteria generated by a selected event.
+   * 
+   * The result list is returned in ascending creation date & time order.
+   * It starts from the earliest known attempt if no pagination arguments are provided.
+   */
+  webhookAttemptsForEvent: WebhookAttemptsConnection;
+  /** The webhook subscription for the given `id`. */
+  webhookSubscription?: Maybe<WebhookSubscription>;
+  /**
+   * A page of webhook subscriptions matching the specified criteria.
+   * 
+   * The result list is returned in ascending creation date & time order.
+   * It starts from the earliest known subscription if no pagination arguments are provided.
+   */
+  webhookSubscriptions: WebhookSubscriptionsConnection;
+  /** The event for the given `id`. */
+  event?: Maybe<Event>;
+  /**
+   * A page of events matching the specified criteria.
+   * 
+   * The result list is returned in ascending stream date & time order.
+   * It starts from the earliest known event if no pagination arguments are provided.
+   */
+  events: EventsConnection;
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QueryApplicationQuestionnaireArgs {
+  id: Scalars['String'];
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QueryQuestionnaireArgs {
+  id: Scalars['String'];
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QueryAdvertisementCreationProductsArgs {
+  hirerId: Scalars['String'];
+  draftAdvertisement: AdProductAdvertisementDraftInput;
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QueryAdvertisementModificationProductsArgs {
+  hirerId: Scalars['String'];
+  advertisement: AdProductAdvertisementInput;
+  draftAdvertisement: AdProductAdvertisementDraftInput;
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QuerySeekAnzHirerAdvertisementCreationProductsArgs {
+  hirerId: Scalars['String'];
+  draftAdvertisement: SeekAnzAdProductAdvertisementDraftInput;
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QuerySeekAnzHirerAdvertisementModificationProductsArgs {
+  hirerId: Scalars['String'];
+  advertisement: SeekAnzAdProductAdvertisementInput;
+  draftAdvertisement: SeekAnzAdProductAdvertisementDraftInput;
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QueryJobCategoryArgs {
+  id: Scalars['String'];
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QueryJobCategoriesArgs {
+  schemeId: Scalars['String'];
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QueryJobCategorySuggestionsArgs {
+  positionProfile: JobCategorySuggestionPositionProfileInput;
+  schemeId: Scalars['String'];
+  hirerId?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QueryLocationArgs {
+  id: Scalars['String'];
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QueryLocationSuggestionsArgs {
+  usageTypeCode: Scalars['String'];
+  schemeId: Scalars['String'];
+  hirerId?: Maybe<Scalars['String']>;
+  text: Scalars['String'];
+  first?: Maybe<Scalars['Int']>;
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QueryHiringOrganizationArgs {
+  id: Scalars['String'];
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QuerySeekAnzAdvertiserArgs {
+  id: Scalars['Int'];
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QueryPositionOpeningArgs {
+  id: Scalars['String'];
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QueryPositionOpeningWithPositionProfileArgs {
+  id: Scalars['String'];
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QueryPositionProfileArgs {
+  id: Scalars['String'];
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QueryPositionOpeningsArgs {
+  hirerId: Scalars['String'];
+  after?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QueryCandidateWithApplicationProfileArgs {
+  applicationProfileId: Scalars['String'];
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QueryCandidateProfileArgs {
+  id: Scalars['String'];
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QueryCandidateArgs {
+  id: Scalars['String'];
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QueryWebhookAttemptsForSubscriptionArgs {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  filter?: Maybe<WebhookAttemptsFilterInput>;
+  subscriptionId: Scalars['String'];
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QueryWebhookAttemptsForEventArgs {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  filter?: Maybe<WebhookAttemptsFilterInput>;
+  eventId: Scalars['String'];
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QueryWebhookSubscriptionArgs {
+  id: Scalars['String'];
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QueryWebhookSubscriptionsArgs {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  filter?: Maybe<WebhookSubscriptionsFilterInput>;
+  schemeId: Scalars['String'];
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QueryEventArgs {
+  id: Scalars['String'];
+}
+
+
+/** The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export interface QueryEventsArgs {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  filter?: Maybe<EventsFilterInput>;
+  schemeId: Scalars['String'];
+}
+
+/** The schema's entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export interface Mutation {
+  __typename?: 'Mutation';
+  _empty?: Maybe<Scalars['String']>;
+  /**
+   * Creates a new questionnaire.
+   * 
+   * This mutation accepts browser tokens that include the `mutate:questionnaires` scope.
+   */
+  createApplicationQuestionnaire: CreateApplicationQuestionnairePayload;
+  /**
+   * Creates a new position opening.
+   * 
+   * Every position profile belongs to a position opening.
+   * Multiple position profiles may belong to the same position opening.
+   */
+  createPositionOpening: CreatePositionOpeningPayload;
+  /** Replaces an existing position opening's person contacts. */
+  updatePositionOpeningPersonContacts?: Maybe<UpdatePositionOpeningPersonContactsPayload>;
+  /**
+   * Deletes an empty position opening.
+   * 
+   * Each position profile that belongs to a position opening must be deleted before the position opening can be deleted.
+   */
+  deletePositionOpening?: Maybe<DeletePositionOpeningPayload>;
+  /** Creates a new position profile for an opening and posts it. */
+  postPositionProfileForOpening: PostPositionProfileForOpeningPayload;
+  /** Creates a new unposted position profile for an opening. */
+  createUnpostedPositionProfileForOpening: CreateUnpostedPositionProfileForOpeningPayload;
+  /** Updates an existing unposted position profile. */
+  updateUnpostedPositionProfile?: Maybe<UpdateUnpostedPositionProfilePayload>;
+  /** Deletes an unposted position profile. */
+  deleteUnpostedPositionProfile?: Maybe<DeleteUnpostedPositionProfilePayload>;
+  /** Creates a new webhook subscription. */
+  createWebhookSubscription: CreateWebhookSubscriptionPayload;
+  /** Deletes an existing webhook subscription. */
+  deleteWebhookSubscription?: Maybe<DeleteWebhookSubscriptionPayload>;
+}
+
+
+/** The schema's entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export interface MutationCreateApplicationQuestionnaireArgs {
+  input: CreateApplicationQuestionnaireInput;
+}
+
+
+/** The schema's entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export interface MutationCreatePositionOpeningArgs {
+  input: CreatePositionOpeningInput;
+}
+
+
+/** The schema's entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export interface MutationUpdatePositionOpeningPersonContactsArgs {
+  input: UpdatePositionOpeningPersonContactsInput;
+}
+
+
+/** The schema's entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export interface MutationDeletePositionOpeningArgs {
+  input: DeletePositionOpeningInput;
+}
+
+
+/** The schema's entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export interface MutationPostPositionProfileForOpeningArgs {
+  input: PostPositionProfileForOpeningInput;
+}
+
+
+/** The schema's entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export interface MutationCreateUnpostedPositionProfileForOpeningArgs {
+  input: CreateUnpostedPositionProfileForOpeningInput;
+}
+
+
+/** The schema's entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export interface MutationUpdateUnpostedPositionProfileArgs {
+  input: UpdateUnpostedPositionProfileInput;
+}
+
+
+/** The schema's entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export interface MutationDeleteUnpostedPositionProfileArgs {
+  input: DeleteUnpostedPositionProfileInput;
+}
+
+
+/** The schema's entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export interface MutationCreateWebhookSubscriptionArgs {
+  input: CreateWebhookSubscriptionInput;
+}
+
+
+/** The schema's entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export interface MutationDeleteWebhookSubscriptionArgs {
+  input: DeleteWebhookSubscriptionInput;
+}
+
+/** An address of a human-accessible web page. */
+export interface WebUrl {
+  __typename?: 'WebUrl';
+  /** The URL of the web page. */
+  url: Scalars['String'];
+}
+
+/** An email address. */
+export interface Email {
+  __typename?: 'Email';
+  /** The email address. */
+  address: Scalars['String'];
+}
+
+/** An email address. */
+export interface EmailInput {
+  /** The email address. */
+  address: Scalars['String'];
+}
+
+/** The phone number of a person. */
+export interface Phone {
+  __typename?: 'Phone';
+  /** The phone number represented as a human readable string. */
+  formattedNumber: Scalars['String'];
+}
+
+/** The phone number of a person. */
+export interface PhoneInput {
+  /** The phone number represented as a human readable string. */
+  formattedNumber: Scalars['String'];
+}
+
+/** Communication channels for a person. */
+export interface Communication {
+  __typename?: 'Communication';
+  /**
+   * An array of phone numbers for the person.
+   * 
+   * The phone numbers are ordered in descending preference.
+   */
+  phone: Array<Phone>;
+  /**
+   * An array of email addresses for the person.
+   * 
+   * The email addresses are ordered in descending preference.
+   */
+  email: Array<Email>;
+}
+
+/** Communication channels for a person. */
+export interface CommunicationInput {
+  /**
+   * An array of phone numbers for the person.
+   * 
+   * The phone numbers are ordered in descending preference.
+   */
+  phone: Array<PhoneInput>;
+  /**
+   * An array of email addresses for the person.
+   * 
+   * The email addresses are ordered in descending preference.
+   */
+  email: Array<EmailInput>;
+}
+
+/** An address of a human-accessible web page. */
+export interface WebUrlInput {
+  /** The URL of the web page. */
+  url: Scalars['String'];
+}
+
+
+
+
+/** An opaque identifier for GraphQL objects. */
+export interface ObjectIdentifier {
+  __typename?: 'ObjectIdentifier';
+  /** The identifier itself. */
+  value: Scalars['String'];
+}
+
+export interface Money {
+  __typename?: 'Money';
+  /**
+   * The three-letter ISO 4217 currency code, in uppercase.
+   * 
+   * This must be a supported currency. Currently supported codes are: `AUD`
+   * and `NZD`. Additional codes may be added in the future.
+   */
+  currencyCode: Scalars['String'];
+  /**
+   * A positive integer in the minor currency unit for the ISO currency code.
+   * 
+   * This is the number of cents in dollar-denominated currencies e.g. 1000
+   * cents for $10.00.
+   */
+  amount: Scalars['Int'];
+}
+
+/**
+ * Pagination metadata for a result list.
+ * 
+ * This is compliant with the _Relay Cursor Connections Specification_:
+ * 
+ * <https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo>
+ */
+export interface PageInfo {
+  __typename?: 'PageInfo';
+  /** Whether there is a previous page of results at the time of retrieval. */
+  hasPreviousPage: Scalars['Boolean'];
+  /** Whether there is a next page of results at the time of retrieval. */
+  hasNextPage: Scalars['Boolean'];
+  /** An opaque string cursor for retrieving the previous page of results. */
+  startCursor?: Maybe<Scalars['String']>;
+  /** An opaque string cursor for retrieving the next page of results. */
+  endCursor?: Maybe<Scalars['String']>;
+}
+
+/**
+ * A set of questions presented to a candidate during an application.
+ * 
+ * This can be associated with one or more `PositionProfile`s when they are created.
+ */
+export interface ApplicationQuestionnaire {
+  __typename?: 'ApplicationQuestionnaire';
+  /** An opaque identifier for the questionnaire. */
+  id: ObjectIdentifier;
+  /** The array of components in the order they are presented to the candidate. */
+  components: Array<ApplicationQuestionnaireComponent>;
+}
+
+/**
+ * A component of an application questionnaire.
+ * 
+ * This only contains identifying metadata;
+ * the `componentTypeCode` can be used to determine the concrete type of the component.
+ */
+export interface ApplicationQuestionnaireComponent {
+  /** An opaque identifier for the component. */
+  id: ObjectIdentifier;
+  /**
+   * The type of the component. Currently, this can be:
+   * 
+   * - "Question" which corresponds to the `ApplicationQuestion` type.
+   * - "PrivacyConsent" which corresponds to the `ApplicationPrivacyConsent` type.
+   */
+  componentTypeCode: Scalars['String'];
+  /**
+   * A partner provided unique reference ID to the component.
+   * 
+   * This can be used to correlate the component with the submission.
+   */
+  value?: Maybe<Scalars['String']>;
+}
+
+/**
+ * A question component of an `ApplicationQuestionnaire`.
+ * 
+ * This consists of label text displayed to a user and an input for them to select a response.
+ */
+export interface ApplicationQuestion extends ApplicationQuestionnaireComponent {
+  __typename?: 'ApplicationQuestion';
+  /** An opaque identifier for the question. */
+  id: ObjectIdentifier;
+  /**
+   * The type of the component.
+   * 
+   * This is always "Question".
+   */
+  componentTypeCode: Scalars['String'];
+  /**
+   * A partner provided unique reference ID to the question.
+   * 
+   * This can be used to correlate the question with the submitted question components.
+   */
+  value?: Maybe<Scalars['String']>;
+  /**
+   * The HTML snippet of the question being asked to the candidate.
+   * 
+   * Unsupported tags will be silently stripped when creating a questionnaire.
+   */
+  questionHtml: Scalars['String'];
+  /**
+   * The type of the question response.
+   * 
+   * The three possible values of this are:
+   * 
+   * - "SingleSelect" for choosing a single response from `responseChoice`.
+   * - "MultiSelect" for choosing one or more responses from `responseChoice`.
+   * - "FreeText" for a free text response.
+   */
+  responseTypeCode: Scalars['String'];
+  /**
+   * The collection of possible responses.
+   * 
+   * For "SingleSelect" and "MultiSelect" this must contain at least one element.
+   */
+  responseChoice?: Maybe<Array<ApplicationQuestionChoice>>;
+}
+
+/**
+ * A privacy policy consent component of an `ApplicationQuestionnaire`.
+ * 
+ * This consists of a URL for candidates to view the privacy policy and text to prompt the candidate as to whether or not they agree.
+ * 
+ * The privacy policy consent component presents the candidate with a 'Yes' or 'No' choice.
+ */
+export interface ApplicationPrivacyConsent extends ApplicationQuestionnaireComponent {
+  __typename?: 'ApplicationPrivacyConsent';
+  /** An opaque identifier for the question. */
+  id: ObjectIdentifier;
+  /**
+   * The type of the component.
+   * 
+   * This is always "PrivacyConsent".
+   */
+  componentTypeCode: Scalars['String'];
+  /**
+   * A partner provided unique reference ID to the question.
+   * 
+   * This can be used to correlate the question with the submitted question components.
+   */
+  value?: Maybe<Scalars['String']>;
+  /** The URL of the privacy policy to show to the candidate. */
+  privacyPolicyUrl: WebUrl;
+  /**
+   * The HTML snippet to prompt the candidate for consent.
+   * 
+   * Unsupported tags will be silently stripped when creating a questionnaire.
+   * 
+   * This is optional and will default to 'Do you agree to the privacy policy?'
+   */
+  descriptionHtml?: Maybe<Scalars['String']>;
+}
+
+/** A possible response to an `ApplicationQuestion`. */
+export interface ApplicationQuestionChoice {
+  __typename?: 'ApplicationQuestionChoice';
+  /** An opaque identifier for the question choice. */
+  id: ObjectIdentifier;
+  /**
+   * Text of the choice displayed to the candidate.
+   * 
+   * This is plain text; all HTML will be escaped.
+   */
+  text: Scalars['String'];
+  /**
+   * A partner provided unique reference ID to the question choice.
+   * 
+   * This can be used to correlate the question with the submitted answers.
+   */
+  value?: Maybe<Scalars['String']>;
+  /**
+   * Indicates if this choice is preferred when scoring the answers.
+   * 
+   * This is not displayed to the candidate.
+   */
+  preferredIndicator: Scalars['Boolean'];
+}
+
+/**
+ * A response to a component in a questionnaire.
+ * 
+ * This only contains metadata related to the component responded to in the questionnaire.
+ * The implementation of a response is based on the `componentTypeCode` of its component.
+ */
+export interface ApplicationQuestionnaireComponentResponse {
+  /** The component this is responding to. */
+  component: ApplicationQuestionnaireComponent;
+  /**
+   * The type of the component. Currently, this can be:
+   * 
+   * - "Question" which corresponds to the `ApplicationQuestion` type.
+   * - "PrivacyConsent" which corresponds to the `ApplicationPrivacyConsent` type.
+   */
+  componentTypeCode: Scalars['String'];
+}
+
+/** A single answer to a question in the questionnaire. */
+export interface ApplicationQuestionAnswer {
+  __typename?: 'ApplicationQuestionAnswer';
+  /**
+   * The questionnaire choice for the current answer.
+   * 
+   * For `FreeText` questions this will be `null`.
+   */
+  choice?: Maybe<ApplicationQuestionChoice>;
+  /** The text value of the selected answer. */
+  answer: Scalars['String'];
+}
+
+/** A candidate's response to a question in the questionnaire. */
+export interface ApplicationQuestionResponse extends ApplicationQuestionnaireComponentResponse {
+  __typename?: 'ApplicationQuestionResponse';
+  /** The question this is responding to. */
+  component: ApplicationQuestion;
+  /**
+   * The type of the component.
+   * 
+   * This is always "Question".
+   */
+  componentTypeCode: Scalars['String'];
+  /**
+   * The answers provided by the candidate.
+   * 
+   * For "SingleSelect" and "FreeText" this will be a single element array.
+   */
+  answers: Array<ApplicationQuestionAnswer>;
+  /**
+   * How well the candidate answered the question against the hirer's preferences.
+   * 
+   * Score is calculated based off the `responseTypeCode`:
+   * - For a `SingleSelect` question the score will be either 1 or 0 based off whether or not the candidate selected a preferred answer.
+   * - For a `MultiSelect` question the score will be between 0 and 1 as a floating point. For example, if the candidate selected half of the preferred answers, the score would be 0.5.
+   * - For a `FreeText` the score will be null.
+   */
+  score?: Maybe<Scalars['Float']>;
+}
+
+/** A candidate's response to a privacy policy consent component in the questionnaire. */
+export interface ApplicationPrivacyConsentResponse extends ApplicationQuestionnaireComponentResponse {
+  __typename?: 'ApplicationPrivacyConsentResponse';
+  /** The privacy consent component this is responding to. */
+  component: ApplicationPrivacyConsent;
+  /**
+   * The type of the component.
+   * 
+   * This is always "PrivacyConsent".
+   */
+  componentTypeCode: Scalars['String'];
+  /** This indicates whether or not the candidate agrees to the provided privacy policy. */
+  consentGivenIndicator: Scalars['Boolean'];
+}
+
+/** A completed candidate submission for an `ApplicationQuestionnaire`. */
+export interface ApplicationQuestionnaireSubmission {
+  __typename?: 'ApplicationQuestionnaireSubmission';
+  /** The set of questions presented to the candidate during the application. */
+  questionnaire: ApplicationQuestionnaire;
+  /** The candidate's responses to the application's questionnaire. */
+  responses: Array<ApplicationQuestionnaireComponentResponse>;
+  /**
+   * The indication of how well the candidate scored on all questions in the questionnaire.
+   * 
+   * The score is a calculation between 0 and 1 as a floating point.
+   * For example, if the candidate received a score of 1 on one question, and a score of 0 on another, this overall score would be calculated as 0.5.
+   * If there are no scored questions this score will be null.
+   */
+  score?: Maybe<Scalars['Float']>;
+}
+
+/**
+ * A privacy policy consent component of an `ApplicationQuestionnaire`.
+ * 
+ * This consists of a URL for candidates to view the privacy policy and text to prompt the candidate as to whether or not they agree.
+ * 
+ * The privacy policy consent component always defaults the available response choices for the candidate to 'Yes' and 'No'.
+ */
+export interface ApplicationPrivacyConsentInput {
+  /**
+   * The type of the component.
+   * 
+   * This is always "PrivacyConsent".
+   */
+  componentTypeCode: Scalars['String'];
+  /**
+   * A partner provided unique reference ID to the consent component.
+   * 
+   * This can be used to correlate the consent component with the submitted response.
+   */
+  value?: Maybe<Scalars['String']>;
+  /** The URL of the privacy policy to show to the candidate. */
+  privacyPolicyUrl: WebUrlInput;
+  /**
+   * The HTML snippet to prompt the candidate for consent.
+   * 
+   * Unsupported tags will be silently stripped when creating a questionnaire.
+   * 
+   * This is optional and will default to 'Do you agree to the privacy policy?'
+   */
+  descriptionHtml?: Maybe<Scalars['String']>;
+}
+
+/**
+ * A question component of an `ApplicationQuestionnaire`.
+ * 
+ * This consists of label text displayed to a user and an input for them to select a response.
+ */
+export interface ApplicationQuestionInput {
+  /**
+   * The type of the component.
+   * 
+   * This is always "Question".
+   */
+  componentTypeCode: Scalars['String'];
+  /**
+   * The HTML snippet of the question being asked to the candidate.
+   * 
+   * Unsupported tags will be silently stripped when creating a questionnaire.
+   */
+  questionHtml: Scalars['String'];
+  /**
+   * The type of the question response.
+   * 
+   * The three possible values of this are:
+   * 
+   * - "SingleSelect" for choosing a single response from `responseChoice`.
+   * - "MultiSelect" for choosing one or more responses from `responseChoice`.
+   * - "FreeText" for a free text response.
+   */
+  responseTypeCode: Scalars['String'];
+  /**
+   * A unique ID for this question.
+   * 
+   * This can be used to correlate the question with the provided answers.
+   * This must be unique within the questionnaire.
+   */
+  value: Scalars['String'];
+  /**
+   * The collection of possible responses.
+   * 
+   * For "SingleSelect" and "MultiSelect" this must contain at least one element.
+   */
+  responseChoice?: Maybe<Array<ApplicationQuestionChoiceInput>>;
+}
+
+/** A possible response to an `ApplicationQuestion`. */
+export interface ApplicationQuestionChoiceInput {
+  /**
+   * Text of the choice displayed to the candidate.
+   * 
+   * This is plain text; all HTML will be escaped.
+   */
+  text: Scalars['String'];
+  /**
+   * A unique ID for this choice.
+   * 
+   * This can be used to correlate the choice with the provided answers.
+   * This must be unique within the questionnaire.
+   */
+  value: Scalars['String'];
+  /**
+   * Indicates if this choice is preferred when scoring the answers.
+   * 
+   * This is not displayed to the candidate.
+   */
+  preferredIndicator: Scalars['Boolean'];
+}
+
+/** A component of the questionnaire to be created. */
+export interface ApplicationQuestionnaireComponentInput {
+  /**
+   * The type of the component. Currently, this can be:
+   * 
+   * - "Question" which corresponds to the `question` property.
+   * - "PrivacyConsent" which corresponds to the `privacyConsent` property.
+   */
+  componentTypeCode: Scalars['String'];
+  /**
+   * A question component of an `ApplicationQuestionnaire`.
+   * 
+   * This must be provided if the `componentTypeCode` is `Question`.
+   */
+  question?: Maybe<ApplicationQuestionInput>;
+  /**
+   * A privacy consent component of an `ApplicationQuestionnaire`.
+   * 
+   * This must be provided if the `componentTypeCode` is `PrivacyConsent`.
+   */
+  privacyConsent?: Maybe<ApplicationPrivacyConsentInput>;
+}
+
+/** The details of the questionnaire to be created. */
+export interface CreateApplicationQuestionnaireApplicationQuestionnaireInput {
+  /**
+   * The identifier for the hirer that will own the questionnaire.
+   * 
+   * Hirers can only associate position profiles with questionnaires they own.
+   */
+  hirerId: Scalars['String'];
+  /** The array of components in the order they are presented to the candidate. */
+  components: Array<ApplicationQuestionnaireComponentInput>;
+}
+
+/** The input parameter for the `createApplicationQuestionnaire` mutation. */
+export interface CreateApplicationQuestionnaireInput {
+  /** The details of the questionnaire to be created. */
+  applicationQuestionnaire: CreateApplicationQuestionnaireApplicationQuestionnaireInput;
+}
+
+/** The output parameter for the `createApplicationQuestionnaire` mutation. */
+export interface CreateApplicationQuestionnairePayload {
+  __typename?: 'CreateApplicationQuestionnairePayload';
+  /** The details of the created questionnaire. */
+  applicationQuestionnaire: ApplicationQuestionnaire;
+}
+
+/** The types of ads which can be placed. */
+export enum AdvertisementType {
+  /** A standard ad. */
+  Classic = 'CLASSIC',
+  /** Ad with branding. */
+  Standout = 'STANDOUT',
+  /** Featured ad */
+  Premium = 'PREMIUM'
+}
+
+export interface AdProduct {
+  __typename?: 'AdProduct';
+  /** The type of the ad product. */
+  advertisementType: AdvertisementType;
+  /** The name of the ad product. */
+  name: Scalars['String'];
+  /** The description of the ad product. */
+  description: Scalars['String'];
+  /** The price component of the ad product. */
+  price: AdProductPrice;
+  /** Whether the ad product is enabled. */
+  enabled: Scalars['Boolean'];
+  /** How the ad product would be paid. */
+  checkoutEstimate: AdProductCheckoutEstimate;
+  /** Fields which are not safe to consume as they are likely to change without notice. */
+  unstable: AdProductUnstable;
+  /** Disclosures related to the ad product. */
+  disclosures: Array<Disclosure>;
+  /** Information messages */
+  messages: Array<Scalars['String']>;
+}
+
+export interface AdProductPrice {
+  __typename?: 'AdProductPrice';
+  /** The product price without tax */
+  amountExcludingTax?: Maybe<Money>;
+  /** Descriptive summary of the Product Price */
+  summary: Scalars['String'];
+  /** Indicates whether the price can be shown to the hirer */
+  canBeShownToHirer: Scalars['Boolean'];
+  /** Specifies whether taxes will be added when purchased. */
+  taxable: Scalars['Boolean'];
+}
+
+export interface AdProductCheckoutEstimate {
+  __typename?: 'AdProductCheckoutEstimate';
+  /** The amount left to be paid. */
+  paymentDueExcludingTax?: Maybe<Money>;
+  /** Checkout estimate summary */
+  summary: Scalars['String'];
+  /** Contract component of the checkout estimate */
+  contractConsumption?: Maybe<AdProductContractConsumption>;
+}
+
+export interface AdProductContractConsumption {
+  __typename?: 'AdProductContractConsumption';
+  /** Summary of contract consumption */
+  summary: Scalars['String'];
+  /** Type of contract consumption. */
+  type: AdProductContractConsumptionType;
+}
+
+export interface AdProductAdvertisementInput {
+  /** The type of the ad product. Classic, StandOut or Premium */
+  type: AdvertisementType;
+  /** The advertisement identifier. */
+  id?: Maybe<Scalars['String']>;
+  /** The hirer's job reference */
+  hirerJobReference?: Maybe<Scalars['String']>;
+  /** The position title */
+  positionTitle: Scalars['String'];
+  /** The job category identifier */
+  jobCategoryId: Scalars['String'];
+  /** The position location identifier */
+  positionLocationId: Scalars['String'];
+}
+
+export interface AdProductAdvertisementDraftInput {
+  /** The type of the ad product. Classic, StandOut or Premium */
+  type?: Maybe<AdvertisementType>;
+  /** The advertisement identifier. */
+  id?: Maybe<Scalars['String']>;
+  /** The hirer's job reference */
+  hirerJobReference?: Maybe<Scalars['String']>;
+  /** The position title */
+  positionTitle?: Maybe<Scalars['String']>;
+  /** The job category identifier */
+  jobCategoryId?: Maybe<Scalars['String']>;
+  /** The position location identifer */
+  positionLocationId?: Maybe<Scalars['String']>;
+}
+
+export enum AdProductContractConsumptionType {
+  /** A contract will be consumed of the same ad type as the product. */
+  SameAdtype = 'SAME_ADTYPE',
+  /** A contract will be consumed of a different ad type than the product. */
+  OtherAdtype = 'OTHER_ADTYPE',
+  /** A contract will be consumed of the same ad type as the product and an invoice will be generated. */
+  SameAdtypePlusInvoice = 'SAME_ADTYPE_PLUS_INVOICE'
+}
+
+/** Advertisement product fields which are not safe to consume as they are likely to change without notice. */
+export interface AdProductUnstable {
+  __typename?: 'AdProductUnstable';
+  /** Flag indicating whether the advertisement product should be recommended. */
+  isRecommended: Scalars['Boolean'];
+}
+
+/** A disclosure shown to the hirer for the current ad product. */
+export interface Disclosure {
+  __typename?: 'Disclosure';
+  /** The type of the disclosure message. */
+  type: DisclosureType;
+  /** The content of the disclosure message. */
+  message: Scalars['String'];
+}
+
+/** The type of disclosure message. */
+export enum DisclosureType {
+  /** A disclosure relating to a pricing error. */
+  PricingError = 'PRICING_ERROR',
+  /** A disclosure relating to an impact on premium ad performance. */
+  PremiumPerformanceChange = 'PREMIUM_PERFORMANCE_CHANGE',
+  /** A disclosure relating to a price increase in update mode for SEEK contracts. */
+  UpdatePricingIncrease = 'UPDATE_PRICING_INCREASE'
+}
+
+export interface SeekAnzAdProduct {
+  __typename?: 'SeekAnzAdProduct';
+  /**
+   * The type of the ad product.
+   * 
+   * Currently, three codes are defined:
+   * - `Classic` indicates a Classic ad.
+   * - `StandOut` indicates a StandOut ad.
+   * - `Premium` indicates a Premium ad.
+   */
+  advertisementTypeCode: Scalars['String'];
+  /** The ad product name. */
+  name: Scalars['String'];
+  /** The description of the ad product. */
+  description: Scalars['String'];
+  /** The price component of the ad product. */
+  price: SeekAnzAdProductPrice;
+  /** Indicates whether the ad product is enabled. */
+  enabledIndicator: Scalars['Boolean'];
+  /** How the ad product would be paid. */
+  checkoutEstimate: SeekAnzAdProductCheckoutEstimate;
+  /** Fields which are not safe to consume as they are likely to change without notice. */
+  unstable: SeekAnzAdProductUnstable;
+  /** Messages that may be shown to hirer. */
+  messages: Array<SeekAnzAdProductMessage>;
+}
+
+export interface SeekAnzAdProductPrice {
+  __typename?: 'SeekAnzAdProductPrice';
+  /** The product price without tax */
+  amountExcludingTax?: Maybe<CurrencyMinorUnit>;
+  /** Descriptive summary of the Product Price */
+  summary: Scalars['String'];
+  /** Indicates whether the price can be shown to the hirer */
+  visibleForHirerIndicator: Scalars['Boolean'];
+  /** Indicates whether taxes will be added when purchased. */
+  taxedIndicator: Scalars['Boolean'];
+}
+
+export interface SeekAnzAdProductCheckoutEstimate {
+  __typename?: 'SeekAnzAdProductCheckoutEstimate';
+  /** The amount left to be paid. */
+  paymentDueExcludingTax?: Maybe<CurrencyMinorUnit>;
+  /** Checkout estimate summary */
+  summary: Scalars['String'];
+  /** Contract component of the checkout estimate */
+  contractConsumption?: Maybe<SeekAnzAdProductContractConsumption>;
+}
+
+export interface SeekAnzAdProductContractConsumption {
+  __typename?: 'SeekAnzAdProductContractConsumption';
+  /** Summary of contract consumption */
+  summary: Scalars['String'];
+  /**
+   * Type of contract consumption.
+   * 
+   * Currently, three codes are defined:
+   * - `SameAdType` indicates payment due will be consumed from a contract of the same ad type as this product.
+   * - `OtherAdType` indicates payment due will be consumed from a contract of a different ad type to this product.
+   * - `SameAdTypePlusInvoice` indicates payment due will be consumed from a contract of the same ad type as this product and an invoice will be generated.
+   */
+  typeCode: Scalars['String'];
+}
+
+export interface SeekAnzAdProductAdvertisementInput {
+  /**
+   * The type of ad product.
+   * 
+   * Currently, three codes are defined:
+   * - `Classic` indicates a Classic ad.
+   * - `StandOut` indicates a StandOut ad.
+   * - `Premium` indicates a Premium ad.
+   */
+  typeCode: Scalars['String'];
+  /** The advertisement identifier. */
+  id?: Maybe<Scalars['String']>;
+  /** The hirer's job reference */
+  hirerJobReference?: Maybe<Scalars['String']>;
+  /** The position title */
+  positionTitle: Scalars['String'];
+  /** The job category identifier */
+  jobCategoryId: Scalars['String'];
+  /** The position location identifier */
+  positionLocationId: Scalars['String'];
+}
+
+export interface SeekAnzAdProductAdvertisementDraftInput {
+  /**
+   * The type of ad product.
+   * 
+   * Currently, three codes are defined:
+   * - `Classic` indicates a Classic ad.
+   * - `StandOut` indicates a StandOut ad.
+   * - `Premium` indicates a Premium ad.
+   */
+  typeCode?: Maybe<Scalars['String']>;
+  /** The advertisement identifier. */
+  id?: Maybe<Scalars['String']>;
+  /** The hirer's job reference */
+  hirerJobReference?: Maybe<Scalars['String']>;
+  /** The position title */
+  positionTitle?: Maybe<Scalars['String']>;
+  /** The job category identifier */
+  jobCategoryId?: Maybe<Scalars['String']>;
+  /** The position location identifer */
+  positionLocationId?: Maybe<Scalars['String']>;
+}
+
+/** Advertisement product fields which are not safe to consume as they are likely to change without notice. */
+export interface SeekAnzAdProductUnstable {
+  __typename?: 'SeekAnzAdProductUnstable';
+  /** Indicates whether the advertisement product should be recommended. */
+  recommendedIndicator: Scalars['Boolean'];
+}
+
+/** A message shown to the hirer for the current ad product. */
+export interface SeekAnzAdProductMessage {
+  __typename?: 'SeekAnzAdProductMessage';
+  /**
+   * The severity of the message.
+   * 
+   * Currently, two codes are defined:
+   * - `Informational` indicates a message with helpful information for a hirer.
+   * - `Critical` indicates a message with critical information for a hirer.
+   */
+  severityCode: Scalars['String'];
+  /** The content of the message. */
+  content: Scalars['String'];
+}
+
+export interface CurrencyMinorUnit {
+  __typename?: 'CurrencyMinorUnit';
+  /**
+   * A non-negative integer in the minor currency unit for the ISO currency code.
+   * 
+   * For example, this is the number of cents in dollar-denominated currencies.
+   */
+  value: Scalars['Int'];
+  /** The three-letter ISO 4217 currency code, in uppercase. */
+  currency: Scalars['String'];
+}
+
+/** The name of a person including a breakdown of name components. */
+export interface PersonName {
+  __typename?: 'PersonName';
+  /** The formatted name of a person, as it would be written out together. */
+  formattedName: Scalars['String'];
+  /** The given name of a person, if provided. */
+  given?: Maybe<Scalars['String']>;
+  /** The family name (or surname) of a person, if provided. */
+  family?: Maybe<Scalars['String']>;
+}
+
+/** A reference to a person associated with an object. */
+export interface SpecifiedPerson {
+  __typename?: 'SpecifiedPerson';
+  /** The person's name */
+  name?: Maybe<PersonName>;
+  /** Methods of communication with the person. */
+  communication: Communication;
+  /**
+   * The role of the person.
+   * 
+   * Currently, two codes are defined:
+   * - `Recruiter` indicates a person recruiting for the position.
+   * - `HiringManager` indicates an employee that requested the position to be filled.
+   */
+  roleCode?: Maybe<Scalars['String']>;
+}
+
+/** The name of a person associated with an object. */
+export interface PersonNameInput {
+  /** The formatted name of a person, as it would be written out together. */
+  formattedName: Scalars['String'];
+  /** The optional given name of a person. */
+  given?: Maybe<Scalars['String']>;
+  /** The optional family name (or surname) of a person. */
+  family?: Maybe<Scalars['String']>;
+}
+
+/** A reference to a person associated with an object. */
+export interface SpecifiedPersonInput {
+  /** The person's name. */
+  name?: Maybe<PersonNameInput>;
+  /** Methods of communication with the person. */
+  communication: CommunicationInput;
+  /**
+   * The role of the person.
+   * 
+   * Currently, two codes are defined:
+   * - `Recruiter` indicates a person recruiting for the position.
+   * - `HiringManager` indicates an employee that requested the position to be filled.
+   */
+  roleCode?: Maybe<Scalars['String']>;
+}
+
+/** The details of the position opening to be created. */
+export interface CreatePositionOpeningInput {
+  /** The party that owns the position opening. */
+  postingRequester: PostingRequesterInput;
+}
+
+/** The details of the person contacts in the position opening to be updated. */
+export interface UpdatePositionOpeningPersonContactsInput {
+  /** The unique identifier for the position opening to update. */
+  documentId: Scalars['String'];
+  /** Specific contact people for the position opening at the party. */
+  personContacts: Array<SpecifiedPersonInput>;
+}
+
+/** The details of the position opening to be deleted. */
+export interface DeletePositionOpeningInput {
+  /** The unique identifier for the position opening. */
+  id: Scalars['String'];
+}
+
+/**
+ * The party that owns the position opening.
+ * 
+ * This may be different from the hiring organization if the position opening is created by a recruitment agency.
+ */
+export interface PostingRequesterInput {
+  /** An opaque identifier for hirer or agency owning the position opening. */
+  id: Scalars['String'];
+  /**
+   * The role of the owner of the position opening.
+   * 
+   * Currently two codes are defined:
+   * - `Agency` indicates a recruitment agency hiring on behalf of another company.
+   * - `Company` indicates a company hiring on behalf of themselves.
+   */
+  roleCode: Scalars['String'];
+  /** Specific contact people for the position opening at the party. */
+  personContacts: Array<SpecifiedPersonInput>;
+}
+
+/**
+ * A profile for posting a job ad against an existing position opening.
+ * 
+ * This contains information of how a position opening is presented on a given channel or job board.
+ */
+export interface PostPositionProfileForOpeningInput {
+  /** The identifier of the position opening that this position profile belongs to. */
+  positionOpeningId: Scalars['String'];
+  /** A short phrase describing the position as it would be listed on a business card or in a company directory. */
+  positionTitle: Scalars['String'];
+  /**
+   * An array of identifiers for the organizations that have the position.
+   * 
+   * Scheme requirements:
+   * 
+   * - The `seekAnz` scheme requires exactly one element.
+   */
+  positionOrganizations: Array<Scalars['String']>;
+  /** An optional hirer-provided opaque job reference. */
+  seekHirerJobReference?: Maybe<Scalars['String']>;
+  /** An array of formatted position profile descriptions. */
+  positionFormattedDescriptions: Array<PositionFormattedDescriptionInput>;
+  /**
+   * An array of codes for the offered schedules for the position.
+   * 
+   * Currently, two codes are defined:
+   * 
+   * - `FullTime` indicates a full-time schedule.
+   * - `PartTime` indicates a part-time schedule.
+   * 
+   * For the `seekAnz` scheme, this field is not supported and should be set to `null`.
+   */
+  positionScheduleTypeCodes?: Maybe<Array<Scalars['String']>>;
+  /** The salary or compensation offered for the position. */
+  offeredRemunerationPackage: RemunerationPackageInput;
+  /**
+   * A SEEK ANZ work type code.
+   * 
+   * For positions in `seekAnz` scheme, this field is used instead of `positionScheduleTypeCodes`.
+   * 
+   * Currently, four work type codes are defined:
+   * 
+   * - `FullTime` indicates a full-time position.
+   * - `PartTime` indicates a part-time position.
+   * - `ContractTemp` indicates a fixed-length contract position.
+   * - `Casual` indicates a casual position.
+   * 
+   * Scheme requirements:
+   * 
+   * - Required for the `seekAnz` scheme when `postingInstructions` are provided.
+   * - Set to `null` for other schemes.
+   */
+  seekAnzWorkTypeCode?: Maybe<Scalars['String']>;
+  /**
+   * An array of `JobCategory` identifiers.
+   * 
+   * Scheme requirements:
+   * 
+   * - The `seekAnz` scheme requires exactly one element.
+   */
+  jobCategories: Array<Scalars['String']>;
+  /**
+   * An array of `Location` identifiers.
+   * 
+   * Scheme requirements:
+   * 
+   * - The `seekAnz` scheme requires exactly one element.
+   */
+  positionLocation: Array<Scalars['String']>;
+  /**
+   * The identifier of the questionnaire with the set of questions to present to candidates during an application.
+   * 
+   * The questionnaire responses will be available as `seekQuestionnaireSubmission` on the application's `CandidateProfile`.
+   */
+  seekApplicationQuestionnaireId?: Maybe<Scalars['String']>;
+  /** The video to render within the advertisement. */
+  seekVideo?: Maybe<SeekVideoInput>;
+  /**
+   * The instructions related to posting the job ad.
+   * 
+   * Scheme requirements:
+   * 
+   * - The `seekAnz` scheme requires exactly one element.
+   */
+  postingInstructions: Array<PostingInstructionInput>;
+}
+
+/** A formatted description of the position profile. */
+export interface PositionFormattedDescriptionInput {
+  /**
+   * The description type.
+   * 
+   * Currently, four description identifiers are defined:
+   * 1. `AdvertisementDetails` is the detailed description of the position that appears on the job ad.
+   * 2. `ContactDetails` is a free-text description of a contact person for the position.
+   *    The use of this field is discouraged in SEEK ANZ but it is still used by certain advertisement templates.
+   * 3. `SearchBulletPoint` is a highlight or selling point of the position that appears in search results.
+   *    SEEK ANZ allows up to three search bullet points for Premium or StandOut ad products.
+   * 4. `SearchSummary` is a short description that appears in search results.
+   */
+  descriptionId: Scalars['String'];
+  /** The HTML content of the description. */
+  content: Scalars['String'];
+}
+
+/** A collection of information about where and how to post a job ad. */
+export interface PostingInstructionInput {
+  /**
+   * A SEEK ANZ advertisement type code.
+   * 
+   * Currently, three codes are defined:
+   * 
+   * - `Classic` indicates a Classic advertisement.
+   * - `StandOut` indicates a StandOut advertisement.
+   * - `Premium` indicates a Premium advertisement.
+   * 
+   * Scheme requirements:
+   * 
+   * - For the `seekAnz` scheme, this field is required.
+   * - For other schemes, set this to `null`.
+   */
+  seekAnzAdvertisementType?: Maybe<Scalars['String']>;
+  /** The end date of the posting. */
+  end?: Maybe<Scalars['DateTime']>;
+  /**
+   * An identifier to ensure that multiple ads are not created on retries.
+   * 
+   * The identifier should be unique in the partner system for each position profile created.
+   * The same identifier must be provided when retrying after create failures.
+   */
+  idempotencyId: Scalars['String'];
+  /**
+   * An array of methods for applying to the position.
+   * 
+   * If no methods are provided, SEEK's native apply form will be used to receive candidate applications.
+   * Native applications will raise a `CandidateApplicationCreated` event that points to a `CandidateProfile` object.
+   * 
+   * Scheme requirements:
+   * 
+   * - For the `seekAnz` scheme, this field is limited to a single element. Requests with more than 1 element will fail.
+   */
+  applicationMethods?: Maybe<Array<ApplicationMethodInput>>;
+}
+
+/** The values to replace on a posted position profile. */
+export interface UpdatePostedPositionProfileInput {
+  /** The identifier of the posted position profile to update. */
+  positionProfileId: Scalars['String'];
+  /** A short phrase describing the position as it would be listed on a business card or in a company directory. */
+  positionTitle: Scalars['String'];
+  /**
+   * An array of identifiers for the organizations that have the position.
+   * 
+   * Scheme requirements:
+   * 
+   * - The `seekAnz` scheme requires exactly one element.
+   */
+  positionOrganizations: Array<Scalars['String']>;
+  /** An optional hirer-provided opaque job reference. */
+  seekHirerJobReference?: Maybe<Scalars['String']>;
+  /** An array of formatted position profile descriptions. */
+  positionFormattedDescriptions: Array<PositionFormattedDescriptionInput>;
+  /**
+   * An array of codes for the offered schedules for the position.
+   * 
+   * Currently, two codes are defined:
+   * 
+   * - `FullTime` indicates a full-time schedule.
+   * - `PartTime` indicates a part-time schedule.
+   * 
+   * For the `seekAnz` scheme, this field is not supported and should be set to `null`.
+   */
+  positionScheduleTypeCodes?: Maybe<Array<Scalars['String']>>;
+  /** The salary or compensation offered for the position. */
+  offeredRemunerationPackage: RemunerationPackageInput;
+  /**
+   * A SEEK ANZ work type code.
+   * 
+   * For positions in `seekAnz` scheme, this field is used instead of `positionScheduleTypeCodes`.
+   * 
+   * Currently, four work type codes are defined:
+   * 
+   * - `FullTime` indicates a full-time position.
+   * - `PartTime` indicates a part-time position.
+   * - `ContractTemp` indicates a fixed-length contract position.
+   * - `Casual` indicates a casual position.
+   * 
+   * Scheme requirements:
+   * 
+   * - Required for the `seekAnz` scheme when `postingInstructions` are provided.
+   * - Set to `null` for other schemes.
+   */
+  seekAnzWorkTypeCode?: Maybe<Scalars['String']>;
+  /**
+   * An array of `JobCategory` identifiers.
+   * 
+   * Scheme requirements:
+   * 
+   * - The `seekAnz` scheme requires exactly one element.
+   */
+  jobCategories: Array<Scalars['String']>;
+  /**
+   * An array of `Location` identifiers.
+   * 
+   * Scheme requirements:
+   * 
+   * - The `seekAnz` scheme requires exactly one element.
+   */
+  positionLocation: Array<Scalars['String']>;
+  /**
+   * The identifier of the questionnaire with the set of questions to present to candidates during an application.
+   * 
+   * The questionnaire responses will be available as `seekQuestionnaireSubmission` on the application's `CandidateProfile`.
+   * 
+   * Scheme requirements:
+   * 
+   * - For the `seekAnz` scheme, this field is ignored.
+   */
+  seekApplicationQuestionnaireId?: Maybe<Scalars['String']>;
+  /** The video to render within the advertisement. */
+  seekVideo?: Maybe<SeekVideoInput>;
+  /**
+   * The instructions related to posting the job ad.
+   * 
+   * Scheme requirements:
+   * 
+   * - The `seekAnz` scheme requires exactly one element.
+   */
+  postingInstructions: Array<PostingInstructionInput>;
+}
+
+/** The details of the posted position profile to be closed. */
+export interface ClosePostedPositionProfileInput {
+  /** The unique identifier for the posted position profile. */
+  id: Scalars['String'];
+}
+
+/** The salary or compensation for a position. */
+export interface RemunerationPackageInput {
+  /**
+   * A code classifying the primary method of payment for a position.
+   * 
+   * Currently, four basis codes are defined:
+   * 
+   * 1. `Hourly` employment is paid for the number of hours worked.
+   * 2. `Salaried` employment is paid on an annual basis.
+   * 3. `SalariedPlusCommission` employment is paid on an annual basis plus a results-based commission.
+   * 4. `CommissionOnly` employment is paid exclusively a results-based commission.
+   */
+  basisCode: Scalars['String'];
+  /**
+   * An array of offered salary ranges.
+   * 
+   * Scheme requirements:
+   * 
+   * - The `seekAnz` scheme is limited to a single element containing the amount for the `basisCode`.
+   */
+  ranges: Array<RemunerationRangeInput>;
+  /** Human readable descriptions of the remuneration package. */
+  descriptions: Array<Scalars['String']>;
+}
+
+/** A salary or compensation range for a position. */
+export interface RemunerationRangeInput {
+  /** The minimum amount an organization is willing to pay for a position. */
+  minimumAmount: RemunerationAmountInput;
+  /**
+   * The maximum amount an organization is willing to pay for a position.
+   * 
+   * A `null` value indicates the organization has not specified an upper bound for the range.
+   * 
+   * Scheme requirements:
+   * 
+   * - Required for the `seekAnz` scheme when `postingInstructions` are provided.
+   */
+  maximumAmount?: Maybe<RemunerationAmountInput>;
+  /**
+   * The interval the remuneration amounts are calculated over.
+   * 
+   * Currently two interval codes are defined:
+   * 
+   * - `Hour` is used to express hourly rates.
+   * - `Year` is used to express annual salaries or commissions.
+   */
+  intervalCode: Scalars['String'];
+}
+
+/** A monetary amount of remuneration in a specified currency. */
+export interface RemunerationAmountInput {
+  /**
+   * A non-negative float in the major currency unit for the ISO currency code.
+   * 
+   * For example, this is the number of dollars in dollar-denominated currencies.
+   */
+  value: Scalars['Float'];
+  /** The three-letter ISO 4217 currency code, in uppercase. */
+  currency: Scalars['String'];
+}
+
+/** An unposted profile of a position opening to create. */
+export interface CreateUnpostedPositionProfileForOpeningInput {
+  /** The identifier of the position opening that this position profile belongs to. */
+  positionOpeningId: Scalars['String'];
+  /** A short phrase describing the position as it would be listed on a business card or in a company directory. */
+  positionTitle: Scalars['String'];
+  /** An array of identifiers for the organizations that have the position. */
+  positionOrganizations: Array<Scalars['String']>;
+  /** An optional hirer-provided opaque job reference. */
+  seekHirerJobReference?: Maybe<Scalars['String']>;
+  /** An array of formatted position profile descriptions. */
+  positionFormattedDescriptions: Array<PositionFormattedDescriptionInput>;
+  /**
+   * An array of codes for the offered schedules for the position.
+   * 
+   * Currently, two codes are defined:
+   * 
+   * - `FullTime` indicates a full-time schedule.
+   * - `PartTime` indicates a part-time schedule.
+   */
+  positionScheduleTypeCodes?: Maybe<Array<Scalars['String']>>;
+  /** The salary or compensation offered for the position. */
+  offeredRemunerationPackage: RemunerationPackageInput;
+  /** An array of `JobCategory` identifiers. */
+  jobCategories: Array<Scalars['String']>;
+  /** An array of `Location` identifiers. */
+  positionLocation: Array<Scalars['String']>;
+}
+
+/** An unposted profile of a position opening to update. */
+export interface UpdateUnpostedPositionProfileInput {
+  /** The identifier of the unposted position profile to update. */
+  positionProfileId: Scalars['String'];
+  /** A short phrase describing the position as it would be listed on a business card or in a company directory. */
+  positionTitle: Scalars['String'];
+  /** An array of identifiers for the organizations that have the position. */
+  positionOrganizations: Array<Scalars['String']>;
+  /** An optional hirer-provided opaque job reference. */
+  seekHirerJobReference?: Maybe<Scalars['String']>;
+  /** An array of formatted position profile descriptions. */
+  positionFormattedDescriptions: Array<PositionFormattedDescriptionInput>;
+  /**
+   * An array of codes for the offered schedules for the position.
+   * 
+   * Currently, two codes are defined:
+   * 
+   * - `FullTime` indicates a full-time schedule.
+   * - `PartTime` indicates a part-time schedule.
+   */
+  positionScheduleTypeCodes?: Maybe<Array<Scalars['String']>>;
+  /** The salary or compensation offered for the position. */
+  offeredRemunerationPackage: RemunerationPackageInput;
+  /** An array of `JobCategory` identifiers. */
+  jobCategories: Array<Scalars['String']>;
+  /** An array of `Location` identifiers. */
+  positionLocation: Array<Scalars['String']>;
+}
+
+/** The details of the unposted position profile to be deleted. */
+export interface DeleteUnpostedPositionProfileInput {
+  /** The unique identifier for the unposted position profile. */
+  id: Scalars['String'];
+}
+
+/** A collection of information about the video to display alongside advertisement details. */
+export interface SeekVideoInput {
+  /**
+   * The URL of the video to display.
+   * 
+   * Scheme requirements:
+   * 
+   *  - The `seekAnz` scheme requires URLs to be YouTube embed URLs less than 255 characters e.g. `https://www.youtube.com/embed/aAgePQvHBQM`.
+   */
+  url: Scalars['String'];
+  /**
+   * The position relative to the advertisement details where the video should be rendered.
+   * 
+   * Currently, two codes are defined:
+   * 
+   * - `Above` indicates the video will render above the advertisement details.
+   * - `Below` indicates the video will render below the advertisement details.
+   */
+  seekAnzPositionCode?: Maybe<Scalars['String']>;
+}
+
+/** A method of applying to a position. */
+export interface ApplicationMethodInput {
+  /**
+   * A URL of an external application form.
+   * 
+   * When this is provided, SEEK's native apply form will be disabled and the candidate will be redirected to the supplied URL.
+   */
+  applicationUri: WebUrlInput;
+}
+
+/**
+ * The category of a job's occupation.
+ * 
+ * This query accepts browser tokens that include the `query:ontologies` scope.
+ */
+export interface JobCategory {
+  __typename?: 'JobCategory';
+  /** An opaque identifier for the job category. */
+  id: ObjectIdentifier;
+  /**
+   * The parent job category.
+   * 
+   * This is a more general classification that this category belongs to.
+   * It will be `null` for root categories that do not belong to a more general classification.
+   */
+  parent?: Maybe<JobCategory>;
+  /**
+   * An array of child job categories.
+   * 
+   * These are more specific categories that belong to this general classification.
+   */
+  children?: Maybe<Array<JobCategory>>;
+  /** Name of the job category. */
+  name: Scalars['String'];
+}
+
+/** A job category with information of the suggested choice. */
+export interface JobCategorySuggestionChoice {
+  __typename?: 'JobCategorySuggestionChoice';
+  /** The job category information of the suggestion choice. */
+  jobCategory: JobCategory;
+  /**
+   * A floating point value ranging from 0 (lowest) to 1 (highest)
+   * that indicates confidence of the job category returned based on the suggestion input.
+   */
+  confidence: Scalars['Float'];
+}
+
+/** The input parameter for the `jobCategorySuggestions` query. */
+export interface JobCategorySuggestionPositionProfileInput {
+  /** The position title. */
+  positionTitle: Scalars['String'];
+  /** An array of location identifiers of the position. */
+  positionLocation?: Maybe<Array<Scalars['String']>>;
+  /**
+   * The descriptions for the position profile.
+   * 
+   * Currently, only the `AdvertisementDetails` description is used. Other
+   * descriptions will be accepted but are ignored when determining the
+   * relevance of suggestion.
+   */
+  positionFormattedDescriptions?: Maybe<Array<PositionFormattedDescriptionInput>>;
+}
+
+export interface Location {
+  __typename?: 'Location';
+  /** An opaque identifier of the location. */
+  id: ObjectIdentifier;
+  /** The parent location. */
+  parent?: Maybe<Location>;
+  /** An array of child locations. */
+  children?: Maybe<Array<Location>>;
+  /** The location name. */
+  name: Scalars['String'];
+  /** Contextual name of the location. */
+  contextualName: Scalars['String'];
+  /** The two-letter ISO 3166-1:2013 country code, in uppercase. */
+  countryCode: Scalars['String'];
+}
+
+export interface LocationSuggestion {
+  __typename?: 'LocationSuggestion';
+  /** Location information of the choice. */
+  location: Location;
+}
+
+/** An organization hiring for an open position. */
+export interface HiringOrganization {
+  __typename?: 'HiringOrganization';
+  /** The opaque identifier of the hiring organization. */
+  id: ObjectIdentifier;
+  /** The name of the hiring organization. */
+  name: Scalars['String'];
+  /**
+   * The legacy SEEK ANZ advertiser ID.
+   * 
+   * This is a numeric identifier used by SEEK ANZ's legacy Job Posting & Application Export APIs.
+   * For organizations in other schemes this will be `null`.
+   */
+  seekAnzAdvertiserId?: Maybe<Scalars['Int']>;
+}
+
+/** The output parameter for the `createPositionOpening` mutation. */
+export interface CreatePositionOpeningPayload {
+  __typename?: 'CreatePositionOpeningPayload';
+  /** The details of the created position opening. */
+  positionOpening: PositionOpening;
+}
+
+/** The output parameter for the `updatePositionOpeningPersonContacts` mutation. */
+export interface UpdatePositionOpeningPersonContactsPayload {
+  __typename?: 'UpdatePositionOpeningPersonContactsPayload';
+  /** The details of the updated position opening. */
+  positionOpening: PositionOpening;
+}
+
+/** The output parameter for the `postPositionProfileForOpening` mutation. */
+export interface PostPositionProfileForOpeningPayload {
+  __typename?: 'PostPositionProfileForOpeningPayload';
+  /** Attributes of the newly created position profile. */
+  positionProfile: PostPositionProfileForOpeningPositionProfilePayload;
+}
+
+export interface PostPositionProfileForOpeningPositionProfilePayload {
+  __typename?: 'PostPositionProfileForOpening_PositionProfilePayload';
+  /** The identifier for the created position profile. */
+  id: ObjectIdentifier;
+}
+
+/** The output of the `updatePostedPositionProfile` mutation. */
+export interface UpdatePostedPositionProfilePayload {
+  __typename?: 'UpdatePostedPositionProfilePayload';
+  /** The identifier of the updated posted position profile. */
+  id: ObjectIdentifier;
+}
+
+/** The output of the `closePostedPositionProfile` mutation. */
+export interface ClosePostedPositionProfilePayload {
+  __typename?: 'ClosePostedPositionProfilePayload';
+  /** The identifier of the closed posted position profile. */
+  id: ObjectIdentifier;
+}
+
+/** The output parameter for the `createUnpostedPositionProfileForOpening` mutation. */
+export interface CreateUnpostedPositionProfileForOpeningPayload {
+  __typename?: 'CreateUnpostedPositionProfileForOpeningPayload';
+  /** Attributes of the newly created unposted position profile. */
+  unpostedPositionProfile: PositionProfile;
+}
+
+/** The output parameter for the `updateUnpostedPositionProfile` mutation. */
+export interface UpdateUnpostedPositionProfilePayload {
+  __typename?: 'UpdateUnpostedPositionProfilePayload';
+  /** Attributes of the unposted position profile. */
+  unpostedPositionProfile: PositionProfile;
+}
+
+/** The output parameter for the `deletePositionOpening` mutation. */
+export interface DeletePositionOpeningPayload {
+  __typename?: 'DeletePositionOpeningPayload';
+  /** The details of the deleted position opening. */
+  positionOpening: PositionOpening;
+}
+
+/** The output parameter for the `deleteUnpostedPositionProfile` mutation. */
+export interface DeleteUnpostedPositionProfilePayload {
+  __typename?: 'DeleteUnpostedPositionProfilePayload';
+  /** The details of the deleted unposted position profile. */
+  unpostedPositionProfile: PositionProfile;
+}
+
+/** A position opening in a paginated list. */
+export interface PositionOpeningEdge {
+  __typename?: 'PositionOpeningEdge';
+  /**
+   * The opaque cursor to the position opening.
+   * 
+   * This can be used as a subsequent pagination argument.
+   */
+  cursor: Scalars['String'];
+  /** The actual position opening. */
+  node: PositionOpening;
+}
+
+/** A page of position openings. */
+export interface PositionOpeningConnection {
+  __typename?: 'PositionOpeningConnection';
+  /**
+   * The page of position openings and their corresponding cursors.
+   * 
+   * This list may be empty.
+   */
+  edges: Array<PositionOpeningEdge>;
+  /** The pagination metadata for this page of position openings. */
+  pageInfo: PageInfo;
+}
+
+/** A job or position opening within an organization. */
+export interface PositionOpening {
+  __typename?: 'PositionOpening';
+  /** An opaque identifier for the position opening. */
+  documentId: ObjectIdentifier;
+  /**
+   * The party that owns the position opening.
+   * 
+   * This may be different from the hiring organization if the position opening is created by a recruitment agency.
+   */
+  postingRequester: PostingRequester;
+  /**
+   * An array of profiles for the position opening.
+   * 
+   * Each profile represents a posted job advertisement or an unposted internal requisition associated with this opening.
+   */
+  positionProfiles: Array<PositionProfile>;
+}
+
+/** The party that owns the position opening. */
+export interface PostingRequester {
+  __typename?: 'PostingRequester';
+  /** An opaque identifier for hirer or agency owning the position opening. */
+  id: ObjectIdentifier;
+  /** The name of the party that owns the position opening. */
+  name: Scalars['String'];
+  /**
+   * The legacy SEEK ANZ advertiser ID.
+   * 
+   * This is a numeric identifier used by SEEK ANZ's legacy Job Posting & Application Export APIs.
+   * For hirers or agencies in other schemes this will be `null`.
+   */
+  seekAnzAdvertiserId?: Maybe<Scalars['Int']>;
+  /**
+   * The role of the owner of the position opening.
+   * 
+   * Currently two codes are defined:
+   * - `Agency` indicates a recruitment agency hiring on behalf of another company.
+   * - `Company` indicates a company hiring on behalf of themselves.
+   */
+  roleCode: Scalars['String'];
+  /** Specific contact people for the position opening at the party. */
+  personContacts: Array<SpecifiedPerson>;
+}
+
+/**
+ * A profile of a position opening.
+ * 
+ * This contains information of how a position opening is presented on a job board or as an internal requisition.
+ */
+export interface PositionProfile {
+  __typename?: 'PositionProfile';
+  /** An opaque identifier for the position profile. */
+  profileId: ObjectIdentifier;
+  /** The `PositionOpening` that this profile was created under. */
+  positionOpening: PositionOpening;
+  /** A short phrase describing the position as it would be listed on a business card or in a company directory. */
+  positionTitle: Scalars['String'];
+  /** The organization which has the position. */
+  positionOrganizations: Array<HiringOrganization>;
+  /** An optional hirer-provided opaque job reference. */
+  seekHirerJobReference?: Maybe<Scalars['String']>;
+  /**
+   * The public web URL of the posted job advertisement.
+   * 
+   * This will be `null` for unposted position profiles.
+   */
+  positionUri?: Maybe<Scalars['String']>;
+  /** An array of formatted position profile descriptions. */
+  positionFormattedDescriptions: Array<PositionFormattedDescription>;
+  /**
+   * An array of codes for the offered schedules for the position.
+   * 
+   * Currently, two codes are defined:
+   * - `FullTime` indicates a full-time schedule.
+   * - `PartTime` indicates a part-time schedule.
+   * 
+   * If the offered schedule isn't known this will be `null`.
+   */
+  positionScheduleTypeCodes?: Maybe<Array<Scalars['String']>>;
+  /** The salary or compensation offered for the position. */
+  offeredRemunerationPackage: RemunerationPackage;
+  /**
+   * A SEEK ANZ work type code.
+   * 
+   * Four work type codes are defined:
+   * - `FullTime` indicates a full-time position.
+   * - `PartTime` indicates a part-time position.
+   * - `ContractTemp` indicates a fixed-length contract position.
+   * - `Casual` indicates a casual position.
+   * 
+   * For positions in other schemes this will be `null`.
+   */
+  seekAnzWorkTypeCode?: Maybe<Scalars['String']>;
+  /** The occupational categories of the job. */
+  jobCategories: Array<JobCategory>;
+  /** The locations of the position. */
+  positionLocation: Array<Location>;
+  /**
+   * The set of questions presented to candidates during an application.
+   * 
+   * The questionnaire responses will be available as `seekQuestionnaireSubmission` on the application's `CandidateProfile`.
+   */
+  seekApplicationQuestionnaire?: Maybe<ApplicationQuestionnaire>;
+  /** The video to render within the advertisement. */
+  seekVideo?: Maybe<SeekVideo>;
+  /** The instructions related to posting the job ad. */
+  postingInstructions: Array<PostingInstruction>;
+}
+
+/**
+ * A description type identifier.
+ * 
+ * This specifies the meaning of the description and determines where it's
+ * presented to the candidate.
+ */
+export interface PositionFormattedDescriptionIdentifier {
+  __typename?: 'PositionFormattedDescriptionIdentifier';
+  /**
+   * The description type.
+   * 
+   * Currently, three description identifiers are defined:
+   * 1. `AdvertisementDetails` is the detailed description of the position that appears on the job ad.
+   * 2. `SearchSummary` is a short description that appears in search results.
+   * 3. `SearchBulletPoint` is a highlight or selling point of the position that appears in search results.
+   *    SEEK ANZ allows up to three search bullet points for Premium or StandOut ad products.
+   */
+  value: Scalars['String'];
+}
+
+/** A formatted description of the position profile. */
+export interface PositionFormattedDescription {
+  __typename?: 'PositionFormattedDescription';
+  /** The description type. */
+  descriptionId: PositionFormattedDescriptionIdentifier;
+  /** The HTML content of the description. */
+  content: Scalars['String'];
+}
+
+/** The salary or compensation for a position. */
+export interface RemunerationPackage {
+  __typename?: 'RemunerationPackage';
+  /**
+   * A code classifying the primary method of payment for a position.
+   * 
+   * Currently, four basis codes are defined:
+   * 
+   * 1. `Hourly` employment is paid for the number of hours worked.
+   * 2. `Salaried` employment is paid on an annual basis.
+   * 3. `SalariedPlusCommission` employment is paid on an annual basis plus a results-based commission.
+   * 4. `CommissionOnly` employment is paid exclusively a results-based commission.
+   */
+  basisCode: Scalars['String'];
+  /**
+   * An array of offered salary ranges.
+   * 
+   * The scheme `seekAnz` will always have a single element containing the amount for the `basisCode`.
+   */
+  ranges: Array<RemunerationRange>;
+  /** Human readable descriptions of the remuneration package. */
+  descriptions: Array<Scalars['String']>;
+}
+
+/** A salary or compensation range for a position. */
+export interface RemunerationRange {
+  __typename?: 'RemunerationRange';
+  /** The minimum amount an organization is willing to pay for a position. */
+  minimumAmount: RemunerationAmount;
+  /**
+   * The maximum amount an organization is willing to pay for a position.
+   * 
+   * A 'null' value indicates the organization has not specified an upper bound for the range.
+   */
+  maximumAmount?: Maybe<RemunerationAmount>;
+  /**
+   * The interval the remuneration amounts are calculated over.
+   * 
+   * Currently two interval codes are defined:
+   * 
+   * - `Hourly` is used to express hourly rates.
+   * - `Year` is used to express annual salaries or commissions.
+   */
+  intervalCode: Scalars['String'];
+}
+
+/** A monetary amount of remuneration in a specified currency. */
+export interface RemunerationAmount {
+  __typename?: 'RemunerationAmount';
+  /**
+   * A non-negative float in the major currency unit for the ISO currency code.
+   * 
+   * For example, this is the number of dollars in dollar-denominated currencies.
+   */
+  value: Scalars['Float'];
+  /** The three-letter ISO 4217 currency code, in uppercase. */
+  currency: Scalars['String'];
+}
+
+/** A collection of information about where and how to post a job ad. */
+export interface PostingInstruction {
+  __typename?: 'PostingInstruction';
+  /** The start date of the posting. */
+  start: Scalars['DateTime'];
+  /** The end date of the posting. */
+  end: Scalars['DateTime'];
+  /**
+   * An array of methods for applying to the position.
+   * 
+   * If no methods are provided, SEEK's native apply form will be used to receive candidate applications.
+   * Native applications will raise a `CandidateApplicationCreated` event that points to a `CandidateProfile` object.
+   */
+  applicationMethods: Array<ApplicationMethod>;
+}
+
+/** A method of applying to a position. */
+export interface ApplicationMethod {
+  __typename?: 'ApplicationMethod';
+  /**
+   * A URL of an external application form.
+   * 
+   * When this is provided, SEEK's native apply form will be disabled and the candidate will be redirected to the supplied URL.
+   */
+  applicationUri: WebUrl;
+}
+
+/** A collection of information about the video to display alongside advertisement details. */
+export interface SeekVideo {
+  __typename?: 'SeekVideo';
+  /** The URL of the video. */
+  url: Scalars['String'];
+  /**
+   * The position relative to the advertisement details where the video is rendered.
+   * 
+   * Currently, two codes are defined:
+   * 
+   * - `Above` indicates the video will render above the advertisement details.
+   * - `Below` indicates the video will render below the advertisement details.
+   */
+  seekAnzPositionCode?: Maybe<Scalars['String']>;
+}
+
+/** Information about a person not specific to a candidate profile. */
+export interface CandidatePerson {
+  __typename?: 'CandidatePerson';
+  /** An opaque identifier for the person. */
+  id: ObjectIdentifier;
+  /** The person's name. */
+  name: PersonName;
+  /** Methods of communication with the person. */
+  communication: Communication;
+}
+
+/**
+ * A person who applied for a position at a company.
+ * 
+ * If the same person applies to multiple hirers they will have distinct
+ * `Candidate` objects created.
+ */
+export interface Candidate {
+  __typename?: 'Candidate';
+  /**
+   * An opaque identifier for the candidate
+   * 
+   * This is unique for a given hirer & person.
+   */
+  documentId: ObjectIdentifier;
+  /**
+   * Information to identify the person, including their name and methods of
+   * communicating with the person.
+   */
+  person: CandidatePerson;
+  /**
+   * The list of profiles associated with with the candidate.
+   * Each submitted application for a position will have an associated profile.
+   */
+  profiles: Array<CandidateProfile>;
+}
+
+/** The role of an attachment within a profile. */
+export enum SeekAttachmentRole {
+  /** A resume or CV. */
+  Resume = 'RESUME',
+  /** A cover letter specific to a position opening. */
+  CoverLetter = 'COVER_LETTER',
+  /** A document supporting a position-specific selection criteria. */
+  SelectionCriteria = 'SELECTION_CRITERIA'
+}
+
+/** The details of a position the candidate applied for. */
+export interface AssociatedPositionOpening {
+  __typename?: 'AssociatedPositionOpening';
+  /**
+   * The identifier for the position opening the candidate applied for.
+   * 
+   * This is included for HR-JSON compatibility; GraphQL users should use the
+   * `positionOpening` nested object instead.
+   */
+  positionOpeningId: ObjectIdentifier;
+  /** The position opening this candidate applied for. */
+  positionOpening: PositionOpening;
+  /**
+   * The public web URL of the posted job advertisement.
+   * 
+   * This will be `null` for unposted position profiles.
+   */
+  positionUri?: Maybe<Scalars['String']>;
+  /**
+   * An indicator that the candidate applied to this associated position.
+   * 
+   * This is always `true` until proactive sourcing is supported.
+   */
+  candidateAppliedIndicator?: Maybe<Scalars['Boolean']>;
+}
+
+/** A profile attachment stored at an external URL. */
+export interface Attachment {
+  __typename?: 'Attachment';
+  /**
+   * The opaque identifier for the attachment.
+   * This is unique across all attachments.
+   */
+  id: ObjectIdentifier;
+  /**
+   * A download URL for the attachment.
+   * 
+   * This URL accepts partner tokens or browser tokens that include the `download:candidate-profile-attachments` scope.
+   * This is guaranteed to be an absolute URL with an origin of `https://graphql.seek.com`.
+   */
+  url: Scalars['String'];
+  /**
+   * An array of human-readable descriptions of the attachment.
+   * 
+   * To programmatically distinguish attachment types `seekRole` should be
+   * used.
+   */
+  descriptions: Array<Scalars['String']>;
+  /** The role of the attachment within a profile. */
+  seekRole: SeekAttachmentRole;
+}
+
+/** Basic information to identify and reference a specific organization. */
+export interface Organization {
+  __typename?: 'Organization';
+  name: Scalars['String'];
+}
+
+/** The details about a person's tenure within the position. */
+export interface PositionHistory {
+  __typename?: 'PositionHistory';
+  /**
+   * The start date of the position.
+   * This may only contain the year and month, e.g. `2019-01`.
+   */
+  start: Scalars['HistoryDate'];
+  /**
+   * The end date of the position if known.
+   * This may only contain the year and month, e.g. `2019-01`.
+   */
+  end?: Maybe<Scalars['HistoryDate']>;
+  /** Indicates whether the person is still working at the organization, if known. */
+  current?: Maybe<Scalars['Boolean']>;
+  /** The title that the person held for this position. */
+  title: Scalars['String'];
+}
+
+/** The details of a person's employment, work, or relevant experience. */
+export interface EmployerHistory {
+  __typename?: 'EmployerHistory';
+  /** The specific organization to which the person held positions. */
+  organization: Organization;
+  /** The set of positions that the person held. */
+  positionHistories: Array<PositionHistory>;
+}
+
+/** Structured information about a candidate related to a particular application. */
+export interface CandidateProfile {
+  __typename?: 'CandidateProfile';
+  /**
+   * The `Candidate` that submitted this application.
+   * 
+   * This contains the candidate's personal details along with all their
+   * applications to the same hirer.
+   */
+  candidate: Candidate;
+  /**
+   * An opaque identifier for the profile.
+   * 
+   * This profile can be queried at any time by passing this identifier string
+   * to `candidateProfile`.
+   */
+  profileId: ObjectIdentifier;
+  /** The date & time the candidate applied for the position. */
+  createDateTime: Scalars['DateTime'];
+  /** The positions this candidate has applied for. */
+  associatedPositionOpenings: Array<AssociatedPositionOpening>;
+  /** The attachments related to the candidate's profile. */
+  attachments: Array<Attachment>;
+  /** The employment history of the candidate. */
+  employment: Array<EmployerHistory>;
+  /** The completed candidate submission for the position profile's questionnaire. */
+  seekQuestionnaireSubmission?: Maybe<ApplicationQuestionnaireSubmission>;
+}
+
+/** A webhook attempt. */
+export interface WebhookAttempt {
+  __typename?: 'WebhookAttempt';
+  /** An opaque identifier for the webhook attempt. */
+  id: ObjectIdentifier;
+  /** The date & time that the webhook attempt was acknowledged or timed out. */
+  createDateTime: Scalars['DateTime'];
+  /** The event opaque identifier that generated the attempt. */
+  eventId: ObjectIdentifier;
+  /** The subscription opaque identifier that generated the attempt. */
+  subscriptionId: ObjectIdentifier;
+  /** The HTTP status for the webhook attempt. */
+  statusCode: Scalars['Int'];
+  /**
+   * The result description for the webhook attempt.
+   * 
+   * Currently, four codes are defined:
+   * 
+   * 1. `BadResponse` indicates that the webhook attempt received a non-2xx HTTP response
+   * 2. `InvalidUrl` indicates that the subscription URL did not pass validation
+   * 3. `RequestTimeout` indicates that the webhook attempt did not receive a timely response
+   * 4. `Success` indicates that the webhook attempt received a 2xx HTTP response
+   */
+  descriptionCode: Scalars['String'];
+  /**
+   * The identifier of the HTTP request for the webhook attempt.
+   * 
+   * This identifier is included in the request as an `X-Request-Id` custom header.
+   */
+  requestId: Scalars['String'];
+}
+
+/** A webhook attempt in a paginated list. */
+export interface WebhookAttemptEdge {
+  __typename?: 'WebhookAttemptEdge';
+  /**
+   * The opaque cursor to the webhook attempt.
+   * 
+   * This can be used as a subsequent pagination argument.
+   */
+  cursor: Scalars['String'];
+  /** The actual webhook attempt. */
+  node: WebhookAttempt;
+}
+
+/** A page of webhook attempts. */
+export interface WebhookAttemptsConnection {
+  __typename?: 'WebhookAttemptsConnection';
+  /**
+   * The page of webhook attempts and their corresponding cursors.
+   * 
+   * This is always a non-empty list.
+   */
+  edges: Array<WebhookAttemptEdge>;
+  /** The pagination metadata for this page of webhook attempts. */
+  pageInfo: PageInfo;
+}
+
+export interface WebhookAttemptsFilterInput {
+  /**
+   * The creation date & time that resulting webhook attempts must succeed.
+   * 
+   * This can be used to initiate the retrieval of paginated results.
+   * Subsequent queries should use the opaque cursors returned from `WebhookAttemptsConnection`.
+   */
+  afterDateTime?: Maybe<Scalars['DateTime']>;
+  /**
+   * The creation date & time that resulting webhook attempts must precede.
+   * 
+   * This can be used to initiate the retrieval of paginated results.
+   * Subsequent queries should use the opaque cursors returned from `WebhookAttemptsConnection`.
+   */
+  beforeDateTime?: Maybe<Scalars['DateTime']>;
+  /**
+   * The types of webhook attempts to retrieve.
+   * 
+   * See the relevant `WebhookAttempt` implementation for a list of supported description types.
+   */
+  descriptionCodes?: Maybe<Array<Scalars['String']>>;
+}
+
+/** The details of the webhook subscription to be created. */
+export interface CreateWebhookSubscriptionSubscriptionInput {
+  /**
+   * The type of event to subscribe to.
+   * 
+   * See `Event` implementations for a list of supported values.
+   */
+  eventTypeCode: Scalars['String'];
+  /**
+   * The data source for the event.
+   * 
+   * This commonly refers to a SEEK brand.
+   * See the relevant `Event` implementation for a list of supported schemes.
+   */
+  schemeId: Scalars['String'];
+  /** The subscriber-owned URL where events will be sent to. */
+  url: Scalars['String'];
+  /**
+   * The maximum number of events that will be sent in each HTTP request.
+   * 
+   * This number must be between 1 and 10 inclusive. Defaults to 10.
+   */
+  maxEventsPerAttempt?: Maybe<Scalars['Int']>;
+  /**
+   * The algorithm for signing webhooks.
+   * 
+   * Currently, two codes are defined:
+   * 
+   * - `None` indicates no signature will be attached.
+   * - `SeekHmacSha512` indicates a HMAC SHA-512 hex digest will be attached to
+   *   each request as a `Seek-Signature` header.
+   * 
+   * A webhook's signature can be used to validate that the request originated
+   * from SEEK.
+   * 
+   * Use a constant-time algorithm to validate the signature. Regular comparison
+   * methods like the `==` operator are susceptible to timing attacks.
+   */
+  signingAlgorithmCode: Scalars['String'];
+  /**
+   * The secret for signing webhooks.
+   * 
+   * This must be specified if `signingAlgorithmCode` is not `None`. It is
+   * used as the key to generate a message authentication code for each request.
+   * 
+   * The secret should be a random string with high entropy that is not reused
+   * for any other purpose.
+   */
+  secret?: Maybe<Scalars['String']>;
+}
+
+/** The details of the webhook subscription to be deleted. */
+export interface DeleteWebhookSubscriptionSubscriptionInput {
+  /** The unique identifier for the subscription. */
+  id: Scalars['String'];
+}
+
+/**
+ * A subscription for a given event type and scheme to be delivered via webhook.
+ * 
+ * Events are delivered in batches with a HTTP POST request to the specified subscription URL.
+ */
+export interface WebhookSubscription {
+  __typename?: 'WebhookSubscription';
+  /** The unique identifier for the subscription. */
+  id: ObjectIdentifier;
+  /**
+   * The type of event.
+   * 
+   * See `Event` implementations for a list of supported values.
+   */
+  eventTypeCode: Scalars['String'];
+  /**
+   * The data source for the event.
+   * 
+   * This commonly refers to a SEEK brand.
+   * See the relevant `Event` implementation for a list of supported schemes.
+   */
+  schemeId: Scalars['String'];
+  /** The subscriber-owned URL where events are sent to. */
+  url: Scalars['String'];
+  /**
+   * The maximum number of events that will be sent in each HTTP request.
+   * 
+   * This number is between 1 and 10 inclusive. Defaults to 10.
+   */
+  maxEventsPerAttempt: Scalars['Int'];
+  /**
+   * The algorithm for signing webhooks.
+   * 
+   * Currently, two codes are defined:
+   * 
+   * - `None` indicates no signature will be attached.
+   * - `SeekHmacSha512` indicates a HMAC SHA-512 hex digest will be attached to
+   *   each request as a `Seek-Signature` header.
+   * 
+   * A webhook's signature can be used to validate that the request originated
+   * from SEEK.
+   * 
+   * Use a constant-time algorithm to validate the signature. Regular comparison
+   * methods like the `==` operator are susceptible to timing attacks.
+   */
+  signingAlgorithmCode: Scalars['String'];
+  /**
+   * The date & time the webhook subscription was created.
+   * 
+   * Initial `afterDateTime` and `beforeDateTime` filters apply to this field.
+   */
+  createDateTime: Scalars['DateTime'];
+  /** The date & time the webhook subscription was last updated. */
+  updateDateTime: Scalars['DateTime'];
+  /**
+   * A page of webhook attempts for the current subscription matching the specified criteria.
+   * 
+   * The result list is returned in ascending creation date & time order.
+   * It starts from the earliest known attempt if no pagination arguments are provided.
+   */
+  webhookAttempts: WebhookAttemptsConnection;
+}
+
+
+/**
+ * A subscription for a given event type and scheme to be delivered via webhook.
+ * 
+ * Events are delivered in batches with a HTTP POST request to the specified subscription URL.
+ */
+export interface WebhookSubscriptionWebhookAttemptsArgs {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  filter?: Maybe<WebhookAttemptsFilterInput>;
+}
+
+/** The input parameter for the `createWebhookSubscription` mutation. */
+export interface CreateWebhookSubscriptionInput {
+  /** The details of the webhook subscription to be created. */
+  webhookSubscription: CreateWebhookSubscriptionSubscriptionInput;
+}
+
+/** The output parameter for the `createWebhookSubscription` mutation. */
+export interface CreateWebhookSubscriptionPayload {
+  __typename?: 'CreateWebhookSubscriptionPayload';
+  /** The details of the created webhook subscription. */
+  webhookSubscription: WebhookSubscription;
+}
+
+/** The input parameter for the `deleteWebhookSubscription` mutation. */
+export interface DeleteWebhookSubscriptionInput {
+  /** The details of the webhook subscription to be deleted. */
+  webhookSubscription: DeleteWebhookSubscriptionSubscriptionInput;
+}
+
+/** The output parameter for the `deleteWebhookSubscription` mutation. */
+export interface DeleteWebhookSubscriptionPayload {
+  __typename?: 'DeleteWebhookSubscriptionPayload';
+  /** The details of the deleted webhook subscription. */
+  webhookSubscription: WebhookSubscription;
+}
+
+/** A webhook subscription in a paginated list. */
+export interface WebhookSubscriptionEdge {
+  __typename?: 'WebhookSubscriptionEdge';
+  /**
+   * The opaque cursor to the webhook subscription.
+   * 
+   * This can be used as a subsequent pagination argument.
+   */
+  cursor: Scalars['String'];
+  /** The actual webhook subscription. */
+  node: WebhookSubscription;
+}
+
+/** A page of webhook subscriptions. */
+export interface WebhookSubscriptionsConnection {
+  __typename?: 'WebhookSubscriptionsConnection';
+  /**
+   * The page of webhook subscriptions and their corresponding cursors.
+   * 
+   * This is always a non-empty list.
+   */
+  edges: Array<WebhookSubscriptionEdge>;
+  /** The pagination metadata for this page of subscriptions. */
+  pageInfo: PageInfo;
+}
+
+/**
+ * The criteria to filter webhook subscriptions by.
+ * 
+ * These are `WebhookSubscription`-specific extensions on top of the standard pagination arguments `before`, `after`, `first` and `last`.
+ */
+export interface WebhookSubscriptionsFilterInput {
+  /**
+   * The creation date & time that resulting webhook subscriptions must succeed.
+   * 
+   * This can be used to initiate the retrieval of paginated results.
+   * Subsequent queries should use the opaque cursors returned from `WebhookSubscriptionsConnection`.
+   */
+  afterDateTime?: Maybe<Scalars['DateTime']>;
+  /**
+   * The creation date & time that resulting webhook subscriptions must precede.
+   * 
+   * This can be used to initiate the retrieval of paginated results.
+   * Subsequent queries should use the opaque cursors returned from `WebhookSubscriptionsConnection`.
+   */
+  beforeDateTime?: Maybe<Scalars['DateTime']>;
+  /**
+   * The types of webhook subscriptions to retrieve.
+   * 
+   * See the relevant `WebhookSubscription` implementation for a list of supported event types.
+   */
+  eventTypeCodes?: Maybe<Array<Scalars['String']>>;
+}
+
+/** A page of events from a stream. */
+export interface EventsConnection {
+  __typename?: 'EventsConnection';
+  /**
+   * The page of events and their corresponding cursors.
+   * 
+   * This is always a non-empty list.
+   */
+  edges: Array<EventEdge>;
+  /** The pagination metadata for this page of events. */
+  pageInfo: PageInfo;
+}
+
+/** An event in a stream. */
+export interface EventEdge {
+  __typename?: 'EventEdge';
+  /**
+   * The opaque cursor to the event in the stream.
+   * 
+   * This can be used as a subsequent pagination argument.
+   */
+  cursor: Scalars['String'];
+  /** The actual event. */
+  node: Event;
+  /**
+   * The date & time the event was added to the stream.
+   * 
+   * Initial `afterDateTime` and `beforeDateTime` filters apply to this field.
+   */
+  streamDateTime: Scalars['DateTime'];
+}
+
+/**
+ * A signal that an action has been performed on the SEEK platform that may be of interest to an integration partner.
+ * 
+ * Events can be delivered via:
+ * 
+ * - Webhook, using the `createWebhookSubscription` mutation
+ * - GraphQL polling, using the paginated `events` query
+ */
+export interface Event {
+  /** The unique identifier of the event. */
+  id: ObjectIdentifier;
+  /**
+   * The data source for the event.
+   * 
+   * This commonly refers to a SEEK brand.
+   * See the relevant `Event` implementation for a list of supported schemes.
+   */
+  schemeId: Scalars['String'];
+  /**
+   * The type of event.
+   * 
+   * See `Event` implementations for a list of supported values.
+   */
+  typeCode: Scalars['String'];
+  /**
+   * The date & time the event was created.
+   * 
+   * This is commonly linked to the creation of an object that can be retrieved from the SEEK API.
+   * 
+   * The data source for this field differs by event type and scheme.
+   * This field has weak ordering guarantees, so it should not be used as a pagination argument.
+   */
+  createDateTime: Scalars['DateTime'];
+  /**
+   * A page of webhook attempts for the current event matching the specified criteria.
+   * 
+   * The result list is returned in ascending creation date & time order.
+   * It starts from the earliest known attempt if no pagination arguments are provided.
+   */
+  webhookAttempts: WebhookAttemptsConnection;
+}
+
+
+/**
+ * A signal that an action has been performed on the SEEK platform that may be of interest to an integration partner.
+ * 
+ * Events can be delivered via:
+ * 
+ * - Webhook, using the `createWebhookSubscription` mutation
+ * - GraphQL polling, using the paginated `events` query
+ */
+export interface EventWebhookAttemptsArgs {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  filter?: Maybe<WebhookAttemptsFilterInput>;
+}
+
+/**
+ * The event signaling that a candidate has applied for a `PositionOpening`.
+ * 
+ * A candidate may apply for the same position opening more than once.
+ * Each application will trigger a new event with a distinct `id`.
+ */
+export interface CandidateApplicationCreatedEvent extends Event {
+  __typename?: 'CandidateApplicationCreatedEvent';
+  /** The unique identifier of the event. */
+  id: ObjectIdentifier;
+  /**
+   * The data source for the event.
+   * 
+   * The following schemes are supported for this event type:
+   * 
+   * - seekAnz
+   */
+  schemeId: Scalars['String'];
+  /** The type of event, i.e. `CandidateApplicationCreated`. */
+  typeCode: Scalars['String'];
+  /**
+   * The date & time the application was accepted from the candidate.
+   * 
+   * This field has weak ordering guarantees, so it should not be used as a pagination argument.
+   */
+  createDateTime: Scalars['DateTime'];
+  /**
+   * The identifier for the specific `CandidateProfile` associated with the application.
+   * 
+   * This can be used to retrieve structured candidate details with the `candidateWithApplicationProfile` query.
+   */
+  candidateApplicationProfileId: Scalars['String'];
+  /** The identifier for the `Candidate` that applied for the position opening. */
+  candidateId: Scalars['String'];
+  /**
+   * The `Candidate` that applied for the position opening.
+   * 
+   * This will include the candidate's personal details along with all
+   * application profiles for a single hirer.
+   */
+  candidate: Candidate;
+  /** The `CandidateProfile` associated with the application. */
+  candidateApplicationProfile: CandidateProfile;
+  /**
+   * A page of webhook attempts for the current event matching the specified criteria.
+   * 
+   * The result list is returned in ascending creation date & time order.
+   * It starts from the earliest known attempt if no pagination arguments are provided.
+   */
+  webhookAttempts: WebhookAttemptsConnection;
+}
+
+
+/**
+ * The event signaling that a candidate has applied for a `PositionOpening`.
+ * 
+ * A candidate may apply for the same position opening more than once.
+ * Each application will trigger a new event with a distinct `id`.
+ */
+export interface CandidateApplicationCreatedEventWebhookAttemptsArgs {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  filter?: Maybe<WebhookAttemptsFilterInput>;
+}
+
+/**
+ * The criteria to filter events by.
+ * 
+ * These are `Event`-specific extensions on top of the standard pagination arguments `before`, `after`, `first` and `last`.
+ */
+export interface EventsFilterInput {
+  /**
+   * The stream date & time that resulting events must succeed.
+   * 
+   * This can be used to initiate the retrieval of paginated results.
+   * Subsequent queries should use the opaque cursors returned from `EventsConnection`.
+   */
+  afterDateTime?: Maybe<Scalars['DateTime']>;
+  /**
+   * The stream date & time that resulting events must precede.
+   * 
+   * This can be used to initiate the retrieval of paginated results.
+   * Subsequent queries should use the opaque cursors returned from `EventsConnection`.
+   */
+  beforeDateTime?: Maybe<Scalars['DateTime']>;
+  /**
+   * An indicator that the event was successfully delivered via the specified webhook `subscriptionId`.
+   * 
+   * This filter does not apply if `subscriptionId` is not specified.
+   */
+  deliveredIndicator?: Maybe<Scalars['Boolean']>;
+  /**
+   * The types of events to retrieve.
+   * 
+   * See `Event` implementations for a list of supported values.
+   */
+  eventTypeCodes?: Maybe<Array<Scalars['String']>>;
+  /**
+   * The subscription stream to retrieve events from.
+   * 
+   * This can be used in combination with `deliveredIndicator` to identify events that were not successfully delivered through a particular webhook subscription.
+   * 
+   * To consume events solely through GraphQL polling, do not specify this field.
+   * This will retrieve events from a persistent stream that is not associated with a webhook subscription.
+   */
+  subscriptionId?: Maybe<Scalars['String']>;
+}
+
+/**
+ * Advertisement branding.
+ * 
+ * This can be associated with one or more `PositionProfile`s when they are created.
+ */
+export interface AdvertisementBranding {
+  __typename?: 'AdvertisementBranding';
+  /** An opaque identifier for advertisement branding. */
+  id: ObjectIdentifier;
+  /** The advertisement branding name. */
+  name: Scalars['String'];
+  /** A list of images associated with the advertisement branding. */
+  images: Array<AdvertisementBrandingImage>;
+  /** The organization that has the advertisement branding. */
+  hirer: HiringOrganization;
+}
+
+/** A visual representation of advertisement branding. */
+export interface AdvertisementBrandingImage {
+  __typename?: 'AdvertisementBrandingImage';
+  /**
+   * The type of advertisement branding image.
+   * 
+   * Currently, only one code is defined:
+   * - `Original` indicates the original advertisement branding image from which other images are derived.
+   */
+  typeCode: Scalars['String'];
+  /**
+   * The URL of the advertisement branding image.
+   * 
+   * This can be retrieved to visually identify an advertisement branding in a partner system.
+   */
+  url: Scalars['String'];
+}
+
+/** A page of advertisement brandings for a hirer. */
+export interface AdvertisementBrandingsConnection {
+  __typename?: 'AdvertisementBrandingsConnection';
+  /**
+   * The page of advertisement brandings and their corresponding cursors.
+   * 
+   * This list may be empty.
+   */
+  edges: Array<AdvertisementBrandingEdge>;
+  /** The pagination metadata for this page of advertisement brandings. */
+  pageInfo: PageInfo;
+}
+
+export interface AdvertisementBrandingEdge {
+  __typename?: 'AdvertisementBrandingEdge';
+  /**
+   * The opaque cursor to advertisement branding.
+   * 
+   * This can be used as a subsequent pagination argument.
+   */
+  cursor: Scalars['String'];
+  /** The actual advertisement branding. */
+  node: AdvertisementBranding;
+}
+
+/**
+ * An advertisement template.
+ * 
+ * This can be associated with one or more `PositionProfile`s when they are created or updated.
+ */
+export interface AdvertisementTemplate {
+  __typename?: 'AdvertisementTemplate';
+  /** An opaque identifier for the advertisement template. */
+  id: ObjectIdentifier;
+  /** The advertisement template name. */
+  name: Scalars['String'];
+  /**
+   * The URL of the advertisement template preview image.
+   * 
+   * This can be retrieved to visually identify the advertisement template in a partner system.
+   */
+  previewImageUrl: Scalars['String'];
+  /**
+   * A list of fields specific to the advertisement template.
+   * 
+   * Advertisement fields are placeholders in the advertisement template which are replaced
+   * with the given values when creating or updating one or more `PositionProfile`s.
+   * 
+   * This list may be empty.
+   */
+  fields: Array<AdvertisementTemplateField>;
+  /** The organization that has the advertisement template. */
+  hirer: HiringOrganization;
+}
+
+/** A custom field that is rendered as part of the template. */
+export interface AdvertisementTemplateField {
+  __typename?: 'AdvertisementTemplateField';
+  /**
+   * A SEEK-provided key for the field in the advertisement template.
+   * 
+   * This can be associated with the advertisement template used when creating or updating one or more `PositionProfile`s.
+   */
+  key: Scalars['String'];
+  /** The advertisement template field name to show to the hirer. */
+  name: Scalars['String'];
+  /**
+   * The input field type.
+   * 
+   * This can be used by a partner system to render the appropriate input control.
+   * 
+   * Currently, these codes are defined:
+   * - `SingleLineText` indicates a single line of text.
+   * - `MultilineText` indicates multiple lines of text.
+   */
+  inputTypeCode: Scalars['String'];
+}
+
+/** A page of advertisement templates for a hirer. */
+export interface AdvertisementTemplatesConnection {
+  __typename?: 'AdvertisementTemplatesConnection';
+  /**
+   * The page of advertisement templates and their corresponding cursors.
+   * 
+   * This list may be empty.
+   */
+  edges: Array<AdvertisementTemplateEdge>;
+  /** The pagination metadata for this page of advertisement templates. */
+  pageInfo: PageInfo;
+}
+
+export interface AdvertisementTemplateEdge {
+  __typename?: 'AdvertisementTemplateEdge';
+  /**
+   * The opaque cursor to the advertisement template.
+   * 
+   * This can be used as a subsequent pagination argument.
+   */
+  cursor: Scalars['String'];
+  /** The actual advertisement template. */
+  node: AdvertisementTemplate;
+}

--- a/types/seekFragmentTypes.ts
+++ b/types/seekFragmentTypes.ts
@@ -1,0 +1,53 @@
+
+      export interface IntrospectionResultData {
+        __schema: {
+          types: {
+            kind: string;
+            name: string;
+            possibleTypes: {
+              name: string;
+            }[];
+          }[];
+        };
+      }
+      const result: IntrospectionResultData = {
+  "__schema": {
+    "types": [
+      {
+        "kind": "INTERFACE",
+        "name": "ApplicationQuestionnaireComponent",
+        "possibleTypes": [
+          {
+            "name": "ApplicationQuestion"
+          },
+          {
+            "name": "ApplicationPrivacyConsent"
+          }
+        ]
+      },
+      {
+        "kind": "INTERFACE",
+        "name": "ApplicationQuestionnaireComponentResponse",
+        "possibleTypes": [
+          {
+            "name": "ApplicationQuestionResponse"
+          },
+          {
+            "name": "ApplicationPrivacyConsentResponse"
+          }
+        ]
+      },
+      {
+        "kind": "INTERFACE",
+        "name": "Event",
+        "possibleTypes": [
+          {
+            "name": "CandidateApplicationCreatedEvent"
+          }
+        ]
+      }
+    ]
+  }
+};
+      export default result;
+    

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,7 +72,7 @@
     invariant "^2.2.4"
     semver "^5.5.0"
 
-"@babel/core@^7.1.0", "@babel/core@^7.4.5", "@babel/core@^7.7.5", "@babel/core@^7.8.3", "@babel/core@^7.9.0":
+"@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.4.5", "@babel/core@^7.7.5", "@babel/core@^7.8.3", "@babel/core@^7.9.0":
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.10.2.tgz#bd6786046668a925ac2bd2fd95b579b92a23b36a"
   integrity sha512-KQmV9yguEjQsXqyOUGKjS4+3K8/DlOCE2pZcq4augdQmtTy5iv5EHtmMSJ7V4c1BIPjuwtZYqYLCq9Ga+hGBRQ==
@@ -94,7 +94,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.10.1", "@babel/generator@^7.10.2":
+"@babel/generator@^7.10.1", "@babel/generator@^7.10.2", "@babel/generator@^7.5.0":
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.10.2.tgz#0fa5b5b2389db8bfdfcc3492b551ee20f5dd69a9"
   integrity sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==
@@ -323,7 +323,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.10.1", "@babel/parser@^7.10.2", "@babel/parser@^7.7.0":
+"@babel/parser@7.10.2", "@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.10.1", "@babel/parser@^7.10.2", "@babel/parser@^7.7.0":
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.2.tgz#871807f10442b92ff97e4783b9b54f6a0ca812d0"
   integrity sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==
@@ -337,7 +337,7 @@
     "@babel/helper-remap-async-to-generator" "^7.10.1"
     "@babel/plugin-syntax-async-generators" "^7.8.0"
 
-"@babel/plugin-proposal-class-properties@^7.10.1", "@babel/plugin-proposal-class-properties@^7.7.0", "@babel/plugin-proposal-class-properties@^7.8.3":
+"@babel/plugin-proposal-class-properties@^7.0.0", "@babel/plugin-proposal-class-properties@^7.10.1", "@babel/plugin-proposal-class-properties@^7.7.0", "@babel/plugin-proposal-class-properties@^7.8.3":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.1.tgz#046bc7f6550bb08d9bd1d4f060f5f5a4f1087e01"
   integrity sha512-sqdGWgoXlnOdgMXU+9MbhzwFRgxVLeiGBqTrnuS7LC2IBU31wSsESbTUreT2O418obpfPdGUR2GbEufZF1bpqw==
@@ -377,7 +377,7 @@
     "@babel/helper-plugin-utils" "^7.10.1"
     "@babel/plugin-syntax-numeric-separator" "^7.10.1"
 
-"@babel/plugin-proposal-object-rest-spread@^7.10.1", "@babel/plugin-proposal-object-rest-spread@^7.6.2", "@babel/plugin-proposal-object-rest-spread@^7.9.0":
+"@babel/plugin-proposal-object-rest-spread@^7.0.0", "@babel/plugin-proposal-object-rest-spread@^7.10.1", "@babel/plugin-proposal-object-rest-spread@^7.6.2", "@babel/plugin-proposal-object-rest-spread@^7.9.0":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.1.tgz#cba44908ac9f142650b4a65b8aa06bf3478d5fb6"
   integrity sha512-Z+Qri55KiQkHh7Fc4BW6o+QBuTagbOp9txE+4U1i79u9oWlf2npkiDx+Rf3iK3lbcHBuNy9UOkwuR5wOMH3LIQ==
@@ -432,7 +432,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-class-properties@^7.10.1", "@babel/plugin-syntax-class-properties@^7.8.3":
+"@babel/plugin-syntax-class-properties@^7.0.0", "@babel/plugin-syntax-class-properties@^7.10.1", "@babel/plugin-syntax-class-properties@^7.8.3":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.1.tgz#d5bc0645913df5b17ad7eda0fa2308330bde34c5"
   integrity sha512-Gf2Yx/iRs1JREDtVZ56OrjjgFHCaldpTnuy9BHla10qyVT3YkIIGEtoDWhyop0ksu1GvNjHIoYRBqm3zoR1jyQ==
@@ -446,7 +446,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-flow@^7.10.1":
+"@babel/plugin-syntax-flow@^7.0.0", "@babel/plugin-syntax-flow@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.10.1.tgz#cd4bbca62fb402babacb174f64f8734310d742f0"
   integrity sha512-b3pWVncLBYoPP60UOTc7NMlbtsHQ6ITim78KQejNHK6WJ2mzV5kCcg4mIWpasAfJEgwVTibwo2e+FU7UEIKQUg==
@@ -460,7 +460,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@^7.10.1":
+"@babel/plugin-syntax-jsx@^7.0.0", "@babel/plugin-syntax-jsx@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.10.1.tgz#0ae371134a42b91d5418feb3c8c8d43e1565d2da"
   integrity sha512-+OxyOArpVFXQeXKLO9o+r2I4dIoVoy6+Uu0vKELrlweDM3QJADZj+Z+5ERansZqIZBcLj42vHnDI8Rz9BnRIuQ==
@@ -488,7 +488,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.1"
 
-"@babel/plugin-syntax-object-rest-spread@^7.8.0", "@babel/plugin-syntax-object-rest-spread@^7.8.3":
+"@babel/plugin-syntax-object-rest-spread@^7.0.0", "@babel/plugin-syntax-object-rest-spread@^7.8.0", "@babel/plugin-syntax-object-rest-spread@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz#60e225edcbd98a640332a2e72dd3e66f1af55871"
   integrity sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
@@ -523,7 +523,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.1"
 
-"@babel/plugin-transform-arrow-functions@^7.10.1":
+"@babel/plugin-transform-arrow-functions@^7.0.0", "@babel/plugin-transform-arrow-functions@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.1.tgz#cb5ee3a36f0863c06ead0b409b4cc43a889b295b"
   integrity sha512-6AZHgFJKP3DJX0eCNJj01RpytUa3SOGawIxweHkNX2L6PYikOZmoh5B0d7hIHaIgveMjX990IAa/xK7jRTN8OA==
@@ -539,14 +539,14 @@
     "@babel/helper-plugin-utils" "^7.10.1"
     "@babel/helper-remap-async-to-generator" "^7.10.1"
 
-"@babel/plugin-transform-block-scoped-functions@^7.10.1":
+"@babel/plugin-transform-block-scoped-functions@^7.0.0", "@babel/plugin-transform-block-scoped-functions@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.1.tgz#146856e756d54b20fff14b819456b3e01820b85d"
   integrity sha512-B7K15Xp8lv0sOJrdVAoukKlxP9N59HS48V1J3U/JGj+Ad+MHq+am6xJVs85AgXrQn4LV8vaYFOB+pr/yIuzW8Q==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.1"
 
-"@babel/plugin-transform-block-scoping@^7.10.1":
+"@babel/plugin-transform-block-scoping@^7.0.0", "@babel/plugin-transform-block-scoping@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.1.tgz#47092d89ca345811451cd0dc5d91605982705d5e"
   integrity sha512-8bpWG6TtF5akdhIm/uWTyjHqENpy13Fx8chg7pFH875aNLwX8JxIxqm08gmAT+Whe6AOmaTeLPe7dpLbXt+xUw==
@@ -554,7 +554,7 @@
     "@babel/helper-plugin-utils" "^7.10.1"
     lodash "^4.17.13"
 
-"@babel/plugin-transform-classes@^7.10.1":
+"@babel/plugin-transform-classes@^7.0.0", "@babel/plugin-transform-classes@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.1.tgz#6e11dd6c4dfae70f540480a4702477ed766d733f"
   integrity sha512-P9V0YIh+ln/B3RStPoXpEQ/CoAxQIhRSUn7aXqQ+FZJ2u8+oCtjIXR3+X0vsSD8zv+mb56K7wZW1XiDTDGiDRQ==
@@ -568,14 +568,14 @@
     "@babel/helper-split-export-declaration" "^7.10.1"
     globals "^11.1.0"
 
-"@babel/plugin-transform-computed-properties@^7.10.1":
+"@babel/plugin-transform-computed-properties@^7.0.0", "@babel/plugin-transform-computed-properties@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.1.tgz#59aa399064429d64dce5cf76ef9b90b7245ebd07"
   integrity sha512-mqSrGjp3IefMsXIenBfGcPXxJxweQe2hEIwMQvjtiDQ9b1IBvDUjkAtV/HMXX47/vXf14qDNedXsIiNd1FmkaQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.1"
 
-"@babel/plugin-transform-destructuring@^7.10.1":
+"@babel/plugin-transform-destructuring@^7.0.0", "@babel/plugin-transform-destructuring@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.1.tgz#abd58e51337815ca3a22a336b85f62b998e71907"
   integrity sha512-V/nUc4yGWG71OhaTH705pU8ZSdM6c1KmmLP8ys59oOYbT7RpMYAR3MsVOt6OHL0WzG7BlTU076va9fjJyYzJMA==
@@ -605,7 +605,7 @@
     "@babel/helper-builder-binary-assignment-operator-visitor" "^7.10.1"
     "@babel/helper-plugin-utils" "^7.10.1"
 
-"@babel/plugin-transform-flow-strip-types@^7.10.1":
+"@babel/plugin-transform-flow-strip-types@^7.0.0", "@babel/plugin-transform-flow-strip-types@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.10.1.tgz#59eafbff9ae85ec8932d4c16c068654be814ec5e"
   integrity sha512-i4o0YwiJBIsIx7/liVCZ3Q2WkWr1/Yu39PksBOnh/khW2SwIFsGa5Ze+MSon5KbDfrEHP9NeyefAgvUSXzaEkw==
@@ -613,14 +613,14 @@
     "@babel/helper-plugin-utils" "^7.10.1"
     "@babel/plugin-syntax-flow" "^7.10.1"
 
-"@babel/plugin-transform-for-of@^7.10.1":
+"@babel/plugin-transform-for-of@^7.0.0", "@babel/plugin-transform-for-of@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.1.tgz#ff01119784eb0ee32258e8646157ba2501fcfda5"
   integrity sha512-US8KCuxfQcn0LwSCMWMma8M2R5mAjJGsmoCBVwlMygvmDUMkTCykc84IqN1M7t+agSfOmLYTInLCHJM+RUoz+w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.1"
 
-"@babel/plugin-transform-function-name@^7.10.1":
+"@babel/plugin-transform-function-name@^7.0.0", "@babel/plugin-transform-function-name@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.1.tgz#4ed46fd6e1d8fde2a2ec7b03c66d853d2c92427d"
   integrity sha512-//bsKsKFBJfGd65qSNNh1exBy5Y9gD9ZN+DvrJ8f7HXr4avE5POW6zB7Rj6VnqHV33+0vXWUwJT0wSHubiAQkw==
@@ -628,14 +628,14 @@
     "@babel/helper-function-name" "^7.10.1"
     "@babel/helper-plugin-utils" "^7.10.1"
 
-"@babel/plugin-transform-literals@^7.10.1":
+"@babel/plugin-transform-literals@^7.0.0", "@babel/plugin-transform-literals@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.1.tgz#5794f8da82846b22e4e6631ea1658bce708eb46a"
   integrity sha512-qi0+5qgevz1NHLZroObRm5A+8JJtibb7vdcPQF1KQE12+Y/xxl8coJ+TpPW9iRq+Mhw/NKLjm+5SHtAHCC7lAw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.1"
 
-"@babel/plugin-transform-member-expression-literals@^7.10.1":
+"@babel/plugin-transform-member-expression-literals@^7.0.0", "@babel/plugin-transform-member-expression-literals@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.10.1.tgz#90347cba31bca6f394b3f7bd95d2bbfd9fce2f39"
   integrity sha512-UmaWhDokOFT2GcgU6MkHC11i0NQcL63iqeufXWfRy6pUOGYeCGEKhvfFO6Vz70UfYJYHwveg62GS83Rvpxn+NA==
@@ -651,7 +651,7 @@
     "@babel/helper-plugin-utils" "^7.10.1"
     babel-plugin-dynamic-import-node "^2.3.3"
 
-"@babel/plugin-transform-modules-commonjs@^7.10.1":
+"@babel/plugin-transform-modules-commonjs@^7.0.0", "@babel/plugin-transform-modules-commonjs@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.1.tgz#d5ff4b4413ed97ffded99961056e1fb980fb9301"
   integrity sha512-AQG4fc3KOah0vdITwt7Gi6hD9BtQP/8bhem7OjbaMoRNCH5Djx42O2vYMfau7QnAzQCa+RJnhJBmFFMGpQEzrg==
@@ -693,7 +693,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.1"
 
-"@babel/plugin-transform-object-super@^7.10.1":
+"@babel/plugin-transform-object-super@^7.0.0", "@babel/plugin-transform-object-super@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.1.tgz#2e3016b0adbf262983bf0d5121d676a5ed9c4fde"
   integrity sha512-WnnStUDN5GL+wGQrJylrnnVlFhFmeArINIR9gjhSeYyvroGhBrSAXYg/RHsnfzmsa+onJrTJrEClPzgNmmQ4Gw==
@@ -701,7 +701,7 @@
     "@babel/helper-plugin-utils" "^7.10.1"
     "@babel/helper-replace-supers" "^7.10.1"
 
-"@babel/plugin-transform-parameters@^7.10.1":
+"@babel/plugin-transform-parameters@^7.0.0", "@babel/plugin-transform-parameters@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.1.tgz#b25938a3c5fae0354144a720b07b32766f683ddd"
   integrity sha512-tJ1T0n6g4dXMsL45YsSzzSDZCxiHXAQp/qHrucOq5gEHncTA3xDxnd5+sZcoQp+N1ZbieAaB8r/VUCG0gqseOg==
@@ -709,7 +709,7 @@
     "@babel/helper-get-function-arity" "^7.10.1"
     "@babel/helper-plugin-utils" "^7.10.1"
 
-"@babel/plugin-transform-property-literals@^7.10.1":
+"@babel/plugin-transform-property-literals@^7.0.0", "@babel/plugin-transform-property-literals@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.10.1.tgz#cffc7315219230ed81dc53e4625bf86815b6050d"
   integrity sha512-Kr6+mgag8auNrgEpbfIWzdXYOvqDHZOF0+Bx2xh4H2EDNwcbRb9lY6nkZg8oSjsX+DH9Ebxm9hOqtKW+gRDeNA==
@@ -723,7 +723,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.1"
 
-"@babel/plugin-transform-react-display-name@^7.10.1":
+"@babel/plugin-transform-react-display-name@^7.0.0", "@babel/plugin-transform-react-display-name@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.10.1.tgz#e6a33f6d48dfb213dda5e007d0c7ff82b6a3d8ef"
   integrity sha512-rBjKcVwjk26H3VX8pavMxGf33LNlbocMHdSeldIEswtQ/hrjyTG8fKKILW1cSkODyRovckN/uZlGb2+sAV9JUQ==
@@ -763,7 +763,7 @@
     "@babel/helper-plugin-utils" "^7.10.1"
     "@babel/plugin-syntax-jsx" "^7.10.1"
 
-"@babel/plugin-transform-react-jsx@^7.10.1":
+"@babel/plugin-transform-react-jsx@^7.0.0", "@babel/plugin-transform-react-jsx@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.10.1.tgz#91f544248ba131486decb5d9806da6a6e19a2896"
   integrity sha512-MBVworWiSRBap3Vs39eHt+6pJuLUAaK4oxGc8g+wY+vuSJvLiEQjW1LSTqKb8OUPtDvHCkdPhk7d6sjC19xyFw==
@@ -805,14 +805,14 @@
     resolve "^1.8.1"
     semver "^5.5.1"
 
-"@babel/plugin-transform-shorthand-properties@^7.10.1":
+"@babel/plugin-transform-shorthand-properties@^7.0.0", "@babel/plugin-transform-shorthand-properties@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.1.tgz#e8b54f238a1ccbae482c4dce946180ae7b3143f3"
   integrity sha512-AR0E/lZMfLstScFwztApGeyTHJ5u3JUKMjneqRItWeEqDdHWZwAOKycvQNCasCK/3r5YXsuNG25funcJDu7Y2g==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.1"
 
-"@babel/plugin-transform-spread@^7.10.1":
+"@babel/plugin-transform-spread@^7.0.0", "@babel/plugin-transform-spread@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.10.1.tgz#0c6d618a0c4461a274418460a28c9ccf5239a7c8"
   integrity sha512-8wTPym6edIrClW8FI2IoaePB91ETOtg36dOkj3bYcNe7aDMN2FXEoUa+WrmPc4xa1u2PQK46fUX2aCb+zo9rfw==
@@ -827,7 +827,7 @@
     "@babel/helper-plugin-utils" "^7.10.1"
     "@babel/helper-regex" "^7.10.1"
 
-"@babel/plugin-transform-template-literals@^7.10.1":
+"@babel/plugin-transform-template-literals@^7.0.0", "@babel/plugin-transform-template-literals@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.1.tgz#914c7b7f4752c570ea00553b4284dad8070e8628"
   integrity sha512-t7B/3MQf5M1T9hPCRG28DNGZUuxAuDqLYS03rJrIk2prj/UV7Z6FOneijhQhnv/Xa039vidXeVbvjK2SK5f7Gg==
@@ -1000,7 +1000,7 @@
     "@babel/parser" "^7.10.1"
     "@babel/types" "^7.10.1"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.10.1", "@babel/traverse@^7.7.0":
+"@babel/traverse@7.10.1", "@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.10.1", "@babel/traverse@^7.7.0":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.10.1.tgz#bbcef3031e4152a6c0b50147f4958df54ca0dd27"
   integrity sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==
@@ -1015,7 +1015,7 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/types@^7.0.0", "@babel/types@^7.10.1", "@babel/types@^7.10.2", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
+"@babel/types@7.10.2", "@babel/types@^7.0.0", "@babel/types@^7.10.1", "@babel/types@^7.10.2", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.10.2.tgz#30283be31cad0dbf6fb00bd40641ca0ea675172d"
   integrity sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==
@@ -1328,6 +1328,198 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
+"@graphql-codegen/cli@^1.15.1":
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/cli/-/cli-1.15.1.tgz#2c858af9b425dde5b3fa23ab80952cbf1f78470d"
+  integrity sha512-UQdeNFpdvYdirtm3rnClGItS0xyJImaSNpRorEXZPfuixeDr6q24EmuxFg7W+oCzSOSHHx3Vu75H4r/EFqH/xA==
+  dependencies:
+    "@graphql-codegen/core" "1.15.1"
+    "@graphql-codegen/plugin-helpers" "1.15.1"
+    "@graphql-tools/apollo-engine-loader" "^6.0.0"
+    "@graphql-tools/code-file-loader" "^6.0.0"
+    "@graphql-tools/git-loader" "^6.0.0"
+    "@graphql-tools/github-loader" "^6.0.0"
+    "@graphql-tools/graphql-file-loader" "^6.0.0"
+    "@graphql-tools/json-file-loader" "^6.0.0"
+    "@graphql-tools/load" "^6.0.0"
+    "@graphql-tools/prisma-loader" "^6.0.0"
+    "@graphql-tools/url-loader" "^6.0.0"
+    "@graphql-tools/utils" "^6.0.0"
+    ansi-escapes "4.3.1"
+    camel-case "4.1.1"
+    chalk "4.0.0"
+    chokidar "3.4.0"
+    common-tags "1.8.0"
+    constant-case "3.0.3"
+    cosmiconfig "6.0.0"
+    debounce "1.2.0"
+    dependency-graph "0.9.0"
+    detect-indent "6.0.0"
+    glob "7.1.6"
+    graphql-config "^3.0.2"
+    indent-string "4.0.0"
+    inquirer "7.1.0"
+    is-glob "4.0.1"
+    json-to-pretty-yaml "1.2.2"
+    listr "0.14.3"
+    listr-update-renderer "0.5.0"
+    log-symbols "4.0.0"
+    lower-case "2.0.1"
+    minimatch "3.0.4"
+    mkdirp "1.0.4"
+    pascal-case "3.1.1"
+    request "2.88.2"
+    string-env-interpolation "1.0.1"
+    ts-log "2.1.4"
+    tslib "^2.0.0"
+    upper-case "2.0.1"
+    valid-url "1.0.9"
+    wrap-ansi "7.0.0"
+    yargs "15.3.1"
+
+"@graphql-codegen/core@1.15.1":
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/core/-/core-1.15.1.tgz#a14d3c8a0100e0aa90df98673f67ae232ec1e0e3"
+  integrity sha512-LxtAFtKECkZPZeapIbUW8SSAxO9yRyIsYpg1+1gnv4GZw/0j6johXJ5Ms64Q6dZt69oMMYUIWmwNcGa/ccRILA==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "1.15.1"
+    "@graphql-tools/merge" "^6.0.0"
+    "@graphql-tools/utils" "^6.0.0"
+    tslib "~2.0.0"
+
+"@graphql-codegen/fragment-matcher@^1.15.1":
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/fragment-matcher/-/fragment-matcher-1.15.1.tgz#3391b86b7b688f803d846abb6ef93d83bb359154"
+  integrity sha512-30oLLPRYLuAo+OvJLPBsBEYEswAaXddOGDYL4QxGQsYnml0IhQMj//24rnLEUmYEV6zy2BAXCPK5whmV/DOnNw==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "1.15.1"
+    tslib "~2.0.0"
+
+"@graphql-codegen/plugin-helpers@1.15.1":
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/plugin-helpers/-/plugin-helpers-1.15.1.tgz#7fce2f93cf42199ca977018bcb8f67e946d5503a"
+  integrity sha512-DnLD+s4ng+rqbqrcHtV0/jtn/bYSUTqL3tpqPDeIhsqmdDSAtOtelVCeTtPHAJGOO7RI6BQB6rXm/ZgaCObIAg==
+  dependencies:
+    "@graphql-tools/utils" "^6.0.0"
+    camel-case "4.1.1"
+    common-tags "1.8.0"
+    constant-case "3.0.3"
+    import-from "3.0.0"
+    lower-case "2.0.1"
+    param-case "3.0.3"
+    pascal-case "3.1.1"
+    tslib "~2.0.0"
+    upper-case "2.0.1"
+
+"@graphql-codegen/typescript@^1.15.1":
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-1.15.1.tgz#dcb9357cd56289d7e98edc76250d8d6c822b34f4"
+  integrity sha512-DfXXHO37Ec/c4uEuFjAYvmDG5tqVgdt20uZ3fbVOCiKyy/mGcc27GkdyDX5UsjbdzQKOAOqQbrRFK4nl4/NWZg==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "1.15.1"
+    "@graphql-codegen/visitor-plugin-common" "1.15.1"
+    auto-bind "~4.0.0"
+    tslib "~2.0.0"
+
+"@graphql-codegen/visitor-plugin-common@1.15.1":
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-1.15.1.tgz#ff01184a0efb02a419e3fb5912f38e94edcbbbe1"
+  integrity sha512-51HybEPeqptIbghtVhJ39W0PjbFtg8hntgIGpzer3882mIL9sY3ButLkJR6Nabu4GyA3pO07uaZIPJ4C85xoYw==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "1.15.1"
+    "@graphql-tools/relay-operation-optimizer" "6.0.6"
+    array.prototype.flatmap "1.2.3"
+    auto-bind "~4.0.0"
+    dependency-graph "0.9.0"
+    graphql-tag "2.10.3"
+    parse-filepath "1.0.2"
+    pascal-case "3.1.1"
+    tslib "~2.0.0"
+
+"@graphql-toolkit/common@0.10.7", "@graphql-toolkit/common@~0.10.6":
+  version "0.10.7"
+  resolved "https://registry.yarnpkg.com/@graphql-toolkit/common/-/common-0.10.7.tgz#e5d4ddeae080c4f7357bc7d6a8d02e75578e9bd1"
+  integrity sha512-epcJvmIAo+vSEY76F0Dj1Ef6oeewT5pdMe1obHj7LHXN9V22O86aQzwdEEm1iG91qROqSw/apcDnSCMjuVeQVA==
+  dependencies:
+    aggregate-error "3.0.1"
+    camel-case "4.1.1"
+    graphql-tools "5.0.0"
+    lodash "4.17.15"
+
+"@graphql-toolkit/core@~0.10.6":
+  version "0.10.7"
+  resolved "https://registry.yarnpkg.com/@graphql-toolkit/core/-/core-0.10.7.tgz#e4d86d9e439fbb05b634054b0865c16d488fad97"
+  integrity sha512-LXcFLG7XcRJrPz/xD+0cExzLx/ptVynDM20650/FbmHbKOU50d9mSbcsrzAOq/3f4q3HrRDssvn0f6pPm0EHMg==
+  dependencies:
+    "@graphql-toolkit/common" "0.10.7"
+    "@graphql-toolkit/schema-merging" "0.10.7"
+    aggregate-error "3.0.1"
+    globby "11.0.0"
+    import-from "^3.0.0"
+    is-glob "4.0.1"
+    lodash "4.17.15"
+    p-limit "2.3.0"
+    resolve-from "5.0.0"
+    tslib "1.11.2"
+    unixify "1.0.0"
+    valid-url "1.0.9"
+
+"@graphql-toolkit/graphql-file-loader@~0.10.6":
+  version "0.10.7"
+  resolved "https://registry.yarnpkg.com/@graphql-toolkit/graphql-file-loader/-/graphql-file-loader-0.10.7.tgz#496e49712def12449b339739d3583ed1bda7a24f"
+  integrity sha512-6tUIuw/YBlm0VyVgXgMrOXsEQ+WpXVgr2NQwHNzmZo82kPGqImveq7A2D3gBWLyVTcinDScRcKJMxM4kCF5T0A==
+  dependencies:
+    "@graphql-toolkit/common" "0.10.7"
+    tslib "1.11.2"
+
+"@graphql-toolkit/json-file-loader@~0.10.6":
+  version "0.10.7"
+  resolved "https://registry.yarnpkg.com/@graphql-toolkit/json-file-loader/-/json-file-loader-0.10.7.tgz#6ac38258bc3da8540b38232b71bb5820bf02cff6"
+  integrity sha512-nVISrODqvn5LiQ4nKL5pz1Let/W1tuj2viEwrNyTS+9mcjaCE2nhV5MOK/7ZY0cR+XeA4N2u65EH1lQd63U3Cw==
+  dependencies:
+    "@graphql-toolkit/common" "0.10.7"
+    tslib "1.11.2"
+
+"@graphql-toolkit/schema-merging@0.10.7", "@graphql-toolkit/schema-merging@~0.10.6":
+  version "0.10.7"
+  resolved "https://registry.yarnpkg.com/@graphql-toolkit/schema-merging/-/schema-merging-0.10.7.tgz#7b33becd48629bc656d602405c0b5c17d33ebd85"
+  integrity sha512-VngxJbVdRfXYhdMLhL90pqN+hD/2XTZwhHPGvpWqmGQhT6roc98yN3xyDyrWFYYsuiY4gTexdmrHQ3d7mzitwA==
+  dependencies:
+    "@graphql-toolkit/common" "0.10.7"
+    deepmerge "4.2.2"
+    graphql-tools "5.0.0"
+    tslib "1.11.2"
+
+"@graphql-toolkit/url-loader@~0.10.6":
+  version "0.10.7"
+  resolved "https://registry.yarnpkg.com/@graphql-toolkit/url-loader/-/url-loader-0.10.7.tgz#0de998eeeaebcbf918526a26cb5f30f8250211f0"
+  integrity sha512-Ec3T4Zuo63LwG+RfK2ryz8ChPfncBf8fiSJ1xr68FtLDVznDNulvlNKFbfREE5koWejwsnJrjLCv6IX5IbhExg==
+  dependencies:
+    "@graphql-toolkit/common" "0.10.7"
+    cross-fetch "3.0.4"
+    graphql-tools "5.0.0"
+    tslib "1.11.2"
+    valid-url "1.0.9"
+
+"@graphql-tools/apollo-engine-loader@^6.0.0":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-6.0.7.tgz#32b51c6db091b474bebae595549a18234da97baf"
+  integrity sha512-VoOzak1Se3bD1MoQXDkho7w3oWJYgG14ZTItYnypj5G0dlHSJFlN323ZgIy0NqV+8YP2cZBHWIfpqkEVcUfegg==
+  dependencies:
+    "@graphql-tools/utils" "6.0.7"
+    cross-fetch "3.0.4"
+    tslib "~2.0.0"
+
+"@graphql-tools/code-file-loader@^6.0.0":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/code-file-loader/-/code-file-loader-6.0.7.tgz#2e0644a621f2ab16cd902172eaee580debc879d0"
+  integrity sha512-KLmOaWiNxi49z5962Xi3/VNYcSkA4M0L3RJJ3p+uTEifGIHyTUbADjRrygXko7cfULGzyOPP5L2Bn6leYGg4vw==
+  dependencies:
+    "@graphql-tools/graphql-tag-pluck" "6.0.7"
+    "@graphql-tools/utils" "6.0.7"
+    fs-extra "9.0.0"
+    tslib "~2.0.0"
+
 "@graphql-tools/delegate@6.0.5", "@graphql-tools/delegate@^6.0.5":
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/@graphql-tools/delegate/-/delegate-6.0.5.tgz#34a5fbcaa749d54e5e13e892dd55d0b6021a418c"
@@ -1337,6 +1529,115 @@
     "@graphql-tools/utils" "6.0.5"
     tslib "~2.0.0"
 
+"@graphql-tools/delegate@6.0.7":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/delegate/-/delegate-6.0.7.tgz#71c92d349f6e5e0f8ac9a74f370d68243319476e"
+  integrity sha512-s2JLxpDD0AXif4yvSdy9W18UEutliO4YzrAOzNL8B1BS6kiIT7BSZv0Eyu7XTuL2fIg4Ln8z7WZclj2bYiK8mw==
+  dependencies:
+    "@graphql-tools/schema" "6.0.7"
+    "@graphql-tools/utils" "6.0.7"
+    tslib "~2.0.0"
+
+"@graphql-tools/git-loader@^6.0.0":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/git-loader/-/git-loader-6.0.7.tgz#9148efab90c3c74d5483a9bfaf1242269aa30f67"
+  integrity sha512-FdbW07zV4sbruoapSfP/bCw6SB8eOXKtO6UO7JMBnITwmznzf6MEH/4Tsr5p2TIg2mZPMvehrF/L128HKDG+8w==
+  dependencies:
+    "@graphql-tools/graphql-tag-pluck" "6.0.7"
+    "@graphql-tools/utils" "6.0.7"
+    simple-git "2.5.0"
+
+"@graphql-tools/github-loader@^6.0.0":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/github-loader/-/github-loader-6.0.7.tgz#df7667c5f078dd3c1bb60753cd7f73ee1c16d5d7"
+  integrity sha512-DY2vImbM+vzRzQ1RRMVwJQ1TT8ywPUoX2aLHZAMyav49LOtzVEjKKyup4ELvgfTlnEceHRUldVbB+9GMZivOGw==
+  dependencies:
+    "@graphql-tools/graphql-tag-pluck" "6.0.7"
+    "@graphql-tools/utils" "6.0.7"
+    cross-fetch "3.0.4"
+
+"@graphql-tools/graphql-file-loader@^6.0.0":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/graphql-file-loader/-/graphql-file-loader-6.0.7.tgz#581af2ecbeda1311a85d0b0c32c6470073ad0aee"
+  integrity sha512-YmaKPZ7fgXA0T+K1yeQ633UnDiS7TPGWbAs5eBAMm9OYN0aCcJi7VCf/Adz/OSOCbus68+eiq4wRZR96XtMkRw==
+  dependencies:
+    "@graphql-tools/import" "6.0.7"
+    "@graphql-tools/utils" "6.0.7"
+    fs-extra "9.0.0"
+    tslib "~2.0.0"
+
+"@graphql-tools/graphql-tag-pluck@6.0.7":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-6.0.7.tgz#beac82beda73b550130940bdee9fcdfd9503ddde"
+  integrity sha512-R7crmiZWStDyJ86I52v1EVAtnvJGzI0ujifG2BI2a6DMiN9G/jY1mDxl4w887Zf8qccT2NsBzzm1HlKgWlUjfQ==
+  dependencies:
+    "@babel/parser" "7.10.2"
+    "@babel/traverse" "7.10.1"
+    "@babel/types" "7.10.2"
+    "@graphql-tools/utils" "6.0.7"
+  optionalDependencies:
+    vue-template-compiler "^2.6.11"
+
+"@graphql-tools/import@6.0.7":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/import/-/import-6.0.7.tgz#a226e0e44fbc355fc988a66092bb0585faa1e12b"
+  integrity sha512-+um2IVjgUOGhuUAVmwiaUZhyodMXLs7IMmsfcHrZqVg7pf4diuyfNF7C+MlRkivWGk3nD48cFCQ7w8bz8XiSsA==
+  dependencies:
+    fs-extra "9.0.0"
+    resolve-from "5.0.0"
+
+"@graphql-tools/json-file-loader@^6.0.0":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/json-file-loader/-/json-file-loader-6.0.7.tgz#876461cc1802ad2a1e58becda3a52216dad85f64"
+  integrity sha512-dHOLffhP3HXKhq2+U22/WRmhqt4r4Mprn+m/kMmNK4qNj+lm+R+I/kCPV6G0KsMLNnjJ4+lA3VVxTZeiz6FJpA==
+  dependencies:
+    "@graphql-tools/utils" "6.0.7"
+    fs-extra "9.0.0"
+    tslib "~2.0.0"
+
+"@graphql-tools/load@^6.0.0":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/load/-/load-6.0.7.tgz#77c739f5e8b3f644f7e7343307743cd9487e3bed"
+  integrity sha512-SflEux607epsd6NtLUOb7l9SSlXqyvm/eW8FjrZuz7QrPWzbCQp6IkS5mx3fyy2qZZiecU1m2jH6jrZbXVabWA==
+  dependencies:
+    "@graphql-tools/merge" "6.0.7"
+    "@graphql-tools/utils" "6.0.7"
+    globby "11.0.1"
+    import-from "3.0.0"
+    is-glob "4.0.1"
+    p-limit "2.3.0"
+    tslib "~2.0.0"
+    unixify "1.0.0"
+    valid-url "1.0.9"
+
+"@graphql-tools/merge@6.0.7", "@graphql-tools/merge@^6.0.0":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-6.0.7.tgz#51e501f1981a0526486cf72ef74dac055b2eb222"
+  integrity sha512-K7efEQbq8l69srWYxNfWRwQjTZOTGxx2K2WLIunLbrQU6IxBXLobmW8LwMYtMK34HowVEkW+NKy4l8FxJmQX9w==
+  dependencies:
+    "@graphql-tools/schema" "6.0.7"
+    "@graphql-tools/utils" "6.0.7"
+    tslib "~2.0.0"
+
+"@graphql-tools/prisma-loader@^6.0.0":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/prisma-loader/-/prisma-loader-6.0.7.tgz#2605d1102e3a6e276093ddaa8eabeec4af7cbb16"
+  integrity sha512-BjMKKEZWptvFlRCz+D8prlSrosU7/So0s5+0HIExarSCTBNY4IxCrSi4S7ef7yAiNgmakhQUDh4GSzd/Y3Oc+Q==
+  dependencies:
+    "@graphql-tools/url-loader" "6.0.7"
+    "@graphql-tools/utils" "6.0.7"
+    fs-extra "9.0.0"
+    prisma-yml "1.34.10"
+    tslib "~2.0.0"
+
+"@graphql-tools/relay-operation-optimizer@6.0.6":
+  version "6.0.6"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.0.6.tgz#1da925a70539439f151fcc1cb6049538389da71e"
+  integrity sha512-5WkcAuqYzIP5i+uzz9WK3eKl/cC+BOSGfRjdRVTX4t0IMBReHoNLKAAvr8Vo+DE9qvyXGf+I0fWKs4sabVyF1g==
+  dependencies:
+    "@graphql-tools/utils" "6.0.6"
+    relay-compiler "9.1.0"
+
 "@graphql-tools/schema@6.0.5":
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-6.0.5.tgz#6dc6f15861a48f2b8f82407b0701b3ec0476e7ce"
@@ -1345,12 +1646,58 @@
     "@graphql-tools/utils" "6.0.5"
     tslib "~2.0.0"
 
+"@graphql-tools/schema@6.0.7":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-6.0.7.tgz#53549f29b626b2d0657a8ce2e9c4edecc249e815"
+  integrity sha512-10BptaXzNh6idEfmx75Y+hmxbtwvG+yB47bAC4JrOL+vy4PZ9wUvCn2IXfHdwXUx4CnU4qvMS8tosUdgYyJ4ag==
+  dependencies:
+    "@graphql-tools/utils" "6.0.7"
+    tslib "~2.0.0"
+
+"@graphql-tools/url-loader@6.0.7", "@graphql-tools/url-loader@^6.0.0":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/url-loader/-/url-loader-6.0.7.tgz#0357e760797a72d2b471fcf55fbc79bb6442c05d"
+  integrity sha512-qgChWEKTNHbnAJ8Je19gtOZ65xFqjNQstV40eo6loQ+3kRX67yRpzfKEaHTJMoW7F0o6SjPtEJAVXasMkleaoQ==
+  dependencies:
+    "@graphql-tools/utils" "6.0.7"
+    "@graphql-tools/wrap" "6.0.7"
+    "@types/websocket" "1.0.0"
+    cross-fetch "3.0.4"
+    subscriptions-transport-ws "0.9.16"
+    tslib "~2.0.0"
+    valid-url "1.0.9"
+    websocket "1.0.31"
+
 "@graphql-tools/utils@6.0.5":
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-6.0.5.tgz#f46462ded39388cc28e1a1477e3e5c82185f9910"
   integrity sha512-RRBx+ZKrw82dFXaXqh5lLNtjF9uD28G9OXESTj404+JSuz+eLbP0LIA/S6bcdUFfWqppgoswkK1sngvNpelKrg==
   dependencies:
     camel-case "4.1.1"
+
+"@graphql-tools/utils@6.0.6":
+  version "6.0.6"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-6.0.6.tgz#49ef23dc96ee92771115c5b35eebaea0b0e3b71a"
+  integrity sha512-GHRnK7uSBERIoDd4D+RRQucF2eHESDpX4gcPvRuFiJblL+tEsno+I91FzyiTix3vFxnz3bAzWt7p+EN25PE4Xw==
+  dependencies:
+    camel-case "4.1.1"
+
+"@graphql-tools/utils@6.0.7", "@graphql-tools/utils@^6.0.0":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-6.0.7.tgz#0dc8837988b04961162bb76741bfa1072a03418c"
+  integrity sha512-ij/ohAg/PBWx8JHKNQO7PMuABDUGICFbpaJHCe1OB5q4lGmpwlJXI1jJ6JjAKN8+FX0fc1TPh7zY/ScJ8/dXgg==
+  dependencies:
+    camel-case "4.1.1"
+
+"@graphql-tools/wrap@6.0.7":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/wrap/-/wrap-6.0.7.tgz#d35d8c67a447d08eb4623b1393230011428dfa43"
+  integrity sha512-2azhUV4xkIE5BoNuR9Gf3YX7pZq7gNusC+bvRB6P88ROpgULZF1deoraXYaFm9BkpJCdH950b4UwsYSD9luy3g==
+  dependencies:
+    "@graphql-tools/delegate" "6.0.7"
+    "@graphql-tools/schema" "6.0.7"
+    "@graphql-tools/utils" "6.0.7"
+    tslib "~2.0.0"
 
 "@graphql-tools/wrap@^6.0.5":
   version "6.0.5"
@@ -1818,6 +2165,11 @@
     koa-compose "^4.1.0"
     methods "^1.1.2"
     path-to-regexp "^6.1.0"
+
+"@kwsites/exec-p@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@kwsites/exec-p/-/exec-p-0.4.0.tgz#ab3765d482849ba6e825721077c248cf9f3323b7"
+  integrity sha512-44DWNv5gDR9EwrCTVQ4ZC99yPqVS0VCWrYIBl45qNR8XQy+4lbl0IQG8kBDf6NHwj4Ib4c2z1Fq1IUJOCbkZcw==
 
 "@loadable/babel-plugin@^5.10.0":
   version "5.12.0"
@@ -2999,6 +3351,13 @@
     "@types/webpack-sources" "*"
     source-map "^0.6.0"
 
+"@types/websocket@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/websocket/-/websocket-1.0.0.tgz#828c794b0a50949ad061aa311af1009934197e4b"
+  integrity sha512-MLr8hDM8y7vvdAdnoDEP5LotRoYJj7wgT6mWzCUQH/gHqzS4qcnOT/K4dhC0WimWIUiA3Arj9QAJGGKNRiRZKA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/ws@^7.0.0":
   version "7.2.4"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.2.4.tgz#b3859f7b9c243b220efac9716ec42c716a72969d"
@@ -3348,7 +3707,14 @@ address@1.1.2, address@^1.0.1:
   resolved "https://registry.yarnpkg.com/address/-/address-1.1.2.tgz#bf1116c9c758c51b7a933d296b72c221ed9428b6"
   integrity sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==
 
-aggregate-error@^3.0.0:
+agent-base@4, agent-base@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
+  integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
+  dependencies:
+    es6-promisify "^5.0.0"
+
+aggregate-error@3.0.1, aggregate-error@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.0.1.tgz#db2fe7246e536f40d9b5442a39e117d7dd6a24e0"
   integrity sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==
@@ -3389,6 +3755,16 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
 
+ajv@5:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
+  integrity sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
+
 ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.5.5:
   version "6.12.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.2.tgz#c629c5eced17baf314437918d2da88c99d5958cd"
@@ -3423,17 +3799,17 @@ ansi-colors@^3.0.0, ansi-colors@^3.2.1:
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
   integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
 
-ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
-  integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
-
-ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
+ansi-escapes@4.3.1, ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.1.tgz#a5c47cc43181f1f38ffd7076837700d395522a61"
   integrity sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==
   dependencies:
     type-fest "^0.11.0"
+
+ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
+  integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
 ansi-html@0.0.7:
   version "0.0.7"
@@ -3569,7 +3945,16 @@ apollo-graphql@^0.4.0:
     apollo-env "^0.6.5"
     lodash.sortby "^4.7.0"
 
-apollo-link@^1.2.14:
+apollo-link-http-common@^0.2.14:
+  version "0.2.16"
+  resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz#756749dafc732792c8ca0923f9a40564b7c59ecc"
+  integrity sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==
+  dependencies:
+    apollo-link "^1.2.14"
+    ts-invariant "^0.4.0"
+    tslib "^1.9.3"
+
+apollo-link@^1.2.12, apollo-link@^1.2.14:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.14.tgz#3feda4b47f9ebba7f4160bef8b977ba725b684d9"
   integrity sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==
@@ -3674,6 +4059,16 @@ apollo-tracing@^0.11.0:
   dependencies:
     apollo-server-env "^2.4.4"
     apollo-server-plugin-base "^0.9.0"
+
+apollo-upload-client@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/apollo-upload-client/-/apollo-upload-client-13.0.0.tgz#146d1ddd85d711fcac8ca97a72d3ca6787f2b71b"
+  integrity sha512-lJ9/bk1BH1lD15WhWRha2J3+LrXrPIX5LP5EwiOUHv8PCORp4EUrcujrA3rI5hZeZygrTX8bshcuMdpqpSrvtA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    apollo-link "^1.2.12"
+    apollo-link-http-common "^0.2.14"
+    extract-files "^8.0.0"
 
 apollo-utilities@^1.0.1, apollo-utilities@^1.3.0:
   version "1.3.4"
@@ -3812,7 +4207,7 @@ array.prototype.flat@^1.2.1:
     define-properties "^1.1.3"
     es-abstract "^1.17.0-next.1"
 
-array.prototype.flatmap@^1.2.1:
+array.prototype.flatmap@1.2.3, array.prototype.flatmap@^1.2.1:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.2.3.tgz#1c13f84a178566042dd63de4414440db9222e443"
   integrity sha512-OOEk+lkePcg+ODXIpvuU9PAryCikCJyo7GlDG1upleEpQRx6mzL9puEBkozQ5iAx20KV0l3DbyQwqciJtqe5Pg==
@@ -3943,6 +4338,11 @@ atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
+
+auto-bind@~4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/auto-bind/-/auto-bind-4.0.0.tgz#e3589fc6c2da8f7ca43ba9f84fa52a744fc997fb"
+  integrity sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==
 
 autoprefixer@^9.6.0, autoprefixer@^9.6.1, autoprefixer@^9.7.2, autoprefixer@^9.7.4:
   version "9.8.0"
@@ -4282,6 +4682,11 @@ babel-plugin-syntax-jsx@^6.18.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
   integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
 
+babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz#aa213c1435e2bffeb6fca842287ef534ad05d5cf"
+  integrity sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==
+
 babel-plugin-transform-inline-consecutive-adds@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.3.tgz#323d47a3ea63a83a7ac3c811ae8e6941faf2b0d1"
@@ -4371,6 +4776,39 @@ babel-preset-current-node-syntax@^0.1.2:
     "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
     "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
     "@babel/plugin-syntax-optional-chaining" "^7.8.3"
+
+babel-preset-fbjs@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-fbjs/-/babel-preset-fbjs-3.3.0.tgz#a6024764ea86c8e06a22d794ca8b69534d263541"
+  integrity sha512-7QTLTCd2gwB2qGoi5epSULMHugSVgpcVt5YAeiFO9ABLrutDQzKfGwzxgZHLpugq8qMdg/DhRZDZ5CLKxBkEbw==
+  dependencies:
+    "@babel/plugin-proposal-class-properties" "^7.0.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
+    "@babel/plugin-syntax-class-properties" "^7.0.0"
+    "@babel/plugin-syntax-flow" "^7.0.0"
+    "@babel/plugin-syntax-jsx" "^7.0.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
+    "@babel/plugin-transform-arrow-functions" "^7.0.0"
+    "@babel/plugin-transform-block-scoped-functions" "^7.0.0"
+    "@babel/plugin-transform-block-scoping" "^7.0.0"
+    "@babel/plugin-transform-classes" "^7.0.0"
+    "@babel/plugin-transform-computed-properties" "^7.0.0"
+    "@babel/plugin-transform-destructuring" "^7.0.0"
+    "@babel/plugin-transform-flow-strip-types" "^7.0.0"
+    "@babel/plugin-transform-for-of" "^7.0.0"
+    "@babel/plugin-transform-function-name" "^7.0.0"
+    "@babel/plugin-transform-literals" "^7.0.0"
+    "@babel/plugin-transform-member-expression-literals" "^7.0.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.0.0"
+    "@babel/plugin-transform-object-super" "^7.0.0"
+    "@babel/plugin-transform-parameters" "^7.0.0"
+    "@babel/plugin-transform-property-literals" "^7.0.0"
+    "@babel/plugin-transform-react-display-name" "^7.0.0"
+    "@babel/plugin-transform-react-jsx" "^7.0.0"
+    "@babel/plugin-transform-shorthand-properties" "^7.0.0"
+    "@babel/plugin-transform-spread" "^7.0.0"
+    "@babel/plugin-transform-template-literals" "^7.0.0"
+    babel-plugin-syntax-trailing-function-commas "^7.0.0-beta.0"
 
 babel-preset-jest@^25.5.0:
   version "25.5.0"
@@ -4548,7 +4986,7 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-bluebird@^3.3.5, bluebird@^3.5.4, bluebird@^3.5.5:
+bluebird@^3.3.5, bluebird@^3.5.1, bluebird@^3.5.4, bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -4827,6 +5265,11 @@ buble@^0.19.8:
     os-homedir "^2.0.0"
     regexpu-core "^4.5.4"
 
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
+
 buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
@@ -5081,7 +5524,15 @@ chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^1.1.3:
+chalk@4.0.0, chalk@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.0.0.tgz#6e98081ed2d17faab615eb52ac66ec1fe6209e72"
+  integrity sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
@@ -5096,14 +5547,6 @@ chalk@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
   integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
-chalk@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.0.0.tgz#6e98081ed2d17faab615eb52ac66ec1fe6209e72"
-  integrity sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -5143,6 +5586,21 @@ check-types@^8.0.3:
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-8.0.3.tgz#3356cca19c889544f2d7a95ed49ce508a0ecf552"
   integrity sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==
 
+chokidar@3.4.0, chokidar@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.0.tgz#b30611423ce376357c765b9b8f904b9fba3c0be8"
+  integrity sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.4.0"
+  optionalDependencies:
+    fsevents "~2.1.2"
+
 chokidar@^2.0.4, chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -5161,21 +5619,6 @@ chokidar@^2.0.4, chokidar@^2.1.8:
     upath "^1.1.1"
   optionalDependencies:
     fsevents "^1.2.7"
-
-chokidar@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.0.tgz#b30611423ce376357c765b9b8f904b9fba3c0be8"
-  integrity sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==
-  dependencies:
-    anymatch "~3.1.1"
-    braces "~3.0.2"
-    glob-parent "~5.1.0"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.4.0"
-  optionalDependencies:
-    fsevents "~2.1.2"
 
 chownr@^1.1.1, chownr@^1.1.2:
   version "1.1.4"
@@ -5239,7 +5682,7 @@ cli-boxes@^2.2.0:
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.0.tgz#538ecae8f9c6ca508e3c3c95b453fe93cb4c168d"
   integrity sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==
 
-cli-cursor@^2.1.0:
+cli-cursor@^2.0.0, cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
   integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
@@ -5270,6 +5713,14 @@ cli-truncate@2.1.0, cli-truncate@^2.1.0:
   dependencies:
     slice-ansi "^3.0.0"
     string-width "^4.2.0"
+
+cli-truncate@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
+  integrity sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=
+  dependencies:
+    slice-ansi "0.0.4"
+    string-width "^1.0.1"
 
 cli-width@^2.0.0:
   version "2.2.1"
@@ -5481,6 +5932,11 @@ commander@^5.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
+common-tags@1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
+  integrity sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -5540,6 +5996,15 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
+
+constant-case@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/constant-case/-/constant-case-3.0.3.tgz#ac910a99caf3926ac5112f352e3af599d8c5fc0a"
+  integrity sha512-FXtsSnnrFYpzDmvwDGQW+l8XK3GV1coLyBN0eBz16ZUzGaZcT2ANVCJmLeuw2GQgxKHQIe9e0w2dzkSfaRlUmA==
+  dependencies:
+    no-case "^3.0.3"
+    tslib "^1.10.0"
+    upper-case "^2.0.1"
 
 constants-browserify@^1.0.0:
   version "1.0.0"
@@ -5640,7 +6105,7 @@ core-js-pure@^3.0.0, core-js-pure@^3.0.1:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
   integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
 
-core-js@^2.4.0:
+core-js@^2.4.0, core-js@^2.4.1:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
@@ -5663,17 +6128,7 @@ corejs-upgrade-webpack-plugin@^2.2.0:
     resolve-from "^5.0.0"
     webpack "^4.38.0"
 
-cosmiconfig@^5.0.0, cosmiconfig@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
-  integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
-  dependencies:
-    import-fresh "^2.0.0"
-    is-directory "^0.3.1"
-    js-yaml "^3.13.1"
-    parse-json "^4.0.0"
-
-cosmiconfig@^6.0.0:
+cosmiconfig@6.0.0, cosmiconfig@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-6.0.0.tgz#da4fee853c52f6b1e6935f41c1a2fc50bd4a9982"
   integrity sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==
@@ -5683,6 +6138,16 @@ cosmiconfig@^6.0.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.7.2"
+
+cosmiconfig@^5.0.0, cosmiconfig@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
+  integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
+  dependencies:
+    import-fresh "^2.0.0"
+    is-directory "^0.3.1"
+    js-yaml "^3.13.1"
+    parse-json "^4.0.0"
 
 create-ecdh@^4.0.0:
   version "4.0.3"
@@ -5722,6 +6187,22 @@ create-react-context@0.3.0, create-react-context@^0.3.0:
   dependencies:
     gud "^1.0.0"
     warning "^4.0.3"
+
+cross-fetch@2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-2.2.2.tgz#a47ff4f7fc712daba8f6a695a11c948440d45723"
+  integrity sha1-pH/09/xxLauo9qaVoRyUhEDUVyM=
+  dependencies:
+    node-fetch "2.1.2"
+    whatwg-fetch "2.0.4"
+
+cross-fetch@3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.4.tgz#7bef7020207e684a7638ef5f2f698e24d9eb283c"
+  integrity sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==
+  dependencies:
+    node-fetch "2.6.0"
+    whatwg-fetch "3.0.0"
 
 cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
@@ -6078,6 +6559,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns@^1.27.2:
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
+  integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
+
 dateformat@~1.0.4-1.2.3:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-1.0.12.tgz#9f124b67594c937ff706932e4a642cca8dbbfee9"
@@ -6086,12 +6572,17 @@ dateformat@~1.0.4-1.2.3:
     get-stdin "^4.0.1"
     meow "^3.3.0"
 
+de-indent@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
+  integrity sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=
+
 death@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/death/-/death-1.1.0.tgz#01aa9c401edd92750514470b8266390c66c67318"
   integrity sha1-AaqcQB7dknUFFEcLgmY5DGbGcxg=
 
-debounce@^1.0.0:
+debounce@1.2.0, debounce@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
   integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
@@ -6103,7 +6594,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@=3.1.0, debug@~3.1.0:
+debug@3.1.0, debug@=3.1.0, debug@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
@@ -6184,7 +6675,7 @@ deep-object-diff@^1.1.0:
   resolved "https://registry.yarnpkg.com/deep-object-diff/-/deep-object-diff-1.1.0.tgz#d6fabf476c2ed1751fc94d5ca693d2ed8c18bc5a"
   integrity sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==
 
-deepmerge@^4.2.2:
+deepmerge@4.2.2, deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
@@ -6285,6 +6776,11 @@ depd@~2.0.0:
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
+dependency-graph@0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-0.9.0.tgz#11aed7e203bc8b00f48356d92db27b265c445318"
+  integrity sha512-9YLIBURXj4DJMFALxXw9K3Y3rwb5Fk0X5/8ipCzaN84+gKxoHK43tVKRNakCQbiEx07E8Uwhuq21BpUagFhZ8w==
+
 deprecated-decorator@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz#00966317b7a12fe92f3cc831f7583af329b86c37"
@@ -6302,6 +6798,11 @@ destroy@^1.0.4, destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
+
+detect-indent@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.0.0.tgz#0abd0f549f69fc6659a254fe96786186b6f528fd"
+  integrity sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -6549,6 +7050,11 @@ dotenv-webpack@^1.7.0:
   dependencies:
     dotenv-defaults "^1.0.2"
 
+dotenv@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
+  integrity sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=
+
 dotenv@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
@@ -6589,6 +7095,13 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -6603,6 +7116,11 @@ electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.413:
   version "1.3.455"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.455.tgz#fd65a3f5db6ffa83eb7c84f16ea9b1b7396f537d"
   integrity sha512-4lwnxp+ArqOX9hiLwLpwhfqvwzUHFuDgLz4NTiU3lhygUzWtocIJ/5Vix+mWVNE2HQ9aI1k2ncGe5H/0OktMvA==
+
+elegant-spinner@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
+  integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
 
 elegant-spinner@^2.0.0:
   version "2.0.0"
@@ -6667,6 +7185,13 @@ encodeurl@^1.0.2, encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
+
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
+  dependencies:
+    iconv-lite "~0.4.13"
 
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.4"
@@ -6814,6 +7339,18 @@ es6-object-assign@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
   integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
+
+es6-promise@^4.0.3:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
+  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
+
+es6-promisify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
+  dependencies:
+    es6-promise "^4.0.3"
 
 es6-shim@^0.35.5:
   version "0.35.5"
@@ -7455,6 +7992,11 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+extract-files@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-8.1.0.tgz#46a0690d0fe77411a2e3804852adeaa65cd59288"
+  integrity sha512-PTGtfthZK79WUMk+avLmwx3NGdU8+iVFXC2NMGxKsn0MnihOG2lvumj+AZo8CTwTrwjXDgZ5tztbRlEdRjBonQ==
+
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -7470,6 +8012,11 @@ fake-tag@^1.0.0:
   resolved "https://registry.yarnpkg.com/fake-tag/-/fake-tag-1.0.1.tgz#1d59da482240a02bd83500ca98976530ed154b0d"
   integrity sha512-qmewZoBpa71mM+y6oxXYW/d1xOYQmeIvnEXAt1oCmdP0sqcogWYLepR87QL1jQVLSVMVYDq2cjY6ec/Wu8/4pg==
 
+fast-deep-equal@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
+  integrity sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=
+
 fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
@@ -7480,7 +8027,7 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
   integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
 
-fast-glob@^2.0.2:
+fast-glob@^2.0.2, fast-glob@^2.2.2:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.7.tgz#6953857c3afa475fff92ee6015d52da70a4cd39d"
   integrity sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==
@@ -7586,10 +8133,37 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+fbjs-css-vars@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
+  integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
+
+fbjs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-1.0.0.tgz#52c215e0883a3c86af2a7a776ed51525ae8e0a5a"
+  integrity sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==
+  dependencies:
+    core-js "^2.4.1"
+    fbjs-css-vars "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
+
 figgy-pudding@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.2.tgz#b4eee8148abb01dcf1d1ac34367d59e12fa61d6e"
   integrity sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==
+
+figures@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
+  integrity sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    object-assign "^4.1.0"
 
 figures@^2.0.0:
   version "2.0.0"
@@ -7923,6 +8497,16 @@ fs-capacitor@^2.0.4:
   resolved "https://registry.yarnpkg.com/fs-capacitor/-/fs-capacitor-2.0.4.tgz#5a22e72d40ae5078b4fe64fe4d08c0d3fc88ad3c"
   integrity sha512-8S4f4WsCryNw2mJJchi46YgB6CR5Ze+4L1h8ewl9tEpL4SJ3ZO+c/bS4BWhB8bK+O3TMqhuZarTitd0S0eh2pA==
 
+fs-extra@9.0.0, fs-extra@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.0.tgz#b6afc31036e247b2466dc99c29ae797d5d4580a3"
+  integrity sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^1.0.0"
+
 fs-extra@^0.30.0:
   version "0.30.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.30.0.tgz#f233ffcc08d4da7d432daa449776989db1df93f0"
@@ -7943,7 +8527,7 @@ fs-extra@^3.0.1:
     jsonfile "^3.0.0"
     universalify "^0.1.0"
 
-fs-extra@^7.0.1:
+fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
@@ -7960,16 +8544,6 @@ fs-extra@^8.0.1, fs-extra@^8.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
-
-fs-extra@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.0.tgz#b6afc31036e247b2466dc99c29ae797d5d4580a3"
-  integrity sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==
-  dependencies:
-    at-least-node "^1.0.0"
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^1.0.0"
 
 fs-minipass@^2.0.0:
   version "2.1.0"
@@ -8180,7 +8754,7 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@7.1.6, glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -8235,6 +8809,30 @@ globalthis@^1.0.0:
   dependencies:
     define-properties "^1.1.3"
 
+globby@11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.0.tgz#56fd0e9f0d4f8fb0c456f1ab0dee96e1380bc154"
+  integrity sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
+
+globby@11.0.1, globby@^11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.1.tgz#9a2bf107a068f3ffeabc49ad702c79ede8cfd357"
+  integrity sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
+
 globby@8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/globby/-/globby-8.0.2.tgz#5697619ccd95c5275dbb2d6faa42087c1a941d8d"
@@ -8247,18 +8845,6 @@ globby@8.0.2:
     ignore "^3.3.5"
     pify "^3.0.0"
     slash "^1.0.0"
-
-globby@^11.0.0:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.1.tgz#9a2bf107a068f3ffeabc49ad702c79ede8cfd357"
-  integrity sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==
-  dependencies:
-    array-union "^2.1.0"
-    dir-glob "^3.0.1"
-    fast-glob "^3.1.1"
-    ignore "^5.1.4"
-    merge2 "^1.3.0"
-    slash "^3.0.0"
 
 globby@^6.1.0:
   version "6.1.0"
@@ -8300,6 +8886,21 @@ grapheme-splitter@^1.0.4:
   resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
+graphql-config@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-3.0.2.tgz#dfec1ff193dc3791457cb09a973887cf1e4aad50"
+  integrity sha512-efoimZ4F2wF2OwZJzPq2KdPjQs1K+UgJSfsHoHBBA0TwveGyQ/0kS3lUphhJg/JXIrZociuRkfjrk8JC4iPPJQ==
+  dependencies:
+    "@graphql-toolkit/common" "~0.10.6"
+    "@graphql-toolkit/core" "~0.10.6"
+    "@graphql-toolkit/graphql-file-loader" "~0.10.6"
+    "@graphql-toolkit/json-file-loader" "~0.10.6"
+    "@graphql-toolkit/schema-merging" "~0.10.6"
+    "@graphql-toolkit/url-loader" "~0.10.6"
+    cosmiconfig "6.0.0"
+    minimatch "3.0.4"
+    tslib "^1.11.1"
+
 graphql-extensions@^0.12.2:
   version "0.12.2"
   resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.12.2.tgz#f22210e812939b7caa2127589f30e6a1c671540f"
@@ -8309,6 +8910,13 @@ graphql-extensions@^0.12.2:
     apollo-server-env "^2.4.4"
     apollo-server-types "^0.5.0"
 
+graphql-request@^1.5.0:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-1.8.2.tgz#398d10ae15c585676741bde3fc01d5ca948f8fbe"
+  integrity sha512-dDX2M+VMsxXFCmUX0Vo0TopIZIX4ggzOtiCsThgtrKR4niiaagsGTDIHj3fsOMFETpa064vzovI+4YV4QnMbcg==
+  dependencies:
+    cross-fetch "2.2.2"
+
 graphql-subscriptions@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/graphql-subscriptions/-/graphql-subscriptions-1.1.0.tgz#5f2fa4233eda44cf7570526adfcf3c16937aef11"
@@ -8316,10 +8924,24 @@ graphql-subscriptions@^1.0.0:
   dependencies:
     iterall "^1.2.1"
 
-graphql-tag@^2.9.2:
+graphql-tag@2.10.3, graphql-tag@^2.9.2:
   version "2.10.3"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.3.tgz#ea1baba5eb8fc6339e4c4cf049dabe522b0edf03"
   integrity sha512-4FOv3ZKfA4WdOKJeHdz6B3F/vxBLSgmBcGeAFPf4n1F64ltJUvOOerNj0rsJxONQGdhUMynQIvd6LzB+1J5oKA==
+
+graphql-tools@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-5.0.0.tgz#67281c834a0e29f458adba8018f424816fa627e9"
+  integrity sha512-5zn3vtn//382b7G3Wzz3d5q/sh+f7tVrnxeuhTMTJ7pWJijNqLxH7VEzv8VwXCq19zAzHYEosFHfXiK7qzvk7w==
+  dependencies:
+    apollo-link "^1.2.14"
+    apollo-upload-client "^13.0.0"
+    deprecated-decorator "^0.1.6"
+    form-data "^3.0.0"
+    iterall "^1.3.0"
+    node-fetch "^2.6.0"
+    tslib "^1.11.1"
+    uuid "^7.0.3"
 
 graphql-tools@^4.0.0:
   version "4.0.8"
@@ -8497,7 +9119,7 @@ he@1.1.1:
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
   integrity sha1-k0EP0hsAlzUVH4howvJx80J+I/0=
 
-he@^1.2.0:
+he@^1.1.0, he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
@@ -8697,6 +9319,14 @@ http-parser-js@>=0.5.1:
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.2.tgz#da2e31d237b393aae72ace43882dd7e270a8ff77"
   integrity sha512-opCO9ASqg5Wy2FNo7A0sxy71yGbbkJJXLdgMK04Tcypw9jr2MgWbyubb0+WdmDmGnFflO7fRbqbaihh/ENDlRQ==
 
+http-proxy-agent@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz#e4821beef5b2142a2026bd73926fe537631c5405"
+  integrity sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==
+  dependencies:
+    agent-base "4"
+    debug "3.1.0"
+
 http-proxy-middleware@0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz#183c7dc4aa1479150306498c210cdaf96080a43a"
@@ -8730,6 +9360,14 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
+https-proxy-agent@^2.2.1:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz#4ee7a737abd92678a293d9b34a1af4d0d08c787b"
+  integrity sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==
+  dependencies:
+    agent-base "^4.3.0"
+    debug "^3.1.0"
+
 human-id@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/human-id/-/human-id-1.0.2.tgz#e654d4b2b0d8b07e45da9f6020d8af17ec0a5df3"
@@ -8745,7 +9383,7 @@ hyphenate-style-name@^1.0.2:
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz#097bb7fa0b8f1a9cf0bd5c734cf95899981a9b48"
   integrity sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ==
 
-iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24:
+iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -8811,6 +9449,11 @@ immer@1.10.0:
   resolved "https://registry.yarnpkg.com/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
   integrity sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==
 
+immutable@~3.7.6:
+  version "3.7.6"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
+  integrity sha1-E7TTyxK++hVIKib+Gy665kAHHks=
+
 import-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"
@@ -8833,6 +9476,13 @@ import-fresh@^3.0.0, import-fresh@^3.1.0:
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
+
+import-from@3.0.0, import-from@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/import-from/-/import-from-3.0.0.tgz#055cfec38cd5a27d8057ca51376d7d3bf0891966"
+  integrity sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==
+  dependencies:
+    resolve-from "^5.0.0"
 
 import-from@^2.1.0:
   version "2.1.0"
@@ -8862,6 +9512,11 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
+indent-string@4.0.0, indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
 indent-string@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
@@ -8873,11 +9528,6 @@ indent-string@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
   integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
-
-indent-string@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
-  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
 indexes-of@^1.0.1:
   version "1.0.1"
@@ -8949,6 +9599,25 @@ inquirer@6.5.0:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
+inquirer@7.1.0, inquirer@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.1.0.tgz#1298a01859883e17c7264b82870ae1034f92dd29"
+  integrity sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^3.0.0"
+    cli-cursor "^3.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.15"
+    mute-stream "0.0.8"
+    run-async "^2.4.0"
+    rxjs "^6.5.3"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+
 inquirer@^3.2.3:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
@@ -8967,25 +9636,6 @@ inquirer@^3.2.3:
     rx-lite-aggregates "^4.0.8"
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
-    through "^2.3.6"
-
-inquirer@^7.0.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.1.0.tgz#1298a01859883e17c7264b82870ae1034f92dd29"
-  integrity sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==
-  dependencies:
-    ansi-escapes "^4.2.1"
-    chalk "^3.0.0"
-    cli-cursor "^3.1.0"
-    cli-width "^2.0.0"
-    external-editor "^3.0.3"
-    figures "^3.0.0"
-    lodash "^4.17.15"
-    mute-stream "0.0.8"
-    run-async "^2.4.0"
-    rxjs "^6.5.3"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
     through "^2.3.6"
 
 internal-ip@^4.3.0:
@@ -9061,6 +9711,14 @@ is-absolute-url@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-3.0.3.tgz#96c6a22b6a23929b11ea0afb1836c36ad4a5d698"
   integrity sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==
+
+is-absolute@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-absolute/-/is-absolute-1.0.0.tgz#395e1ae84b11f26ad1795e73c17378e48a301576"
+  integrity sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==
+  dependencies:
+    is-relative "^1.0.0"
+    is-windows "^1.0.1"
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
@@ -9271,6 +9929,13 @@ is-git-repository@^1.0.0:
     execa "^0.6.1"
     path-is-absolute "^1.0.1"
 
+is-glob@4.0.1, is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
+  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  dependencies:
+    is-extglob "^2.1.1"
+
 is-glob@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
@@ -9284,13 +9949,6 @@ is-glob@^3.1.0:
   integrity sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=
   dependencies:
     is-extglob "^2.1.0"
-
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
-  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
-  dependencies:
-    is-extglob "^2.1.1"
 
 is-hexadecimal@^1.0.0:
   version "1.0.4"
@@ -9336,6 +9994,13 @@ is-obj@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
   integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
 
+is-observable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-1.1.0.tgz#b3e986c8f44de950867cab5403f5a3465005975e"
+  integrity sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==
+  dependencies:
+    symbol-observable "^1.1.0"
+
 is-path-cwd@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"
@@ -9379,7 +10044,7 @@ is-potential-custom-element-name@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz#0c52e54bcca391bb2c494b21e8626d7336c6e397"
   integrity sha1-DFLlS8yjkbssSUsh6GJtczbG45c=
 
-is-promise@^2.0.0, is-promise@^2.1:
+is-promise@^2.0.0, is-promise@^2.1, is-promise@^2.1.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
   integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
@@ -9395,6 +10060,13 @@ is-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
   integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
+
+is-relative@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-relative/-/is-relative-1.0.0.tgz#a1bb6935ce8c5dba1e8b9754b9b2dcc020e2260d"
+  integrity sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==
+  dependencies:
+    is-unc-path "^1.0.0"
 
 is-resolvable@^1.0.0:
   version "1.1.0"
@@ -9418,7 +10090,7 @@ is-ssh@^1.3.0:
   dependencies:
     protocols "^1.1.0"
 
-is-stream@^1.1.0:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -9469,12 +10141,19 @@ is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
+is-unc-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-unc-path/-/is-unc-path-1.0.0.tgz#d731e8898ed090a12c352ad2eaed5095ad322c9d"
+  integrity sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==
+  dependencies:
+    unc-path-regex "^0.1.2"
+
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
-is-windows@^1.0.0, is-windows@^1.0.2:
+is-windows@^1.0.0, is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
@@ -9533,6 +10212,14 @@ isolated-scroll@^0.1.0:
   resolved "https://registry.yarnpkg.com/isolated-scroll/-/isolated-scroll-0.1.0.tgz#463126c5adaabb5b759c721498ece090d8bef7a7"
   integrity sha1-RjEmxa2qu1t1nHIUmOzgkNi+96c=
 
+isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
+
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -9579,7 +10266,7 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-iterall@^1.1.3, iterall@^1.2.1, iterall@^1.2.2:
+iterall@^1.1.3, iterall@^1.2.1, iterall@^1.2.2, iterall@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
@@ -10416,7 +11103,7 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.6.1:
+js-yaml@^3.10.0, js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.6.1:
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
   integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
@@ -10540,6 +11227,11 @@ json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
+json-schema-traverse@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
+  integrity sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -10555,10 +11247,25 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
+json-stable-stringify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
+  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
+  dependencies:
+    jsonify "~0.0.0"
+
 json-stringify-safe@5.0.x, json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
+
+json-to-pretty-yaml@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/json-to-pretty-yaml/-/json-to-pretty-yaml-1.2.2.tgz#f4cd0bd0a5e8fe1df25aaf5ba118b099fd992d5b"
+  integrity sha1-9M0L0KXo/h3yWq9boRiwmf2ZLVs=
+  dependencies:
+    remedial "^1.0.7"
+    remove-trailing-spaces "^1.0.6"
 
 json3@^3.3.2:
   version "3.3.3"
@@ -10614,6 +11321,27 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonify@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
+  integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
+
+jsonwebtoken@^8.1.0:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^5.6.0"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -10646,6 +11374,23 @@ jsx-ast-utils@^2.2.3:
   dependencies:
     array-includes "^3.1.1"
     object.assign "^4.1.0"
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
 
 keygrip@~1.1.0:
   version "1.1.0"
@@ -10939,6 +11684,35 @@ lint-staged@^10.0.0:
     string-argv "0.3.1"
     stringify-object "^3.3.0"
 
+listr-silent-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
+  integrity sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=
+
+listr-update-renderer@0.5.0, listr-update-renderer@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz#4ea8368548a7b8aecb7e06d8c95cb45ae2ede6a2"
+  integrity sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^2.3.0"
+    strip-ansi "^3.0.1"
+
+listr-verbose-renderer@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz#f1132167535ea4c1261102b9f28dac7cba1e03db"
+  integrity sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==
+  dependencies:
+    chalk "^2.4.1"
+    cli-cursor "^2.1.0"
+    date-fns "^1.27.2"
+    figures "^2.0.0"
+
 listr2@^2.0.2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/listr2/-/listr2-2.0.4.tgz#b39100b0a227ec5659dcf76ddc516211fc168d61"
@@ -10958,6 +11732,21 @@ listr2@^2.0.2:
     rxjs "^6.5.5"
     through "^2.3.8"
     uuid "^7.0.2"
+
+listr@0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/listr/-/listr-0.14.3.tgz#2fea909604e434be464c50bddba0d496928fa586"
+  integrity sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==
+  dependencies:
+    "@samverschueren/stream-to-observable" "^0.3.0"
+    is-observable "^1.1.0"
+    is-promise "^2.1.0"
+    is-stream "^1.1.0"
+    listr-silent-renderer "^1.1.1"
+    listr-update-renderer "^0.5.0"
+    listr-verbose-renderer "^0.5.0"
+    p-map "^2.0.0"
+    rxjs "^6.3.3"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -11087,10 +11876,45 @@ lodash.deburr@^4.1.0:
   resolved "https://registry.yarnpkg.com/lodash.deburr/-/lodash.deburr-4.1.0.tgz#ddb1bbb3ef07458c0177ba07de14422cb033ff9b"
   integrity sha1-3bG7s+8HRYwBd7oH3hRCLLAz/5s=
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+
 lodash.memoize@4.x, lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -11117,17 +11941,33 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.0.1, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.3.0:
+lodash@4.17.15, lodash@^4.0.1, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-log-symbols@^4.0.0:
+log-symbols@4.0.0, log-symbols@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.0.0.tgz#69b3cc46d20f448eccdb75ea1fa733d9e821c920"
   integrity sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==
   dependencies:
     chalk "^4.0.0"
+
+log-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+  integrity sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=
+  dependencies:
+    chalk "^1.0.0"
+
+log-update@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-2.3.0.tgz#88328fd7d1ce7938b29283746f0b1bc126b24708"
+  integrity sha1-iDKP19HOeTiykoN0bwsbwSayRwg=
+  dependencies:
+    ansi-escapes "^3.0.0"
+    cli-cursor "^2.0.0"
+    wrap-ansi "^3.0.1"
 
 log-update@^4.0.0:
   version "4.0.0"
@@ -11171,17 +12011,17 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
-lower-case@^1.1.1:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
-  integrity sha1-miyr0bno4K6ZOkv31YdcOcQujqw=
-
-lower-case@^2.0.1:
+lower-case@2.0.1, lower-case@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.1.tgz#39eeb36e396115cc05e29422eaea9e692c9408c7"
   integrity sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==
   dependencies:
     tslib "^1.10.0"
+
+lower-case@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
+  integrity sha1-miyr0bno4K6ZOkv31YdcOcQujqw=
 
 lowlight@~1.11.0:
   version "1.11.0"
@@ -11267,7 +12107,7 @@ map-age-cleaner@^0.1.1:
   dependencies:
     p-defer "^1.0.0"
 
-map-cache@^0.2.2:
+map-cache@^0.2.0, map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
   integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
@@ -11663,7 +12503,7 @@ mixme@^0.3.1:
   resolved "https://registry.yarnpkg.com/mixme/-/mixme-0.3.5.tgz#304652cdaf24a3df0487205e61ac6162c6906ddd"
   integrity sha512-SyV9uPETRig5ZmYev0ANfiGeB+g6N2EnqqEfBbCGmmJ6MgZ3E4qv5aPbnHVdZ60KAHHXV+T3sXopdrnIXQdmjQ==
 
-mkdirp@1.x:
+mkdirp@1.0.4, mkdirp@1.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -11730,7 +12570,7 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nan@^2.12.1:
+nan@^2.12.1, nan@^2.14.0:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
@@ -11840,10 +12680,23 @@ node-emoji@^1.10.0:
   dependencies:
     lodash.toarray "^4.4.0"
 
-node-fetch@^2.1.2, node-fetch@^2.2.0, node-fetch@^2.6.0:
+node-fetch@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
+  integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
+
+node-fetch@2.6.0, node-fetch@^2.1.2, node-fetch@^2.2.0, node-fetch@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 node-forge@0.9.0:
   version "0.9.0"
@@ -12016,6 +12869,11 @@ nth-check@^1.0.2, nth-check@~1.0.1:
   integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
   dependencies:
     boolbase "~1.0.0"
+
+nullthrows@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/nullthrows/-/nullthrows-1.1.1.tgz#7818258843856ae971eae4208ad7d7eb19a431b1"
+  integrity sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==
 
 num2fraction@^1.2.2:
   version "1.2.2"
@@ -12314,19 +13172,19 @@ p-is-promise@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
   integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
 
+p-limit@2.3.0, p-limit@^2.0.0, p-limit@^2.2.0, p-limit@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
+  integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
+  dependencies:
+    p-try "^2.0.0"
+
 p-limit@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
   integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
   dependencies:
     p-try "^1.0.0"
-
-p-limit@^2.0.0, p-limit@^2.2.0, p-limit@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
-  integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
-  dependencies:
-    p-try "^2.0.0"
 
 p-locate@^2.0.0:
   version "2.0.0"
@@ -12406,20 +13264,20 @@ parallel-transform@^1.1.0:
     inherits "^2.0.3"
     readable-stream "^2.1.5"
 
-param-case@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/param-case/-/param-case-2.1.1.tgz#df94fd8cf6531ecf75e6bef9a0858fbc72be2247"
-  integrity sha1-35T9jPZTHs915r75oIWPvHK+Ikc=
-  dependencies:
-    no-case "^2.2.0"
-
-param-case@^3.0.3:
+param-case@3.0.3, param-case@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.3.tgz#4be41f8399eff621c56eebb829a5e451d9801238"
   integrity sha512-VWBVyimc1+QrzappRs7waeN2YmoZFCGXWASRYX1/rGHtXqEcrGEIDm+jqIwFa2fRXNgQEwrxaYuIrX0WcAguTA==
   dependencies:
     dot-case "^3.0.3"
     tslib "^1.10.0"
+
+param-case@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/param-case/-/param-case-2.1.1.tgz#df94fd8cf6531ecf75e6bef9a0858fbc72be2247"
+  integrity sha1-35T9jPZTHs915r75oIWPvHK+Ikc=
+  dependencies:
+    no-case "^2.2.0"
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -12451,6 +13309,15 @@ parse-entities@^1.1.2:
     is-alphanumerical "^1.0.0"
     is-decimal "^1.0.0"
     is-hexadecimal "^1.0.0"
+
+parse-filepath@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/parse-filepath/-/parse-filepath-1.0.2.tgz#a632127f53aaf3d15876f5872f3ffac763d6c891"
+  integrity sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=
+  dependencies:
+    is-absolute "^1.0.0"
+    map-cache "^0.2.0"
+    path-root "^0.1.1"
 
 parse-json@^2.2.0:
   version "2.2.0"
@@ -12530,7 +13397,7 @@ parseurl@^1.3.2, parseurl@~1.3.2, parseurl@~1.3.3:
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
-pascal-case@^3.1.1:
+pascal-case@3.1.1, pascal-case@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.1.tgz#5ac1975133ed619281e88920973d2cd1f279de5f"
   integrity sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==
@@ -12594,6 +13461,18 @@ path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
+path-root-regex@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/path-root-regex/-/path-root-regex-0.1.2.tgz#bfccdc8df5b12dc52c8b43ec38d18d72c04ba96d"
+  integrity sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=
+
+path-root@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/path-root/-/path-root-0.1.1.tgz#9a4a6814cac1c0cd73360a95f32083c8ea4745b7"
+  integrity sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=
+  dependencies:
+    path-root-regex "^0.1.0"
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -13305,6 +14184,35 @@ pretty-ms@^6.0.1:
   integrity sha512-ke4njoVmlotekHlHyCZ3wI/c5AMT8peuHs8rKJqekj/oR5G8lND2dVpicFlUz5cbZgE290vvkMuDwfj/OcW1kw==
   dependencies:
     parse-ms "^2.1.0"
+
+prisma-json-schema@0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/prisma-json-schema/-/prisma-json-schema-0.1.3.tgz#6c302db8f464f8b92e8694d3f7dd3f41ac9afcbe"
+  integrity sha512-XZrf2080oR81mY8/OC8al68HiwBm0nXlFE727JIia0ZbNqwuV4MyRYk6E0+OIa6/9KEYxZrcAmoBs3EW1cCvnA==
+
+prisma-yml@1.34.10:
+  version "1.34.10"
+  resolved "https://registry.yarnpkg.com/prisma-yml/-/prisma-yml-1.34.10.tgz#0ef1ad3a125f54f200289cba56bdd9597f17f410"
+  integrity sha512-N9on+Cf/XQKFGUULk/681tnpfqiZ19UBTurFMm+/9rnml37mteDaFr2k8yz+K8Gt2xpEJ7kBu7ikG5PrXI1uoA==
+  dependencies:
+    ajv "5"
+    bluebird "^3.5.1"
+    chalk "^2.3.0"
+    debug "^3.1.0"
+    dotenv "^4.0.0"
+    fs-extra "^7.0.0"
+    graphql-request "^1.5.0"
+    http-proxy-agent "^2.1.0"
+    https-proxy-agent "^2.2.1"
+    isomorphic-fetch "^2.2.1"
+    js-yaml "^3.10.0"
+    json-stable-stringify "^1.0.1"
+    jsonwebtoken "^8.1.0"
+    lodash "^4.17.4"
+    prisma-json-schema "0.1.3"
+    replaceall "^0.1.6"
+    scuid "^1.0.2"
+    yaml-ast-parser "^0.0.40"
 
 prismjs@^1.8.4:
   version "1.20.0"
@@ -14166,10 +15074,50 @@ relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
+relay-compiler@9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-9.1.0.tgz#e2975de85192e2470daad78e30052bf9614d22ed"
+  integrity sha512-jsJx0Ux5RoxM+JFm3M3xl7UfZAJ0kUTY/r6jqOpcYgVI3GLJthvNI4IoziFRlWbhizEzGFbpkdshZcu9IObJYA==
+  dependencies:
+    "@babel/core" "^7.0.0"
+    "@babel/generator" "^7.5.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/runtime" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    babel-preset-fbjs "^3.3.0"
+    chalk "^2.4.1"
+    fast-glob "^2.2.2"
+    fb-watchman "^2.0.0"
+    fbjs "^1.0.0"
+    immutable "~3.7.6"
+    nullthrows "^1.1.1"
+    relay-runtime "9.1.0"
+    signedsource "^1.0.0"
+    yargs "^14.2.0"
+
+relay-runtime@9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-9.1.0.tgz#d0534007d5c43e7b9653c6f5cc112ffac09c5020"
+  integrity sha512-6FE5YlZpR/b3R/HzGly85V+c4MdtLJhFY/outQARgxXonomrwqEik0Cr34LnPK4DmGS36cMLUliqhCs/DZyPVw==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    fbjs "^1.0.0"
+
+remedial@^1.0.7:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/remedial/-/remedial-1.0.8.tgz#a5e4fd52a0e4956adbaf62da63a5a46a78c578a0"
+  integrity sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg==
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
   integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
+
+remove-trailing-spaces@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/remove-trailing-spaces/-/remove-trailing-spaces-1.0.7.tgz#491f04e11d98880714d12429b0d0938cbe030ae6"
+  integrity sha512-wjM17CJ2kk0SgoGyJ7ZMzRRCuTq+V8YhMwpZ5XEWX0uaked2OUq6utvHXGNBQrfkUzUUABFMyxlKn+85hMv4dg==
 
 renderkid@^2.0.1:
   version "2.0.3"
@@ -14199,6 +15147,11 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
+replaceall@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/replaceall/-/replaceall-0.1.6.tgz#81d81ac7aeb72d7f5c4942adf2697a3220688d8e"
+  integrity sha1-gdgax663LX9cSUKt8ml6MiBojY4=
+
 request-promise-core@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.3.tgz#e9a3c081b51380dfea677336061fea879a829ee9"
@@ -14215,7 +15168,7 @@ request-promise-native@^1.0.5, request-promise-native@^1.0.7, request-promise-na
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-"request@>=2.76.0 <3.0.0", request@^2.83.0, request@^2.87.0, request@^2.88.0, request@^2.88.2:
+request@2.88.2, "request@>=2.76.0 <3.0.0", request@^2.83.0, request@^2.87.0, request@^2.88.0, request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -14290,6 +15243,11 @@ resolve-cwd@^3.0.0:
   dependencies:
     resolve-from "^5.0.0"
 
+resolve-from@5.0.0, resolve-from@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
+  integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
 resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
@@ -14299,11 +15257,6 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
-
-resolve-from@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
-  integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -14438,7 +15391,7 @@ rx-lite@*, rx-lite@^4.0.8:
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
   integrity sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=
 
-rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.5.5:
+rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.5.5:
   version "6.5.5"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
   integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
@@ -14541,6 +15494,11 @@ screenfull@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-5.0.2.tgz#b9acdcf1ec676a948674df5cd0ff66b902b0bed7"
   integrity sha512-cCF2b+L/mnEiORLN5xSAz6H3t18i2oHh9BA8+CQlAh5DRw2+NFAGQJOSYbcGw8B2k04g/lVvFcfZ83b3ysH5UQ==
+
+scuid@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/scuid/-/scuid-1.1.0.tgz#d3f9f920956e737a60f72d0e4ad280bf324d5dab"
+  integrity sha512-MuCAyrGZcTLfQoH2XoBlQ8C6bzwN88XT/0slOGz0pn8+gIP85BOAfYa44ZXQUTOwRwPU0QvgU+V+OSajl/59Xg==
 
 select-hose@^2.0.0:
   version "2.0.0"
@@ -14683,7 +15641,7 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.4:
+setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
@@ -14781,6 +15739,19 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
+
+signedsource@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/signedsource/-/signedsource-1.0.0.tgz#1ddace4981798f93bd833973803d80d52e93ad6a"
+  integrity sha1-HdrOSYF5j5O9gzlzgD2A1S6TrWo=
+
+simple-git@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-2.5.0.tgz#538b14b25f83916a56f30eca53f13796db6712f6"
+  integrity sha512-4gmtMqfIL9bsBNJDP/rDwZe3GsQL/tp85Qv5cmRc8iIDNOZJS4IX1oPfcqp9b7BGPc5bfuw4yd1i3lQacvuqDQ==
+  dependencies:
+    "@kwsites/exec-p" "^0.4.0"
+    debug "^4.0.1"
 
 simple-swizzle@^0.2.2:
   version "0.2.2"
@@ -14943,6 +15914,11 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+slice-ansi@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
+  integrity sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=
 
 slice-ansi@^2.1.0:
   version "2.1.0"
@@ -15392,6 +16368,11 @@ string-argv@0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
+string-env-interpolation@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz#ad4397ae4ac53fe6c91d1402ad6f6a52862c7152"
+  integrity sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==
+
 string-length@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
@@ -15660,7 +16641,7 @@ stylis@3.5.0:
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.0.tgz#016fa239663d77f868fef5b67cf201c4b7c701e1"
   integrity sha512-pP7yXN6dwMzAR29Q0mBrabPCe0/mNO1MSr93bhay+hcZondvMMTpeGyd8nbhYJdyperNT2DRxONQuUGcJr5iPw==
 
-subscriptions-transport-ws@^0.9.11:
+subscriptions-transport-ws@0.9.16, subscriptions-transport-ws@^0.9.11:
   version "0.9.16"
   resolved "https://registry.yarnpkg.com/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.16.tgz#90a422f0771d9c32069294c08608af2d47f596ec"
   integrity sha512-pQdoU7nC+EpStXnCfh/+ho0zE0Z+ma+i7xvj7bkXKb1dvYHSZxgRPaU6spRP+Bjzow67c/rRDoix5RT0uU9omw==
@@ -15761,7 +16742,7 @@ svgo@^1.0.0, svgo@^1.2.2, svgo@^1.3.0:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-symbol-observable@^1.0.4:
+symbol-observable@^1.0.4, symbol-observable@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
@@ -16138,6 +17119,11 @@ ts-jest@26.1.0:
     semver "7.x"
     yargs-parser "18.x"
 
+ts-log@2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/ts-log/-/ts-log-2.1.4.tgz#063c5ad1cbab5d49d258d18015963489fb6fb59a"
+  integrity sha512-P1EJSoyV+N3bR/IWFeAqXzKPZwHpnLY6j7j58mAvewHRipo+BQM2Y1f9Y9BjEQznKwgqqZm7H8iuixmssU7tYQ==
+
 ts-node-dev@1.0.0-pre.44:
   version "1.0.0-pre.44"
   resolved "https://registry.yarnpkg.com/ts-node-dev/-/ts-node-dev-1.0.0-pre.44.tgz#2f4d666088481fb9c4e4f5bc8f15995bd8b06ecb"
@@ -16187,12 +17173,17 @@ tsconfig@^7.0.0:
     strip-bom "^3.0.0"
     strip-json-comments "^2.0.0"
 
-tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@1.11.2:
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.2.tgz#9c79d83272c9a7aaf166f73915c9667ecdde3cc9"
+  integrity sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==
+
+tslib@^1.10.0, tslib@^1.11.1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
-tslib@~2.0.0:
+tslib@^2.0.0, tslib@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
   integrity sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
@@ -16322,6 +17313,16 @@ typical@^5.0.0, typical@^5.2.0:
   resolved "https://registry.yarnpkg.com/typical/-/typical-5.2.0.tgz#4daaac4f2b5315460804f0acf6cb69c52bb93066"
   integrity sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==
 
+ua-parser-js@^0.7.18:
+  version "0.7.21"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"
+  integrity sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==
+
+unc-path-regex@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
+  integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
+
 unfetch@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.1.0.tgz#6ec2dd0de887e58a4dee83a050ded80ffc4137db"
@@ -16394,6 +17395,13 @@ universalify@^1.0.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d"
   integrity sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==
 
+unixify@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unixify/-/unixify-1.0.0.tgz#3a641c8c2ffbce4da683a5c70f03a462940c2090"
+  integrity sha1-OmQcjC/7zk2mg6XHDwOkYpQMIJA=
+  dependencies:
+    normalize-path "^2.1.1"
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
@@ -16423,6 +17431,13 @@ upath@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
+
+upper-case@2.0.1, upper-case@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-2.0.1.tgz#6214d05e235dc817822464ccbae85822b3d8665f"
+  integrity sha512-laAsbea9SY5osxrv7S99vH9xAaJKrw5Qpdh4ENRLcaxipjKsiaBwiAsxfa8X5mObKNTQPsupSq0J/VIxsSJe3A==
+  dependencies:
+    tslib "^1.10.0"
 
 uri-js@^4.2.2:
   version "4.2.2"
@@ -16596,6 +17611,11 @@ v8-to-istanbul@^4.1.3:
     convert-source-map "^1.6.0"
     source-map "^0.7.3"
 
+valid-url@1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/valid-url/-/valid-url-1.0.9.tgz#1c14479b40f1397a75782f115e4086447433a200"
+  integrity sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=
+
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
@@ -16634,6 +17654,14 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+vue-template-compiler@^2.6.11:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.11.tgz#c04704ef8f498b153130018993e56309d4698080"
+  integrity sha512-KIq15bvQDrcCjpGjrAhx4mUlyyHfdmTaoNfeoATHLAiWB+MU3cx4lOzMwrnUh9cCxy0Lt1T11hAFY6TQgroUAA==
+  dependencies:
+    de-indent "^1.0.2"
+    he "^1.1.0"
 
 w3c-hr-time@^1.0.1, w3c-hr-time@^1.0.2:
   version "1.0.2"
@@ -16929,12 +17957,33 @@ websocket-extensions@>=0.1.1:
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
   integrity sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==
 
+websocket@1.0.31:
+  version "1.0.31"
+  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.31.tgz#e5d0f16c3340ed87670e489ecae6144c79358730"
+  integrity sha512-VAouplvGKPiKFDTeCCO65vYHsyay8DqoBSlzIO3fayrfOgU94lQN5a1uWVnFrMLceTJw/+fQXR5PGbUVRaHshQ==
+  dependencies:
+    debug "^2.2.0"
+    es5-ext "^0.10.50"
+    nan "^2.14.0"
+    typedarray-to-buffer "^3.1.5"
+    yaeti "^0.0.6"
+
 whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3, whatwg-encoding@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
+
+whatwg-fetch@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
+  integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
+
+whatwg-fetch@3.0.0, whatwg-fetch@>=0.10.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"
@@ -17060,6 +18109,15 @@ worker-rpc@^0.1.0:
   dependencies:
     microevent.ts "~0.1.1"
 
+wrap-ansi@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrap-ansi@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
@@ -17067,6 +18125,14 @@ wrap-ansi@^2.0.0:
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
+
+wrap-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-3.0.1.tgz#288a04d87eda5c286e060dfe8f135ce8d007f8ba"
+  integrity sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
 
 wrap-ansi@^5.1.0:
   version "5.1.0"
@@ -17166,6 +18232,11 @@ y18n@^3.2.1:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
+yaeti@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/yaeti/-/yaeti-0.0.6.tgz#f26f484d72684cf42bedfb76970aa1608fbf9577"
+  integrity sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=
+
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
@@ -17180,6 +18251,11 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yaml-ast-parser@^0.0.40:
+  version "0.0.40"
+  resolved "https://registry.yarnpkg.com/yaml-ast-parser/-/yaml-ast-parser-0.0.40.tgz#08536d4e73d322b1c9ce207ab8dd70e04d20ae6e"
+  integrity sha1-CFNtTnPTIrHJziB6uN1w4E0grm4=
 
 yaml@^1.7.2:
   version "1.10.0"
@@ -17217,6 +18293,14 @@ yargs-parser@^13.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^15.0.1:
+  version "15.0.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
+  integrity sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-4.2.1.tgz#29cceac0dc4f03c6c87b4a9f217dd18c9f74871c"
@@ -17241,6 +18325,23 @@ yargs@12.0.5:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
+
+yargs@15.3.1, yargs@^15.0.0, yargs@^15.1.0, yargs@^15.3.1:
+  version "15.3.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
+  integrity sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.1"
 
 yargs@6.6.0:
   version "6.6.0"
@@ -17277,22 +18378,22 @@ yargs@^13.3.2:
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
 
-yargs@^15.0.0, yargs@^15.1.0, yargs@^15.3.1:
-  version "15.3.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
-  integrity sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==
+yargs@^14.2.0:
+  version "14.2.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.3.tgz#1a1c3edced1afb2a2fea33604bc6d1d8d688a414"
+  integrity sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==
   dependencies:
-    cliui "^6.0.0"
+    cliui "^5.0.0"
     decamelize "^1.2.0"
-    find-up "^4.1.0"
+    find-up "^3.0.0"
     get-caller-file "^2.0.1"
     require-directory "^2.1.1"
     require-main-filename "^2.0.0"
     set-blocking "^2.0.0"
-    string-width "^4.2.0"
+    string-width "^3.0.0"
     which-module "^2.0.0"
     y18n "^4.0.0"
-    yargs-parser "^18.1.1"
+    yargs-parser "^15.0.1"
 
 ylru@^1.2.0:
   version "1.2.1"


### PR DESCRIPTION
## Overview:
- Adds SEEK graphql type via codegen. This is pulled into the root of wingman to then be consumed by both the frontend and backend.
- Re-exports these within the front-end so it and consumers of `fe/lib` can use them. Keen to get some feedback on this, it means we have a  double up in files but easier to maintain/use.

## Front-end use
As they are being re-exported in `/fe/lib/types` we can consume them like

```
import { JobCategory } from 'lib/types/seekTypes';

interface Props {
  jobCategory: JobCategory;
}
```