### PR TITLE
Disable Apollo Server subscriptions

### DIFF
--- a/.changeset/dirty-items-wave.md
+++ b/.changeset/dirty-items-wave.md
@@ -1,0 +1,5 @@
+---
+'wingman-be': patch
+---
+
+Disable Apollo Server subscriptions

--- a/be/package.json
+++ b/be/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@graphql-tools/delegate": "^6.0.5",
     "@graphql-tools/wrap": "^6.0.5",
-    "apollo-server-koa": "^2.14.1",
+    "apollo-server-koa": "^2.14.2",
     "graphql": "^15.0.0",
     "koa": "^2.12.0",
     "koa-bodyparser": "^4.3.0",

--- a/be/src/seekGraph/middleware.ts
+++ b/be/src/seekGraph/middleware.ts
@@ -30,6 +30,7 @@ export const createSeekGraphMiddleware = async ({
     debug,
     playground: debug,
     schema,
+    subscriptions: false,
   });
 
   return server.getMiddleware({ path });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1520,16 +1520,7 @@
     fs-extra "9.0.0"
     tslib "~2.0.0"
 
-"@graphql-tools/delegate@6.0.5", "@graphql-tools/delegate@^6.0.5":
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/delegate/-/delegate-6.0.5.tgz#34a5fbcaa749d54e5e13e892dd55d0b6021a418c"
-  integrity sha512-JOXfDor3wQyjLkGD8JvTLRoXi3KNZvybm9fIwyPlbFghTac+KRH1A1RmHqQdaLE1ieYVv34Cplp/itoA77R4FQ==
-  dependencies:
-    "@graphql-tools/schema" "6.0.5"
-    "@graphql-tools/utils" "6.0.5"
-    tslib "~2.0.0"
-
-"@graphql-tools/delegate@6.0.7":
+"@graphql-tools/delegate@6.0.7", "@graphql-tools/delegate@^6.0.5":
   version "6.0.7"
   resolved "https://registry.yarnpkg.com/@graphql-tools/delegate/-/delegate-6.0.7.tgz#71c92d349f6e5e0f8ac9a74f370d68243319476e"
   integrity sha512-s2JLxpDD0AXif4yvSdy9W18UEutliO4YzrAOzNL8B1BS6kiIT7BSZv0Eyu7XTuL2fIg4Ln8z7WZclj2bYiK8mw==
@@ -1638,14 +1629,6 @@
     "@graphql-tools/utils" "6.0.6"
     relay-compiler "9.1.0"
 
-"@graphql-tools/schema@6.0.5":
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-6.0.5.tgz#6dc6f15861a48f2b8f82407b0701b3ec0476e7ce"
-  integrity sha512-F1MAW2uufz5O6fSUTdb72MMICbgP0km7l7wbsOC0izeEG/EqvvAs0dBDzvC6cNokDz/X/PCHhIdunK9o7XY/0g==
-  dependencies:
-    "@graphql-tools/utils" "6.0.5"
-    tslib "~2.0.0"
-
 "@graphql-tools/schema@6.0.7":
   version "6.0.7"
   resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-6.0.7.tgz#53549f29b626b2d0657a8ce2e9c4edecc249e815"
@@ -1668,13 +1651,6 @@
     valid-url "1.0.9"
     websocket "1.0.31"
 
-"@graphql-tools/utils@6.0.5":
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-6.0.5.tgz#f46462ded39388cc28e1a1477e3e5c82185f9910"
-  integrity sha512-RRBx+ZKrw82dFXaXqh5lLNtjF9uD28G9OXESTj404+JSuz+eLbP0LIA/S6bcdUFfWqppgoswkK1sngvNpelKrg==
-  dependencies:
-    camel-case "4.1.1"
-
 "@graphql-tools/utils@6.0.6":
   version "6.0.6"
   resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-6.0.6.tgz#49ef23dc96ee92771115c5b35eebaea0b0e3b71a"
@@ -1689,7 +1665,7 @@
   dependencies:
     camel-case "4.1.1"
 
-"@graphql-tools/wrap@6.0.7":
+"@graphql-tools/wrap@6.0.7", "@graphql-tools/wrap@^6.0.5":
   version "6.0.7"
   resolved "https://registry.yarnpkg.com/@graphql-tools/wrap/-/wrap-6.0.7.tgz#d35d8c67a447d08eb4623b1393230011428dfa43"
   integrity sha512-2azhUV4xkIE5BoNuR9Gf3YX7pZq7gNusC+bvRB6P88ROpgULZF1deoraXYaFm9BkpJCdH950b4UwsYSD9luy3g==
@@ -1697,16 +1673,6 @@
     "@graphql-tools/delegate" "6.0.7"
     "@graphql-tools/schema" "6.0.7"
     "@graphql-tools/utils" "6.0.7"
-    tslib "~2.0.0"
-
-"@graphql-tools/wrap@^6.0.5":
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/wrap/-/wrap-6.0.5.tgz#134e890657cc7be64ce57d46f04cfc135c79294e"
-  integrity sha512-eXQeA9RXZ9w5a7zORQxI3Dw1W0fyMQ4H5u/R80AEqbLYGAaqrr/4WEB3fhIBaOUw6D3ZsC34a3tmImwx77VHTw==
-  dependencies:
-    "@graphql-tools/delegate" "6.0.5"
-    "@graphql-tools/schema" "6.0.5"
-    "@graphql-tools/utils" "6.0.5"
     tslib "~2.0.0"
 
 "@hapi/address@2.x.x":
@@ -3971,10 +3937,10 @@ apollo-server-caching@^0.5.1:
   dependencies:
     lru-cache "^5.0.0"
 
-apollo-server-core@^2.14.1:
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-2.14.1.tgz#d930c62bfbe36e40fa5fce707aa3bfbfe3d1393b"
-  integrity sha512-Uk/jJwLtm+5YvExghNoq9V2ZHJRXPfaVOt4cIyo+mcjWG6YymHhMg5h9pR/auz9HMI8NP7ykmfo/bsTR1qutWQ==
+apollo-server-core@^2.14.2:
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-2.14.2.tgz#4ab055b96b8be7821a726c81e8aa412deb7f3644"
+  integrity sha512-8G6Aoz+k+ecuQco1KNLFbMrxhe/8uR4AOaOYEvT/N5m/6lrkPYzvBAxbpRIub5AxEwpBPcIrI452rR3PD9DItA==
   dependencies:
     "@apollographql/apollo-tools" "^0.4.3"
     "@apollographql/graphql-playground-html" "1.6.24"
@@ -4012,10 +3978,10 @@ apollo-server-errors@^2.4.1:
   resolved "https://registry.yarnpkg.com/apollo-server-errors/-/apollo-server-errors-2.4.1.tgz#16ad49de6c9134bfb2b7dede9842e73bb239dbe2"
   integrity sha512-7oEd6pUxqyWYUbQ9TA8tM0NU/3aGtXSEibo6+txUkuHe7QaxfZ2wHRp+pfT1LC1K3RXYjKj61/C2xEO19s3Kdg==
 
-apollo-server-koa@^2.14.1:
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/apollo-server-koa/-/apollo-server-koa-2.14.1.tgz#ebaaa67a18d17ac6ec3f308c804a87ace3941af9"
-  integrity sha512-1YtJXONKoxO7q6c8vf+Hn46VbSD3vNHNwa2MmhBm3hAKDuRa5jOdFYWqDKpcgWEDeZxq6hnY+kYa4u89RgpHRQ==
+apollo-server-koa@^2.14.2:
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/apollo-server-koa/-/apollo-server-koa-2.14.2.tgz#95d098dd6cf831e2e466908956c2dee8b8b6d59b"
+  integrity sha512-pQuQPQeIkUdsjn3anRN5y1nZSM+tu/H2rCLae3l2gBZknj8ABJ20EeBKFjnB2/6OuHo3FQJSZVt9zeRbMfWKSw==
   dependencies:
     "@apollographql/graphql-playground-html" "1.6.24"
     "@koa/cors" "^2.2.1"
@@ -4026,7 +3992,7 @@ apollo-server-koa@^2.14.1:
     "@types/koa-compose" "^3.2.2"
     "@types/koa__cors" "^2.2.1"
     accepts "^1.3.5"
-    apollo-server-core "^2.14.1"
+    apollo-server-core "^2.14.2"
     apollo-server-types "^0.5.0"
     graphql-subscriptions "^1.0.0"
     graphql-tools "^4.0.0"


### PR DESCRIPTION
There was a bug in Apollo Server that allowed introspection through subscriptions, bypassing validation checks.

The SEEK API schema is publicly available so it doesn't impact us, but we don't make use of subscriptions anyway.

https://github.com/apollographql/apollo-server/security/advisories/GHSA-w42g-7vfc-xf37