### PR TITLE
Apply fixes to browser token middleware

### DIFF
--- a/.changeset/itchy-roses-grab.md
+++ b/.changeset/itchy-roses-grab.md
@@ -1,0 +1,8 @@
+---
+'wingman-be': patch
+---
+
+Apply fixes to browser token middleware
+
+The middleware now points to the browser token playground URL,
+and accepts a `callback` for debugging/logging.

--- a/be/src/browserToken/middleware.test.ts
+++ b/be/src/browserToken/middleware.test.ts
@@ -2,7 +2,10 @@ import Koa from 'koa';
 import nock from 'nock';
 import * as fetchModule from 'node-fetch';
 
-import { SEEK_API_BASE_URL, SEEK_BROWSER_TOKEN_PATH } from '../constants';
+import {
+  SEEK_BROWSER_TOKEN_PATH,
+  SEEK_BROWSER_TOKEN_PLAYGROUND_BASE_URL,
+} from '../constants';
 import { RetrieveRequest } from '../getPartnerToken';
 import { createAgent } from '../testing/http';
 import { errorHandler } from '../testing/koa';
@@ -53,7 +56,7 @@ describe('createBrowserTokenMiddleware', () => {
   afterAll(agent.teardown);
 
   it('issues a browser token for a valid request', async () => {
-    nock(SEEK_API_BASE_URL)
+    nock(SEEK_BROWSER_TOKEN_PLAYGROUND_BASE_URL)
       .post(SEEK_BROWSER_TOKEN_PATH)
       .matchHeader('user-agent', 'abc/1.2.3')
       .reply(200, VALID_BROWSER_TOKEN_RESPONSE);
@@ -73,7 +76,7 @@ describe('createBrowserTokenMiddleware', () => {
   it('caches a browser token', async () => {
     const fetchSpy = jest.spyOn(fetchModule, 'default');
 
-    nock(SEEK_API_BASE_URL)
+    nock(SEEK_BROWSER_TOKEN_PLAYGROUND_BASE_URL)
       .post(SEEK_BROWSER_TOKEN_PATH)
       .matchHeader('user-agent', 'abc/1.2.3')
       .reply(200, VALID_BROWSER_TOKEN_RESPONSE);
@@ -111,7 +114,7 @@ describe('createBrowserTokenMiddleware', () => {
 
   it('fails on invalid response from the SEEK API', () => {
     nock.cleanAll();
-    nock(SEEK_API_BASE_URL)
+    nock(SEEK_BROWSER_TOKEN_PLAYGROUND_BASE_URL)
       .post(SEEK_BROWSER_TOKEN_PATH)
       .matchHeader('user-agent', 'abc/1.2.3')
       .reply(200, INVALID_BROWSER_TOKEN_RESPONSE);

--- a/be/src/browserToken/types.ts
+++ b/be/src/browserToken/types.ts
@@ -1,10 +1,22 @@
 /* eslint-disable new-cap */
 
+import { Context } from 'koa';
 import * as t from 'runtypes';
 
 import { GetPartnerToken } from '../getPartnerToken';
 
+export type BrowserTokenEvent =
+  | {
+      type: 'CACHED';
+      expiry: string;
+    }
+  | {
+      type: 'RETRIEVED';
+      expiry: string;
+    };
+
 export interface BrowserTokenMiddlewareOptions {
+  callback?: (ctx: Context, event: BrowserTokenEvent) => void | Promise<void>;
   getPartnerToken: GetPartnerToken<{ hirerId: string; partnerToken: string }>;
   userAgent: string;
 }

--- a/be/src/constants.ts
+++ b/be/src/constants.ts
@@ -3,5 +3,7 @@ export const SEEK_API_BASE_URL = 'https://graphql.seek.com';
 export const SEEK_API_PATH = '/graphql';
 export const SEEK_API_URL = `${SEEK_API_BASE_URL}${SEEK_API_PATH}`;
 
+export const SEEK_BROWSER_TOKEN_PLAYGROUND_BASE_URL =
+  'https://indie-jessiej-public-test.public.indirect-apply.prod.outfra.xyz';
 export const SEEK_BROWSER_TOKEN_PATH = '/auth/token';
-export const SEEK_BROWSER_TOKEN_URL = `${SEEK_API_BASE_URL}${SEEK_BROWSER_TOKEN_PATH}`;
+export const SEEK_BROWSER_TOKEN_PLAYGROUND_URL = `${SEEK_BROWSER_TOKEN_PLAYGROUND_BASE_URL}${SEEK_BROWSER_TOKEN_PATH}`;

--- a/be/src/partnerWebhook/middleware.ts
+++ b/be/src/partnerWebhook/middleware.ts
@@ -53,16 +53,14 @@ const _createPartnerWebhookMiddleware = ({
             secret,
           });
 
-    if (typeof callback !== 'undefined') {
-      const event: PartnerWebhookEvent = {
-        type: 'RECEIVED',
-        body,
-        signature,
-        valid,
-      };
+    const event: PartnerWebhookEvent = {
+      type: 'RECEIVED',
+      body,
+      signature,
+      valid,
+    };
 
-      await callback(ctx, event);
-    }
+    await callback?.(ctx, event);
 
     if (!valid) {
       return ctx.throw(400, 'Invalid request');

--- a/be/src/seekAttachment/middleware.ts
+++ b/be/src/seekAttachment/middleware.ts
@@ -61,15 +61,11 @@ export const createSeekAttachmentMiddleware = ({
 
     ctx.status = response.status;
 
-    if (typeof callback === 'undefined') {
-      return;
-    }
-
     const event: SeekAttachmentEvent = {
       type: 'RETRIEVED',
       status: response.status,
       url,
     };
 
-    return callback(ctx, event);
+    return callback?.(ctx, event);
   };


### PR DESCRIPTION
The middleware now points to the browser token playground URL, and accepts a `callback` for debugging/logging.