### PR TITLE
refactor: removes enforced/restrictive typing on ApolloClient

### DIFF
--- a/.changeset/three-jars-collect.md
+++ b/.changeset/three-jars-collect.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': minor
+---
+
+Remove enforced typing on client (ApolloClient) for LocationSuggest

--- a/fe/lib/components/LocationSuggest/LocationSuggest.tsx
+++ b/fe/lib/components/LocationSuggest/LocationSuggest.tsx
@@ -17,7 +17,7 @@ import { LOCATION_SUGGEST } from './queries';
 interface FieldProps extends ComponentPropsWithRef<typeof TextField> {}
 
 interface Props extends Omit<FieldProps, 'value' | 'onChange'> {
-  client?: ApolloClient<Record<string, unknown>>;
+  client?: ApolloClient<unknown>;
   debounceDelay?: number;
   first?: number;
   usageTypeCode?: string;


### PR DESCRIPTION
The typing on the passed in ApolloClient is more restrictive than it needs to be for consumers. Removes the Record or string and unknown to just unknown.