### PR TITLE
refactor(LocationSuggest): switch to relative path to resolve SEEK types

### DIFF
--- a/.changeset/heavy-eggs-flow.md
+++ b/.changeset/heavy-eggs-flow.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': minor
+---
+
+Fixes type resolution error in consumers. Now resolves SEEK types via relative path

--- a/fe/lib/components/LocationSuggest/LocationSuggest.tsx
+++ b/fe/lib/components/LocationSuggest/LocationSuggest.tsx
@@ -9,7 +9,7 @@ import React, {
 } from 'react';
 import { useDebounce } from 'use-debounce';
 
-import { Location, LocationSuggestion } from 'lib/types/seek.graphql';
+import { Location, LocationSuggestion } from '../../types/seek.graphql';
 
 import LocationSuggestInput from './LocationSuggestInput';
 import { LOCATION_SUGGEST } from './queries';

--- a/fe/lib/components/LocationSuggest/LocationSuggestInput.tsx
+++ b/fe/lib/components/LocationSuggest/LocationSuggestInput.tsx
@@ -2,7 +2,7 @@ import matchHighlights from 'autosuggest-highlight/match';
 import { Autosuggest, IconSearch } from 'braid-design-system';
 import React, { useState } from 'react';
 
-import { Location, LocationSuggestion } from 'lib/types/seek.graphql';
+import { Location, LocationSuggestion } from '../../types/seek.graphql';
 
 interface Suggestion {
   text: string;


### PR DESCRIPTION
As we are not compiling wingman (yet), the consumer needs to set-up custom resolve rules for `/lib`. Switches to relative paths for SEEK type imports. 