### PR TITLE
Unify browser token URLs

### DIFF
--- a/.changeset/quick-carpets-attend.md
+++ b/.changeset/quick-carpets-attend.md
@@ -1,0 +1,5 @@
+---
+'wingman-be': patch
+---
+
+Point back to graphql.seek.com for browser tokens

--- a/be/src/browserToken/middleware.test.ts
+++ b/be/src/browserToken/middleware.test.ts
@@ -2,10 +2,7 @@ import Koa from 'koa';
 import nock from 'nock';
 import * as fetchModule from 'node-fetch';
 
-import {
-  SEEK_BROWSER_TOKEN_PATH,
-  SEEK_BROWSER_TOKEN_PLAYGROUND_BASE_URL,
-} from '../constants';
+import { SEEK_API_BASE_URL, SEEK_BROWSER_TOKEN_PATH } from '../constants';
 import { RetrieveRequest } from '../getPartnerToken';
 import { createAgent } from '../testing/http';
 import { errorHandler } from '../testing/koa';
@@ -55,7 +52,7 @@ describe('createBrowserTokenMiddleware', () => {
   afterAll(agent.teardown);
 
   it('issues a browser token for a valid request', () => {
-    nock(SEEK_BROWSER_TOKEN_PLAYGROUND_BASE_URL)
+    nock(SEEK_API_BASE_URL)
       .post(SEEK_BROWSER_TOKEN_PATH)
       .matchHeader('user-agent', 'abc/1.2.3')
       .reply(200, VALID_BROWSER_TOKEN_RESPONSE);
@@ -70,7 +67,7 @@ describe('createBrowserTokenMiddleware', () => {
   it('caches a browser token by scope', async () => {
     const fetchSpy = jest.spyOn(fetchModule, 'default');
 
-    nock(SEEK_BROWSER_TOKEN_PLAYGROUND_BASE_URL)
+    nock(SEEK_API_BASE_URL)
       .post(SEEK_BROWSER_TOKEN_PATH)
       .matchHeader('user-agent', 'abc/1.2.3')
       .reply(200, VALID_BROWSER_TOKEN_RESPONSE)
@@ -123,7 +120,7 @@ describe('createBrowserTokenMiddleware', () => {
       .expect(401, 'Nice try'));
 
   it('fails on invalid response from the SEEK API', () => {
-    nock(SEEK_BROWSER_TOKEN_PLAYGROUND_BASE_URL)
+    nock(SEEK_API_BASE_URL)
       .post(SEEK_BROWSER_TOKEN_PATH)
       .matchHeader('user-agent', 'abc/1.2.3')
       .reply(200, INVALID_BROWSER_TOKEN_RESPONSE);

--- a/be/src/browserToken/middleware.ts
+++ b/be/src/browserToken/middleware.ts
@@ -4,7 +4,7 @@ import compose from 'koa-compose';
 import LRU from 'lru-cache';
 import fetch from 'node-fetch';
 
-import { SEEK_BROWSER_TOKEN_PLAYGROUND_URL } from '../constants';
+import { SEEK_BROWSER_TOKEN_URL } from '../constants';
 import { wrapRetriever } from '../getPartnerToken';
 
 import {
@@ -82,7 +82,7 @@ const _createBrowserTokenMiddleware = ({
       userId: hirerId,
     };
 
-    const fetchResponse = await fetch(SEEK_BROWSER_TOKEN_PLAYGROUND_URL, {
+    const fetchResponse = await fetch(SEEK_BROWSER_TOKEN_URL, {
       body: JSON.stringify(seekApiRequest),
       headers: {
         Authorization: `Bearer ${partnerToken}`,

--- a/be/src/constants.ts
+++ b/be/src/constants.ts
@@ -3,7 +3,5 @@ export const SEEK_API_BASE_URL = 'https://graphql.seek.com';
 export const SEEK_API_PATH = '/graphql';
 export const SEEK_API_URL = `${SEEK_API_BASE_URL}${SEEK_API_PATH}`;
 
-export const SEEK_BROWSER_TOKEN_PLAYGROUND_BASE_URL =
-  'https://indie-jessiej-public-test.public.indirect-apply.prod.outfra.xyz';
 export const SEEK_BROWSER_TOKEN_PATH = '/auth/token';
-export const SEEK_BROWSER_TOKEN_PLAYGROUND_URL = `${SEEK_BROWSER_TOKEN_PLAYGROUND_BASE_URL}${SEEK_BROWSER_TOKEN_PATH}`;
+export const SEEK_BROWSER_TOKEN_URL = `${SEEK_API_BASE_URL}${SEEK_BROWSER_TOKEN_PATH}`;


### PR DESCRIPTION
The same URL can now be used across Playground and live.

Remove references to the old Playground-specific URL which wasn't intended for external use.