### PR TITLE
refactor: change all storybook braid themes to unified

### DIFF
--- a/fe/lib/components/Example/Example.stories.tsx
+++ b/fe/lib/components/Example/Example.stories.tsx
@@ -12,8 +12,8 @@ storiesOf('Example', module)
   .add('Custom message', () => (
     <Example message={`${text('message', 'Hello There.')}`} />
   ))
-  .addDecorator((story) => (
-    <BraidLoadableProvider themeName="seekAnz">
+  .addDecorator(story => (
+    <BraidLoadableProvider themeName="seekUnifiedBeta">
       <Box paddingX="gutter" paddingY="large">
         {story()}
       </Box>

--- a/fe/lib/components/Example/Example.stories.tsx
+++ b/fe/lib/components/Example/Example.stories.tsx
@@ -12,7 +12,7 @@ storiesOf('Example', module)
   .add('Custom message', () => (
     <Example message={`${text('message', 'Hello There.')}`} />
   ))
-  .addDecorator(story => (
+  .addDecorator((story) => (
     <BraidLoadableProvider themeName="seekUnifiedBeta">
       <Box paddingX="gutter" paddingY="large">
         {story()}

--- a/fe/lib/components/QuestionnaireBuilder/app.stories.tsx
+++ b/fe/lib/components/QuestionnaireBuilder/app.stories.tsx
@@ -8,8 +8,8 @@ import { QuestionnaireBuilder } from './QuestionnaireBuilder/QuestionnaireBuilde
 
 storiesOf('QuestionnaireBuilder', module)
   .add('Builder', () => <QuestionnaireBuilder />)
-  .addDecorator((story) => (
-    <BraidLoadableProvider themeName="seekAnz">
+  .addDecorator(story => (
+    <BraidLoadableProvider themeName="seekUnifiedBeta">
       <Box paddingX="gutter" paddingY="large">
         {story()}
       </Box>

--- a/fe/lib/components/QuestionnaireBuilder/app.stories.tsx
+++ b/fe/lib/components/QuestionnaireBuilder/app.stories.tsx
@@ -8,7 +8,7 @@ import { QuestionnaireBuilder } from './QuestionnaireBuilder/QuestionnaireBuilde
 
 storiesOf('QuestionnaireBuilder', module)
   .add('Builder', () => <QuestionnaireBuilder />)
-  .addDecorator(story => (
+  .addDecorator((story) => (
     <BraidLoadableProvider themeName="seekUnifiedBeta">
       <Box paddingX="gutter" paddingY="large">
         {story()}

--- a/fe/lib/components/QuestionnaireBuilder/components/GraphqlQueryRenderer/GraphqlQueryRenderer.stories.tsx
+++ b/fe/lib/components/QuestionnaireBuilder/components/GraphqlQueryRenderer/GraphqlQueryRenderer.stories.tsx
@@ -42,8 +42,8 @@ storiesOf('QuestionnaireBuilder', module)
       hirerId="Test:hirer:id"
     />
   ))
-  .addDecorator((story) => (
-    <BraidLoadableProvider themeName="seekAnz">
+  .addDecorator(story => (
+    <BraidLoadableProvider themeName="seekUnifiedBeta">
       <Box paddingX="gutter" paddingY="large">
         {story()}
       </Box>

--- a/fe/lib/components/QuestionnaireBuilder/components/GraphqlQueryRenderer/GraphqlQueryRenderer.stories.tsx
+++ b/fe/lib/components/QuestionnaireBuilder/components/GraphqlQueryRenderer/GraphqlQueryRenderer.stories.tsx
@@ -42,7 +42,7 @@ storiesOf('QuestionnaireBuilder', module)
       hirerId="Test:hirer:id"
     />
   ))
-  .addDecorator(story => (
+  .addDecorator((story) => (
     <BraidLoadableProvider themeName="seekUnifiedBeta">
       <Box paddingX="gutter" paddingY="large">
         {story()}


### PR DESCRIPTION
Cleaning up the other themes and making them all the same. I noticed a bug when switching between stories of different themes it would not load the CSS, this only happened in the built version of storybook (not dev).

In addition, eventually I would like to eventually make the required wrapping `BraidLoadableProvider` a util we can include or add to all stories via global config. 