### PR TITLE
feat: add JobCategorySelect component

### DIFF
--- a/.changeset/lemon-worms-flow.md
+++ b/.changeset/lemon-worms-flow.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': minor
+---
+
+Add Job Category Select component

--- a/fe/lib/components/JobCategorySelect/JobCategoriesSelect.stories.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategoriesSelect.stories.tsx
@@ -20,7 +20,7 @@ storiesOf('JobCategories', module)
   .add('Job Category Select', () => (
     <JobCategorySelect id="jobCategories" schemeId="seekAnz" />
   ))
-  .addDecorator(story => (
+  .addDecorator((story) => (
     <ApolloProvider client={mockClient}>
       <BraidLoadableProvider themeName="seekUnifiedBeta">
         <Box paddingX="gutter" paddingY="large">

--- a/fe/lib/components/JobCategorySelect/JobCategoriesSelect.stories.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategoriesSelect.stories.tsx
@@ -1,0 +1,31 @@
+import 'braid-design-system/reset';
+
+import { Box, BraidLoadableProvider } from 'braid-design-system';
+import { createMockClient } from 'mock-apollo-client';
+import React from 'react';
+import { ApolloProvider } from 'react-apollo';
+import { storiesOf } from 'sku/@storybook/react';
+
+import { JobCategorySelect } from './JobCategorySelect';
+import { mockJobCategories } from './__fixtures__/jobCategories';
+import { JOB_CATEGORIES } from './queries';
+
+const mockClient = createMockClient();
+
+mockClient.setRequestHandler(JOB_CATEGORIES, () =>
+  Promise.resolve({ data: mockJobCategories }),
+);
+
+storiesOf('JobCategories', module)
+  .add('Job Category Select', () => (
+    <JobCategorySelect id="jobCategories" schemeId="seekAnz" />
+  ))
+  .addDecorator(story => (
+    <ApolloProvider client={mockClient}>
+      <BraidLoadableProvider themeName="seekUnifiedBeta">
+        <Box paddingX="gutter" paddingY="large">
+          {story()}
+        </Box>
+      </BraidLoadableProvider>
+    </ApolloProvider>
+  ));

--- a/fe/lib/components/JobCategorySelect/JobCategorySelect.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelect.tsx
@@ -1,0 +1,83 @@
+import { useQuery } from '@apollo/react-hooks';
+import ApolloClient from 'apollo-client';
+import {
+  Dropdown,
+  FieldMessage,
+  Loader,
+  Stack,
+  Text,
+} from 'braid-design-system';
+import React, { ComponentPropsWithRef, forwardRef, useState } from 'react';
+
+import { JobCategory } from '../../types/seek.graphql';
+
+import JobCategorySelectInput from './JobCategorySelectInput';
+import { JOB_CATEGORIES } from './queries';
+
+interface FieldProps extends ComponentPropsWithRef<typeof Dropdown> {}
+
+interface Props extends Omit<FieldProps, 'value' | 'onChange' | 'children'> {
+  client?: ApolloClient<unknown>;
+  schemeId: string;
+  onSelect?: (jobCategory: JobCategory) => void;
+}
+
+export const JobCategorySelect = forwardRef<HTMLInputElement, Props>(
+  ({ schemeId, onSelect, client, ...restProps }, forwardedRef) => {
+    const {
+      data: categoriesData,
+      loading: categoriesLoading,
+      error: categoriesError,
+    } = useQuery(JOB_CATEGORIES, {
+      ...(client && { client }),
+      fetchPolicy: 'no-cache',
+      variables: {
+        schemeId,
+      },
+    });
+
+    const [selectedJobCategoryId, setselectedJobCategoryId] = useState('');
+
+    const handleJobCategoriesSelect = (selectedJobCategory: JobCategory) => {
+      if (onSelect) {
+        onSelect(selectedJobCategory);
+      }
+      if (selectedJobCategory?.id?.value) {
+        setselectedJobCategoryId(selectedJobCategory.id.value);
+      }
+    };
+
+    return (
+      <>
+        {categoriesLoading ? (
+          <Stack space="medium">
+            <Text>Loading all categories</Text>
+            <Loader size="xsmall" />
+          </Stack>
+        ) : (
+          categoriesData?.jobCategories && (
+            <JobCategorySelectInput
+              onSelect={handleJobCategoriesSelect}
+              jobCategories={categoriesData.jobCategories}
+              {...restProps}
+            />
+          )
+        )}
+        <input
+          type="hidden"
+          name={name}
+          value={selectedJobCategoryId}
+          ref={forwardedRef}
+          readOnly
+        />
+        {categoriesError && (
+          <FieldMessage
+            id="selectError"
+            message="Error fetching job category, please try again"
+            tone="critical"
+          />
+        )}
+      </>
+    );
+  },
+);

--- a/fe/lib/components/JobCategorySelect/JobCategorySelect.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelect.tsx
@@ -36,14 +36,14 @@ export const JobCategorySelect = forwardRef<HTMLInputElement, Props>(
       },
     });
 
-    const [selectedJobCategoryId, setselectedJobCategoryId] = useState('');
+    const [selectedJobCategoryId, setSelectedJobCategoryId] = useState('');
 
     const handleJobCategoriesSelect = (selectedJobCategory: JobCategory) => {
       if (onSelect) {
         onSelect(selectedJobCategory);
       }
       if (selectedJobCategory?.id?.value) {
-        setselectedJobCategoryId(selectedJobCategory.id.value);
+        setSelectedJobCategoryId(selectedJobCategory.id.value);
       }
     };
 

--- a/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
@@ -1,4 +1,4 @@
-import { Column, Columns, Dropdown, Stack } from 'braid-design-system';
+import { Column, Columns, Dropdown } from 'braid-design-system';
 import React, { useEffect, useState } from 'react';
 
 import { JobCategory } from '../../types/seek.graphql';

--- a/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
@@ -1,0 +1,96 @@
+import { Column, Columns, Dropdown, Stack } from 'braid-design-system';
+import React, { useEffect, useState } from 'react';
+
+import { JobCategory } from '../../types/seek.graphql';
+import { findCategory } from '../../utils';
+
+interface Props {
+  jobCategories: JobCategory[];
+  onSelect: (jobCategory: JobCategory) => void;
+}
+
+const JobCategorySelectInput = ({
+  jobCategories,
+  onSelect,
+  ...restProps
+}: Props) => {
+  const [selectedParentCategoryId, setSelectedParentCategoryId] = useState('');
+  const [selectedChildCategoryId, setSelectedChildCategoryId] = useState('');
+  const [childCategories, setChildCategories] = useState<JobCategory[]>();
+
+  useEffect(() => {
+    if (selectedParentCategoryId !== '') {
+      const parentCategory = findCategory(
+        jobCategories,
+        selectedParentCategoryId,
+      );
+
+      if (parentCategory?.children) {
+        setChildCategories(parentCategory.children);
+        setSelectedChildCategoryId('');
+        onSelect(parentCategory);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedParentCategoryId]);
+
+  useEffect(() => {
+    if (selectedChildCategoryId !== '' && childCategories) {
+      const childCategory = findCategory(
+        childCategories,
+        selectedChildCategoryId,
+      );
+      if (childCategory) {
+        onSelect(childCategory);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedChildCategoryId, childCategories]);
+
+  return (
+    <Stack space="medium">
+      <Columns space="small">
+        <Column>
+          <Dropdown
+            id="jobCategoriesSelect"
+            label="Job category"
+            placeholder="Please select a job category"
+            onChange={event =>
+              setSelectedParentCategoryId(event.currentTarget.value)
+            }
+            value={selectedParentCategoryId}
+            {...restProps}
+          >
+            {jobCategories.map(({ name, id }) => (
+              <option key={id.value} value={id.value}>
+                {name}
+              </option>
+            ))}
+          </Dropdown>
+        </Column>
+        <Column>
+          {childCategories && (
+            <Dropdown
+              id="subJobCategoriesSelect"
+              label="Sub category"
+              placeholder="Please select a sub category"
+              onChange={event =>
+                setSelectedChildCategoryId(event.currentTarget.value)
+              }
+              value={selectedChildCategoryId}
+              {...restProps}
+            >
+              {childCategories.map(({ name, id }) => (
+                <option key={id.value} value={id.value}>
+                  {name}
+                </option>
+              ))}
+            </Dropdown>
+          )}
+        </Column>
+      </Columns>
+    </Stack>
+  );
+};
+
+export default JobCategorySelectInput;

--- a/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
@@ -48,48 +48,46 @@ const JobCategorySelectInput = ({
   }, [selectedChildCategoryId, childCategories]);
 
   return (
-    <Stack space="medium">
-      <Columns space="small">
-        <Column>
+    <Columns space="small">
+      <Column>
+        <Dropdown
+          id="jobCategoriesSelect"
+          label="Job category"
+          placeholder="Please select a job category"
+          onChange={(event) =>
+            setSelectedParentCategoryId(event.currentTarget.value)
+          }
+          value={selectedParentCategoryId}
+          {...restProps}
+        >
+          {jobCategories.map(({ name, id }) => (
+            <option key={id.value} value={id.value}>
+              {name}
+            </option>
+          ))}
+        </Dropdown>
+      </Column>
+      <Column>
+        {childCategories && (
           <Dropdown
-            id="jobCategoriesSelect"
-            label="Job category"
-            placeholder="Please select a job category"
+            id="subJobCategoriesSelect"
+            label="Sub category"
+            placeholder="Please select a sub category"
             onChange={(event) =>
-              setSelectedParentCategoryId(event.currentTarget.value)
+              setSelectedChildCategoryId(event.currentTarget.value)
             }
-            value={selectedParentCategoryId}
+            value={selectedChildCategoryId}
             {...restProps}
           >
-            {jobCategories.map(({ name, id }) => (
+            {childCategories.map(({ name, id }) => (
               <option key={id.value} value={id.value}>
                 {name}
               </option>
             ))}
           </Dropdown>
-        </Column>
-        <Column>
-          {childCategories && (
-            <Dropdown
-              id="subJobCategoriesSelect"
-              label="Sub category"
-              placeholder="Please select a sub category"
-              onChange={(event) =>
-                setSelectedChildCategoryId(event.currentTarget.value)
-              }
-              value={selectedChildCategoryId}
-              {...restProps}
-            >
-              {childCategories.map(({ name, id }) => (
-                <option key={id.value} value={id.value}>
-                  {name}
-                </option>
-              ))}
-            </Dropdown>
-          )}
-        </Column>
-      </Columns>
-    </Stack>
+        )}
+      </Column>
+    </Columns>
   );
 };
 

--- a/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
@@ -55,7 +55,7 @@ const JobCategorySelectInput = ({
             id="jobCategoriesSelect"
             label="Job category"
             placeholder="Please select a job category"
-            onChange={event =>
+            onChange={(event) =>
               setSelectedParentCategoryId(event.currentTarget.value)
             }
             value={selectedParentCategoryId}
@@ -74,7 +74,7 @@ const JobCategorySelectInput = ({
               id="subJobCategoriesSelect"
               label="Sub category"
               placeholder="Please select a sub category"
-              onChange={event =>
+              onChange={(event) =>
                 setSelectedChildCategoryId(event.currentTarget.value)
               }
               value={selectedChildCategoryId}

--- a/fe/lib/components/JobCategorySelect/README.md
+++ b/fe/lib/components/JobCategorySelect/README.md
@@ -88,7 +88,7 @@ import { JobCategorySelect } from 'wingman-fe';
 const JobCategoryForm = () => {
   const { register, handleSubmit } = useForm();
 
-  const handleFormSubmit = formData => {
+  const handleFormSubmit = (formData) => {
     // submit logic here
   };
 

--- a/fe/lib/components/JobCategorySelect/README.md
+++ b/fe/lib/components/JobCategorySelect/README.md
@@ -22,7 +22,7 @@ Required
 Optional:
 
 - `client`: An `ApolloClient` instance. By default JobCategorySelect uses the client passed down via context, but a different client can be passed in.
-- `onSelect`: Callback function that is supplied a [SEEK JobCategory](https://developer.seek.com/schema/#definition-JobCategory) on job category select.
+- `onSelect`: Callback function that is supplied a [SEEK JobCategory](https://developer.seek.com/schema/#definition-JobCategory) on job category selection.
 
 Extends:
 

--- a/fe/lib/components/JobCategorySelect/README.md
+++ b/fe/lib/components/JobCategorySelect/README.md
@@ -11,7 +11,8 @@ $ yarn add wingman-fe
 
 ## Job Category Select Widget
 
-The JobCategorySelect widget abstracts the `jobCategories` query on SEEK API and provides a select input that returns a SEEK JobCategory. Read more about underlying [`jobCategories` query](https://developer.seek.com/schema/#operation-jobCategories).
+The JobCategorySelect widget abstracts the `jobCategories` query on SEEK API and provides a select input that returns a SEEK JobCategory.
+Read more about underlying [`jobCategories` query](https://developer.seek.com/schema/#operation-jobCategories).
 
 ### Properties
 

--- a/fe/lib/components/JobCategorySelect/README.md
+++ b/fe/lib/components/JobCategorySelect/README.md
@@ -1,6 +1,7 @@
 # JobCategorySelect
 
-A JobCategory select component that provides a full list of parent and child job categories for SEEK. Returns a JobCategory (parent or child) with object identifier on category select.
+A JobCategory select component that provides a full list of parent and child job categories for SEEK.
+Returns a JobCategory (parent or child) with object identifier on category selection.
 
 ## Installation
 

--- a/fe/lib/components/JobCategorySelect/README.md
+++ b/fe/lib/components/JobCategorySelect/README.md
@@ -1,0 +1,109 @@
+# JobCategorySelect
+
+A JobCategory select component that provides a full list of parent and child job categories for SEEK. Returns a JobCategory (parent or child) with object identifier on category select.
+
+## Installation
+
+```shell
+$ yarn add wingman-fe
+```
+
+## Job Category Select Widget
+
+The JobCategorySelect widget abstracts the `jobCategories` query on SEEK API and provides a select input that returns a SEEK JobCategory. Read more about underlying [`jobCategories` query](https://developer.seek.com/schema/#operation-jobCategories).
+
+### Properties
+
+Required
+
+- `schemeId`: The scheme for the location dataset to query.
+
+Optional:
+
+- `client`: An `ApolloClient` instance. By default JobCategorySelect uses the client passed down via context, but a different client can be passed in.
+- `onSelect`: Callback function that is supplied a [SEEK JobCategory](https://developer.seek.com/schema/#definition-JobCategory) on job category select.
+
+Extends:
+
+- You may pass through various HTML input field props including: `id`, `name`, `label`
+
+### Usage
+
+#### Default usage
+
+```javascript
+import { JobCategorySelect } from 'wingman-fe';
+
+// Higher component in tree wraps children in apollo provider
+<JobCategorySelect schemeId="seekAnz" />;
+```
+
+#### Default usage with Apollo Client
+
+```javascript
+import { ApolloClient } from 'apollo-client';
+import { JobCategorySelect } from 'wingman-fe';
+
+// cache and link set-up as required
+
+const client = new ApolloClient({
+  cache,
+  link,
+});
+
+<JobCategorySelect schemeId="seekAnz" client={client} />;
+```
+
+#### onSelect callback usage
+
+```javascript
+import React, { useState } from 'react';
+import { JobCategorySelect } from 'wingman-fe';
+
+// client set-up as per the previous example
+
+const JobCategoryForm = () => {
+  const [jobCategory, setJobCategory] = useState();
+  return (
+    <div>
+      <JobCategorySelect
+        schemeId="seekAnz"
+        client={client}
+        onSelect={setJobCategory}
+      />
+      Your selected job category is: {jobCategory.name}
+    </div>
+  );
+};
+```
+
+#### react-hook-form (controlled form) usage
+
+```javascript
+import { useForm } from 'react-hook-form';
+import { JobCategorySelect } from 'wingman-fe';
+
+// client set-up as per the previous example
+
+const JobCategoryForm = () => {
+  const { register, handleSubmit } = useForm();
+
+  const handleFormSubmit = formData => {
+    // submit logic here
+  };
+
+  return (
+    <form action="" method="post" onSubmit={handleSubmit(handleFormSubmit)}>
+      <JobCategorySelect
+        schemeId="seekAnz"
+        client={client}
+        id="jobCategorySelect"
+        name="jobCategorySelect"
+        label="Job category"
+        ref={register({ required: true })}
+      />
+      <button type="submit">Submit job category</button>
+    </form>
+  );
+};
+```

--- a/fe/lib/components/JobCategorySelect/README.md
+++ b/fe/lib/components/JobCategorySelect/README.md
@@ -16,7 +16,7 @@ The JobCategorySelect widget abstracts the `jobCategories` query on SEEK API and
 
 Required
 
-- `schemeId`: The scheme for the location dataset to query.
+- `schemeId`: The scheme for the job category dataset to query.
 
 Optional:
 
@@ -88,7 +88,7 @@ import { JobCategorySelect } from 'wingman-fe';
 const JobCategoryForm = () => {
   const { register, handleSubmit } = useForm();
 
-  const handleFormSubmit = (formData) => {
+  const handleFormSubmit = formData => {
     // submit logic here
   };
 

--- a/fe/lib/components/JobCategorySelect/__fixtures__/jobCategories.ts
+++ b/fe/lib/components/JobCategorySelect/__fixtures__/jobCategories.ts
@@ -1,0 +1,68 @@
+export const mockJobCategories = {
+  jobCategories: [
+    {
+      id: {
+        value: 'seekAnz:jobCategory:seek:2WejkktVM',
+      },
+      name: 'Accounting',
+      children: [
+        {
+          id: {
+            value: 'seekAnz:jobCategory:seek:CTriSTrf',
+          },
+          name: 'Accounts Payable',
+          parent: {
+            id: {
+              value: 'seekAnz:jobCategory:seek:2WejkktVM',
+            },
+            name: 'Accounting',
+          },
+        },
+        {
+          id: {
+            value: 'seekAnz:jobCategory:seek:2cdSPDcy5',
+          },
+          name: 'Payroll',
+          parent: {
+            id: {
+              value: 'seekAnz:jobCategory:seek:2WejkktVM',
+            },
+            name: 'Accounting',
+          },
+        },
+      ],
+    },
+    {
+      id: {
+        value: 'seekAnz:jobCategory:seek:2Ze2oDqf5',
+      },
+      name: 'Construction',
+      children: [
+        {
+          id: {
+            value: 'seekAnz:jobCategory:seek:vHyJwnCo',
+          },
+          name: 'Estimating',
+          parent: {
+            id: {
+              value: 'seekAnz:jobCategory:seek:2Ze2oDqf5',
+            },
+            name: 'Construction',
+          },
+        },
+        {
+          id: {
+            value: 'seekAnz:jobCategory:seek:2w67bem51',
+          },
+          name: 'Contracts Management',
+          parent: {
+            id: {
+              value: 'seekAnz:jobCategory:seek:2Ze2oDqf5',
+            },
+            name: 'Construction',
+          },
+        },
+      ],
+    },
+  ],
+};

--- a/fe/lib/components/JobCategorySelect/index.ts
+++ b/fe/lib/components/JobCategorySelect/index.ts
@@ -1,0 +1,1 @@
+export { JobCategorySelect } from './JobCategorySelect';

--- a/fe/lib/components/JobCategorySelect/queries.ts
+++ b/fe/lib/components/JobCategorySelect/queries.ts
@@ -47,13 +47,11 @@ export const JOB_CATEGORY_SUGGESTION = gql`
   query(
     $positionProfile: JobCategorySuggestionPositionProfileInput!
     $schemeId: String!
-    $hirerId: String
     $first: Int
   ) {
     jobCategorySuggestions(
       positionProfile: $positionProfile
       schemeId: $schemeId
-      hirerId: $hirerId
       first: $first
     ) {
       jobCategory {

--- a/fe/lib/components/JobCategorySelect/queries.ts
+++ b/fe/lib/components/JobCategorySelect/queries.ts
@@ -1,0 +1,66 @@
+import { gql } from 'apollo-boost';
+
+const JOB_CATEGORY_ATTRIBUTES = gql`
+  fragment jobCategoryAttributes on JobCategory {
+    id {
+      value
+    }
+    name
+  }
+`;
+
+const NESTED_JOB_CATEGORY_ATTRIBUTES = gql`
+  fragment nestedJobCategoryAttributes on JobCategory {
+    ...jobCategoryAttributes
+    parent {
+      ...jobCategoryAttributes
+    }
+    children {
+      ...jobCategoryAttributes
+      parent {
+        ...jobCategoryAttributes
+      }
+    }
+  }
+  ${JOB_CATEGORY_ATTRIBUTES}
+`;
+
+export const JOB_CATEGORY = gql`
+  query($id: String!) {
+    jobCategory(id: $id) {
+      ...nestedJobCategoryAttributes
+    }
+  }
+  ${NESTED_JOB_CATEGORY_ATTRIBUTES}
+`;
+
+export const JOB_CATEGORIES = gql`
+  query($schemeId: String!) {
+    jobCategories(schemeId: $schemeId) {
+      ...nestedJobCategoryAttributes
+    }
+  }
+  ${NESTED_JOB_CATEGORY_ATTRIBUTES}
+`;
+
+export const JOB_CATEGORY_SUGGESTION = gql`
+  query(
+    $positionProfile: JobCategorySuggestionPositionProfileInput!
+    $schemeId: String!
+    $hirerId: String
+    $first: Int
+  ) {
+    jobCategorySuggestions(
+      positionProfile: $positionProfile
+      schemeId: $schemeId
+      hirerId: $hirerId
+      first: $first
+    ) {
+      jobCategory {
+        ...nestedJobCategoryAttributes
+      }
+      confidence
+    }
+  }
+  ${NESTED_JOB_CATEGORY_ATTRIBUTES}
+`;

--- a/fe/lib/components/index.ts
+++ b/fe/lib/components/index.ts
@@ -1,2 +1,3 @@
 export { Example } from './Example/Example';
 export { LocationSuggest } from './LocationSuggest/LocationSuggest';
+export { JobCategorySelect } from './JobCategorySelect/JobCategorySelect';

--- a/fe/lib/utils/findCategory.ts
+++ b/fe/lib/utils/findCategory.ts
@@ -1,4 +1,4 @@
 import { JobCategory } from '../types/seek.graphql';
 
 export const findCategory = (jobCategories: JobCategory[], id: string) =>
-  jobCategories.find(category => category.id.value === id);
+  jobCategories.find((category) => category.id.value === id);

--- a/fe/lib/utils/findCategory.ts
+++ b/fe/lib/utils/findCategory.ts
@@ -1,0 +1,4 @@
+import { JobCategory } from '../types/seek.graphql';
+
+export const findCategory = (jobCategories: JobCategory[], id: string) =>
+  jobCategories.find(category => category.id.value === id);

--- a/fe/lib/utils/index.ts
+++ b/fe/lib/utils/index.ts
@@ -1,0 +1,1 @@
+export { findCategory } from './findCategory';


### PR DESCRIPTION
## Overview
Pulls in the JobCategorySelect. The JobCategory select component provides a full list of parent and child job categories for SEEK. Returns a JobCategory (parent or child) with object identifier on category select.

This component can be used to fetch a job category or used inline within a form that generates the input structure for other queries and mutations. For example, you can use this component to resolve a job category OID for PositionPosting.

## Includes:
- Storybook example, only resolves a mock query with 2 job categories and 2 child job categories each
- Readme with usage instructions.