### PR TITLE
fix(JobCategorySuggest): module resolution

### DIFF
--- a/.changeset/late-chicken-compete.md
+++ b/.changeset/late-chicken-compete.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': patch
+---
+
+JobCategorySuggest: Resolve module imports using relative paths to fix consumer errors

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
@@ -7,7 +7,7 @@ import { useDebounce } from 'use-debounce';
 import {
   JobCategorySuggestionChoice,
   JobCategorySuggestionPositionProfileInput,
-} from 'lib/types/seek.graphql';
+} from '../../types/seek.graphql';
 
 import JobCategorySuggestChoices from './JobCategorySuggestChoices';
 import { JOB_CATEGORY_SUGGESTION } from './queries';

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -4,8 +4,8 @@ import React, { forwardRef, useState } from 'react';
 import {
   JobCategory,
   JobCategorySuggestionChoice,
-} from 'lib/types/seek.graphql';
-import { flattenResourceByKey } from 'lib/utils';
+} from '../../types/seek.graphql';
+import { flattenResourceByKey } from '../../utils';
 
 interface Props {
   choices: JobCategorySuggestionChoice[];


### PR DESCRIPTION
As we are not compiling our packages we cannot resolve `lib/xxx`. Switches import paths to relative to fix import error within consumers. 