### PR TITLE
Fix(JobCategorySuggest): field props not being passed through correctly 

### DIFF
--- a/.changeset/twelve-lamps-cover.md
+++ b/.changeset/twelve-lamps-cover.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': minor
+---
+
+Enable `name`, `message` and `tone` to be passed in as props for JobCategorySuggest

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.stories.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.stories.tsx
@@ -4,6 +4,7 @@ import { Box, BraidLoadableProvider } from 'braid-design-system';
 import { createMockClient } from 'mock-apollo-client';
 import React from 'react';
 import { ApolloProvider } from 'react-apollo';
+import { select, text } from 'sku/@storybook/addon-knobs';
 import { storiesOf } from 'sku/@storybook/react';
 
 import { JobCategorySuggest } from './JobCategorySuggest';
@@ -23,9 +24,11 @@ storiesOf('JobCategories', module)
       positionProfile={{
         positionTitle: `Senior Developer`,
       }}
+      message={text('message', 'Select a job category')}
+      tone={select('tone', ['neutral', 'critical'], undefined)}
     />
   ))
-  .addDecorator((story) => (
+  .addDecorator(story => (
     <ApolloProvider client={mockClient}>
       <BraidLoadableProvider themeName="seekUnifiedBeta">
         <Box paddingX="gutter" paddingY="large">

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.stories.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.stories.tsx
@@ -28,7 +28,7 @@ storiesOf('JobCategories', module)
       tone={select('tone', ['neutral', 'critical'], undefined)}
     />
   ))
-  .addDecorator(story => (
+  .addDecorator((story) => (
     <ApolloProvider client={mockClient}>
       <BraidLoadableProvider themeName="seekUnifiedBeta">
         <Box paddingX="gutter" paddingY="large">

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
@@ -1,6 +1,6 @@
 import { useLazyQuery } from '@apollo/react-hooks';
 import ApolloClient from 'apollo-client';
-import { FieldMessage, Loader, Stack, Text } from 'braid-design-system';
+import { FieldMessage, Loader, Radio, Stack, Text } from 'braid-design-system';
 import React, { ComponentPropsWithRef, forwardRef, useEffect } from 'react';
 import { useDebounce } from 'use-debounce';
 
@@ -12,9 +12,11 @@ import {
 import JobCategorySuggestChoices from './JobCategorySuggestChoices';
 import { JOB_CATEGORY_SUGGESTION } from './queries';
 
-interface FieldProps extends ComponentPropsWithRef<typeof FieldMessage> {}
+interface RadioProps extends ComponentPropsWithRef<typeof Radio> {}
+interface FieldMessageProps
+  extends Omit<ComponentPropsWithRef<typeof FieldMessage>, 'tone' | 'id'> {}
 
-interface Props extends Partial<FieldProps> {
+interface Props extends Partial<RadioProps>, FieldMessageProps {
   client?: ApolloClient<unknown>;
   schemeId: string;
   debounceDelay?: number;
@@ -32,7 +34,7 @@ export const JobCategorySuggest = forwardRef<HTMLInputElement, Props>(
       positionProfile,
       debounceDelay = 250,
       showConfidence,
-      message,
+      message = '',
       tone,
       ...restProps
     },
@@ -83,13 +85,11 @@ export const JobCategorySuggest = forwardRef<HTMLInputElement, Props>(
             />
           )
         )}
-        {message && (
-          <FieldMessage
-            id="jobCategorySuggestMessage"
-            message={message}
-            tone={tone}
-          />
-        )}
+        <FieldMessage
+          message={message}
+          id="jobCategorySuggestMessage"
+          tone={tone}
+        />
         {suggestError && (
           <FieldMessage
             id="suggestError"

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
@@ -1,7 +1,7 @@
 import { useLazyQuery } from '@apollo/react-hooks';
 import ApolloClient from 'apollo-client';
 import { FieldMessage, Loader, Stack, Text } from 'braid-design-system';
-import React, { forwardRef, useEffect } from 'react';
+import React, { ComponentPropsWithRef, forwardRef, useEffect } from 'react';
 import { useDebounce } from 'use-debounce';
 
 import {
@@ -12,7 +12,9 @@ import {
 import JobCategorySuggestChoices from './JobCategorySuggestChoices';
 import { JOB_CATEGORY_SUGGESTION } from './queries';
 
-interface Props {
+interface FieldProps extends ComponentPropsWithRef<typeof FieldMessage> {}
+
+interface Props extends Partial<FieldProps> {
   client?: ApolloClient<unknown>;
   schemeId: string;
   debounceDelay?: number;
@@ -30,6 +32,9 @@ export const JobCategorySuggest = forwardRef<HTMLInputElement, Props>(
       positionProfile,
       debounceDelay = 250,
       showConfidence,
+      message,
+      tone,
+      ...restProps
     },
     forwardedRef,
   ) => {
@@ -73,8 +78,17 @@ export const JobCategorySuggest = forwardRef<HTMLInputElement, Props>(
               ref={forwardedRef}
               onSelect={onSelect}
               showConfidence={showConfidence}
+              tone={tone}
+              {...restProps}
             />
           )
+        )}
+        {message && (
+          <FieldMessage
+            id="jobCategorySuggestMessage"
+            message={message}
+            tone={tone}
+          />
         )}
         {suggestError && (
           <FieldMessage

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -1,5 +1,5 @@
 import { Radio, Stack, Strong, Text } from 'braid-design-system';
-import React, { forwardRef, useState } from 'react';
+import React, { ComponentPropsWithRef, forwardRef, useState } from 'react';
 
 import {
   JobCategory,
@@ -7,7 +7,9 @@ import {
 } from '../../types/seek.graphql';
 import { flattenResourceByKey } from '../../utils';
 
-interface Props {
+interface Tone extends Pick<ComponentPropsWithRef<typeof Radio>, 'tone'> {}
+
+interface Props extends Tone {
   choices: JobCategorySuggestionChoice[];
   onSelect?: (jobCategorySuggestionChoice: JobCategorySuggestionChoice) => void;
   showConfidence?: boolean;

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -1,5 +1,5 @@
 import { Radio, Stack, Strong, Text } from 'braid-design-system';
-import React, { ComponentPropsWithRef, forwardRef, useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 
 import {
   JobCategory,
@@ -7,9 +7,7 @@ import {
 } from '../../types/seek.graphql';
 import { flattenResourceByKey } from '../../utils';
 
-interface Tone extends Pick<ComponentPropsWithRef<typeof Radio>, 'tone'> {}
-
-interface Props extends Tone {
+interface Props {
   choices: JobCategorySuggestionChoice[];
   onSelect?: (jobCategorySuggestionChoice: JobCategorySuggestionChoice) => void;
   showConfidence?: boolean;
@@ -23,7 +21,7 @@ const getJobCategoryName = (jobCategory: JobCategory): string =>
 
 const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
   (
-    { choices, onSelect, showConfidence = false, tone, ...restProps },
+    { choices, onSelect, showConfidence = false, ...restProps },
     forwardedRef,
   ) => {
     const [selectedJobCategory, setSelectedJobCategory] = useState<
@@ -54,7 +52,6 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
               id={id.value}
               label={getJobCategoryName(jobCategory)}
               ref={forwardedRef}
-              tone={tone}
               {...restProps}
             >
               {showConfidence && (

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -1,5 +1,5 @@
 import { Radio, Stack, Strong, Text } from 'braid-design-system';
-import React, { ComponentPropsWithRef, forwardRef, useState } from 'react';
+import React, { ComponentProps, forwardRef, useState } from 'react';
 
 import {
   JobCategory,
@@ -7,12 +7,11 @@ import {
 } from '../../types/seek.graphql';
 import { flattenResourceByKey } from '../../utils';
 
-interface Tone extends Pick<ComponentPropsWithRef<typeof Radio>, 'tone'> {}
-
-interface Props extends Tone {
+interface Props {
   choices: JobCategorySuggestionChoice[];
   onSelect?: (jobCategorySuggestionChoice: JobCategorySuggestionChoice) => void;
   showConfidence?: boolean;
+  tone: ComponentProps<typeof Radio>['tone'];
 }
 
 const getJobCategoryName = (jobCategory: JobCategory): string =>

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -1,5 +1,5 @@
 import { Radio, Stack, Strong, Text } from 'braid-design-system';
-import React, { forwardRef, useState } from 'react';
+import React, { ComponentPropsWithRef, forwardRef, useState } from 'react';
 
 import {
   JobCategory,
@@ -7,7 +7,9 @@ import {
 } from '../../types/seek.graphql';
 import { flattenResourceByKey } from '../../utils';
 
-interface Props {
+interface Tone extends Pick<ComponentPropsWithRef<typeof Radio>, 'tone'> {}
+
+interface Props extends Tone {
   choices: JobCategorySuggestionChoice[];
   onSelect?: (jobCategorySuggestionChoice: JobCategorySuggestionChoice) => void;
   showConfidence?: boolean;
@@ -20,7 +22,10 @@ const getJobCategoryName = (jobCategory: JobCategory): string =>
     .join(' > ');
 
 const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
-  ({ choices, onSelect, showConfidence = false }, forwardedRef) => {
+  (
+    { choices, onSelect, showConfidence = false, tone, ...restProps },
+    forwardedRef,
+  ) => {
     const [selectedJobCategory, setSelectedJobCategory] = useState<
       JobCategory
     >();
@@ -46,10 +51,11 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
               checked={id.value === selectedJobCategory?.id.value}
               onChange={() => handleChoiceSelect(choice)}
               value={id.value}
-              name="jobCategorySuggestion"
               id={id.value}
               label={getJobCategoryName(jobCategory)}
               ref={forwardedRef}
+              tone={tone}
+              {...restProps}
             >
               {showConfidence && (
                 <Text tone="secondary" size="small">


### PR DESCRIPTION
# Overview
When using JobCategorySuggest as a field in a form you could not pass through props to the underlying fields

# Changes
- Removes hardcoded "name" prop on radio
- Creates a new field message to receive passed in "message" and "tone" 
- Pass tone, and spreads extra props (name and other field props) to the radio button