### PR TITLE
fix(jobCategorySuggest): Make `tone` and `message` props optional

### DIFF
--- a/.changeset/seven-monkeys-retire.md
+++ b/.changeset/seven-monkeys-retire.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': patch
+---
+
+JobCategorySuggest: `tone` and `message` props are now optional

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
@@ -1,7 +1,12 @@
 import { useLazyQuery } from '@apollo/react-hooks';
 import ApolloClient from 'apollo-client';
 import { FieldMessage, Loader, Radio, Stack, Text } from 'braid-design-system';
-import React, { ComponentPropsWithRef, forwardRef, useEffect } from 'react';
+import React, {
+  ComponentProps,
+  ComponentPropsWithRef,
+  forwardRef,
+  useEffect,
+} from 'react';
 import { useDebounce } from 'use-debounce';
 
 import {
@@ -13,16 +18,15 @@ import JobCategorySuggestChoices from './JobCategorySuggestChoices';
 import { JOB_CATEGORY_SUGGESTION } from './queries';
 
 interface RadioProps extends ComponentPropsWithRef<typeof Radio> {}
-interface FieldMessageProps
-  extends Omit<ComponentPropsWithRef<typeof FieldMessage>, 'tone' | 'id'> {}
 
-interface Props extends Partial<RadioProps>, FieldMessageProps {
+interface Props extends Partial<RadioProps> {
   client?: ApolloClient<unknown>;
   schemeId: string;
   debounceDelay?: number;
   positionProfile: JobCategorySuggestionPositionProfileInput;
   onSelect?: (jobCategorySuggestionChoice: JobCategorySuggestionChoice) => void;
   showConfidence?: boolean;
+  message?: ComponentProps<typeof FieldMessage>['message'];
 }
 
 export const JobCategorySuggest = forwardRef<HTMLInputElement, Props>(

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -11,7 +11,7 @@ interface Props {
   choices: JobCategorySuggestionChoice[];
   onSelect?: (jobCategorySuggestionChoice: JobCategorySuggestionChoice) => void;
   showConfidence?: boolean;
-  tone: ComponentProps<typeof Radio>['tone'];
+  tone?: ComponentProps<typeof Radio>['tone'];
 }
 
 const getJobCategoryName = (jobCategory: JobCategory): string =>


### PR DESCRIPTION
## Changes
- Sets `tone` on `JobCategorySuggestChoices.tsx ` as optional
- Sets `message` on main parent component `JobCategorySuggest.tsx` as optional