### PR TITLE
Fix questionnaire builder mutation variables

### DIFF
--- a/.changeset/rotten-walls-sit.md
+++ b/.changeset/rotten-walls-sit.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': patch
+---
+
+Fix questionnaire builder mutation variables

--- a/fe/lib/components/QuestionnaireBuilder/components/GraphqlQueryRenderer/GraphqlQueryRenderer.tsx
+++ b/fe/lib/components/QuestionnaireBuilder/components/GraphqlQueryRenderer/GraphqlQueryRenderer.tsx
@@ -59,7 +59,7 @@ export const convertComponentsToMutationVariables = (
   hirerId: string,
 ): MutationVariables => {
   const questionnaireComponents: MutationQuestionnaireComponents[] = components.map(
-    (component) =>
+    component =>
       component.componentTypeCode === 'Question'
         ? {
             componentTypeCode: 'Question',
@@ -86,7 +86,11 @@ export const convertComponentsToMutationVariables = (
 
 const renderVariablesPane = (components: FormComponent[], hirerId: string) => {
   if (components.length > 0 && hirerId) {
-    const variables = convertComponentsToMutationVariables(components, hirerId);
+    const { variables } = convertComponentsToMutationVariables(
+      components,
+      hirerId,
+    );
+
     const variablesString = JSON.stringify(variables, null, 2);
 
     return (

--- a/fe/lib/components/QuestionnaireBuilder/components/GraphqlQueryRenderer/GraphqlQueryRenderer.tsx
+++ b/fe/lib/components/QuestionnaireBuilder/components/GraphqlQueryRenderer/GraphqlQueryRenderer.tsx
@@ -59,7 +59,7 @@ export const convertComponentsToMutationVariables = (
   hirerId: string,
 ): MutationVariables => {
   const questionnaireComponents: MutationQuestionnaireComponents[] = components.map(
-    component =>
+    (component) =>
       component.componentTypeCode === 'Question'
         ? {
             componentTypeCode: 'Question',


### PR DESCRIPTION
Right now we produce JSON with top-level `variables` and `valid` properties.  If you copy and paste this in to the Playground it will fail; you just need the variables.

This doesn't bother with `valid` as it doesn't seem to be possible to create an invalid questionnaire with the UI.