### PR TITLE
Update to react-hook-form@6

### DIFF
--- a/fe/lib/components/QuestionnaireBuilder/QuestionnaireBuilder/FormBuilder/components/NewPrivacyConsentForm/NewPrivacyConsentForm.tsx
+++ b/fe/lib/components/QuestionnaireBuilder/QuestionnaireBuilder/FormBuilder/components/NewPrivacyConsentForm/NewPrivacyConsentForm.tsx
@@ -1,3 +1,4 @@
+import { yupResolver } from '@hookform/resolvers';
 import {
   Actions,
   Box,
@@ -44,7 +45,7 @@ export default ({
   const { dispatch } = useContext(StateContext);
 
   const { control, handleSubmit, errors } = useForm<FormValues>({
-    validationSchema: schema,
+    resolver: yupResolver(schema),
   });
 
   const saveThisPrivacyConsent = (formData: FormValues) => {
@@ -70,24 +71,32 @@ export default ({
             </Heading>
           </Box>
           <Controller
-            as={TextField}
+            render={(formProps) => (
+              <TextField
+                id="url"
+                label="URL"
+                message={errors.url?.message}
+                tone={errors.url ? 'critical' : undefined}
+                {...formProps}
+              />
+            )}
             control={control}
-            id="url"
             name="url"
             value=""
             defaultValue={initialValues.privacyPolicyUrl.url}
-            label="URL"
-            message={errors.url?.message}
-            tone={errors.url ? 'critical' : undefined}
           />
           <Controller
-            as={TextField}
+            render={(formProps) => (
+              <TextField
+                id="description"
+                label="Description"
+                message={errors.description?.message}
+                tone={errors.description ? 'critical' : undefined}
+                {...formProps}
+              />
+            )}
             control={control}
-            id="description"
             name="description"
-            label="Description"
-            message={errors.description?.message}
-            tone={errors.description ? 'critical' : undefined}
             value=""
             defaultValue={
               initialValues.descriptionHtml ||

--- a/fe/package.json
+++ b/fe/package.json
@@ -4,6 +4,7 @@
   },
   "dependencies": {
     "@apollo/react-hooks": "^3.1.5",
+    "@hookform/resolvers": "^0.0.5",
     "@types/uuid": "^8.0.0",
     "@types/yup": "^0.29.2",
     "apollo-boost": "^0.4.9",
@@ -11,7 +12,7 @@
     "content-disposition": "^0.5.3",
     "graphql": "^15.0.0",
     "react-apollo": "^3.1.5",
-    "react-hook-form": "^5.7.2",
+    "react-hook-form": "^6.0.2",
     "runtypes": "^4.2.0",
     "use-debounce": "^3.4.2",
     "uuid": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1937,6 +1937,11 @@
   dependencies:
     "@hapi/hoek" "^8.3.0"
 
+"@hookform/resolvers@^0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-0.0.5.tgz#eddf423734c35b1b02a048528be80a64f67781ab"
+  integrity sha512-EDp4nclPiE4slWS/v9Q/Ad9ETdqC4zLivDOkj+PCvsXc2mpe9YlkXYM4N3iR9cdcSKA34EG1bTq4+5JG8GaYAQ==
+
 "@iarna/cli@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@iarna/cli/-/cli-1.2.0.tgz#0f7af5e851afe895104583c4ca07377a8094d641"
@@ -17286,10 +17291,10 @@ react-helmet-async@^1.0.2:
     react-fast-compare "^3.0.1"
     shallowequal "^1.1.0"
 
-react-hook-form@^5.7.2:
-  version "5.7.2"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-5.7.2.tgz#a84e259e5d37dd30949af4f79c4dac31101b79ac"
-  integrity sha512-bJvY348vayIvEUmSK7Fvea/NgqbT2racA2IbnJz/aPlQ3GBtaTeDITH6rtCa6y++obZzG6E3Q8VuoXPir7QYUg==
+react-hook-form@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.0.2.tgz#4a16064b9a47509736f1b1afe84ad87cac617e58"
+  integrity sha512-8KR2bJbwFLuDci/c3tbmCLrkAsHPV7bKGbbXoCokhWx6gYL5me55Gzz2IiVPetj1rlvQejgUGWL+iZF/LpBYUg==
 
 react-hotkeys@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- Built-in Yup support has been removed in favour of a `@hookform/resolvers` package that supports multiple schema validators.

  This just passes our existing Yup schema in to the new resolver.

- `react-hook-form` is moving away from `as` for non-trivial cases (see react-hook-form/react-hook-form#1580).

  Their types no longer include `onChange` for the `as` prop even though they're passing it. This works for most form elements but Braid requires `TextField`s to have an `onChange`.

  This seems to technically be a `react-hook-form` type bug but they seem to be pushing people towards the `render` prop anyway. I think the result also more clearly separates the form logic from the Braid logic.