### PR TITLE
Add example Table component

### DIFF
--- a/fe/example/src/components/Table/Table.treat.ts
+++ b/fe/example/src/components/Table/Table.treat.ts
@@ -1,0 +1,21 @@
+import { style } from 'sku/treat';
+
+export const head = style((theme) => ({
+  borderBottomColor: theme.border.color.standard,
+  borderBottomStyle: 'solid',
+  borderBottomWidth: theme.border.width.standard,
+}));
+
+export const row = style((theme) => ({
+  selectors: {
+    '&:not(:last-child)': {
+      borderBottomColor: theme.border.color.standard,
+      borderBottomStyle: 'dotted',
+      borderBottomWidth: theme.border.width.large,
+    },
+  },
+}));
+
+export const table = style({
+  minWidth: '100%',
+});

--- a/fe/example/src/components/Table/Table.tsx
+++ b/fe/example/src/components/Table/Table.tsx
@@ -1,0 +1,82 @@
+import { Box, Text } from 'braid-design-system';
+import React, { ReactNode } from 'react';
+import { useStyles } from 'sku/react-treat';
+
+import { TableCell } from './TableCell';
+
+import * as styleRefs from './Table.treat';
+
+export type Align = 'left' | 'center' | 'right';
+
+export type BaseRow = { id: string };
+
+export interface TableColumn<Row extends BaseRow> {
+  align: Align;
+  label: string;
+  render: (row: Row) => ReactNode;
+  to?: (row: Row) => string;
+
+  // TODO: switch to CSS Grid for fractional column widths?
+  weight: 1 | 2 | 3;
+}
+
+interface Props<Row extends BaseRow> {
+  columns: TableColumn<Row>[];
+
+  rows: Row[];
+}
+
+const TableHead = <T extends BaseRow>({ columns }: Props<T>) => {
+  const styles = useStyles(styleRefs);
+
+  return (
+    <Box className={styles.head} component="thead">
+      <Box component="tr">
+        {columns.map((column) => (
+          <Box
+            component="th"
+            key={column.label}
+            padding="gutter"
+            textAlign={column.align}
+          >
+            <Text weight="strong">{column.label}</Text>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+const TableBody = <T extends BaseRow>({ columns, rows }: Props<T>) => {
+  const styles = useStyles(styleRefs);
+
+  return (
+    <Box background="card" component="tbody">
+      {rows.map((row) => (
+        <Box className={styles.row} component="tr" key={row.id}>
+          {columns.map((column) => (
+            <TableCell
+              align={column.align}
+              key={column.label}
+              to={column.to?.(row)}
+            >
+              {column.render(row)}
+            </TableCell>
+          ))}
+        </Box>
+      ))}
+    </Box>
+  );
+};
+
+export const Table = <T extends BaseRow>(props: Props<T>) => {
+  const styles = useStyles(styleRefs);
+
+  return (
+    <Box className={styles.table} component="table">
+      <TableHead {...props} />
+
+      <TableBody {...props} />
+    </Box>
+  );
+};

--- a/fe/example/src/components/Table/TableCell.tsx
+++ b/fe/example/src/components/Table/TableCell.tsx
@@ -1,0 +1,37 @@
+import { Box, Text } from 'braid-design-system';
+import React, { ReactNode } from 'react';
+
+import { Align } from './Table';
+import { TableCellLink } from './TableCellLink';
+
+interface Props {
+  align?: Align;
+  children: ReactNode;
+  to?: string;
+}
+
+export const TableCell = ({ align, children, to }: Props) => {
+  let wrappedChildren = children;
+
+  if (typeof to === 'string') {
+    wrappedChildren = (
+      <TableCellLink align={align} to={to}>
+        {wrappedChildren}
+      </TableCellLink>
+    );
+  }
+
+  if (typeof wrappedChildren === 'string') {
+    wrappedChildren = (
+      <Text align={align} baseline={false}>
+        {wrappedChildren}
+      </Text>
+    );
+  }
+
+  return (
+    <Box component="td" padding={typeof to === 'string' ? 'none' : 'gutter'}>
+      {wrappedChildren}
+    </Box>
+  );
+};

--- a/fe/example/src/components/Table/TableCellLink.treat.ts
+++ b/fe/example/src/components/Table/TableCellLink.treat.ts
@@ -1,0 +1,22 @@
+import { style } from 'sku/treat';
+
+export const linkRef = style({});
+
+export const link = style((theme) => ({
+  textDecoration: 'none',
+
+  ':hover': {
+    color: theme.color.foreground.linkHover,
+    textDecoration: 'underline',
+  },
+}));
+
+export const linkBox = style((theme) => ({
+  transition: theme.transitions.touchable,
+
+  selectors: {
+    [`${linkRef}:active &`]: {
+      transform: 'translateY(1px)',
+    },
+  },
+}));

--- a/fe/example/src/components/Table/TableCellLink.tsx
+++ b/fe/example/src/components/Table/TableCellLink.tsx
@@ -1,0 +1,33 @@
+import { Box, Text } from 'braid-design-system';
+import classNames from 'classnames';
+import React, { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import { useStyles } from 'sku/react-treat';
+
+import { Align } from './Table';
+
+import * as styleRefs from './TableCellLink.treat';
+
+interface Props {
+  align?: Align;
+  children: ReactNode;
+  to: string;
+}
+
+export const TableCellLink = ({ align, children, to }: Props) => {
+  const styles = useStyles(styleRefs);
+
+  return (
+    <Link
+      className={classNames([styles.link, styles.linkRef])}
+      tabIndex={-1}
+      to={to}
+    >
+      <Text align={align} baseline={false} tone="link">
+        <Box className={styles.linkBox} padding="gutter">
+          {children}
+        </Box>
+      </Text>
+    </Link>
+  );
+};

--- a/fe/example/src/components/Table/index.ts
+++ b/fe/example/src/components/Table/index.ts
@@ -1,0 +1,3 @@
+export { Table } from './Table';
+
+export type { TableColumn } from './Table';


### PR DESCRIPTION
This kicks off the deconstruction of the `mock-frontend` mega-branch. I'll try to keep things small so they are easier to review in isolation.

This is all going into the `fe/example` directory as I'm not sure if any of this stuff should be part of our package interface. We can always shift stuff over once we've evaluated that they are a good fit with non-mock data.