### PR TITLE
Craft artisanal deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,9 @@
 name: Release
 
-# TODO: restore
-# on:
-#   push:
-#     branches:
-#       - master
-
 on:
-  - push
+  push:
+    branches:
+      - master
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,13 @@
 name: Release
 
+# TODO: restore
+# on:
+#   push:
+#     branches:
+#       - master
+
 on:
-  push:
-    branches:
-      - master
+  - push
 
 jobs:
   release:
@@ -36,7 +40,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.SEEK_OSS_CI_NPM_TOKEN }}
 
-      - name: Publish Storybook
-        run: yarn fe storybook:build && yarn fe storybook:deploy -- --ci --host-token-env-variable=GITHUB_TOKEN
+      - name: Deploy to GitHub Pages
+        run: yarn deploy
         env:
-          GITHUB_TOKEN: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IS_GITHUB_PAGES: true

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules/
 
 /be/lib/
 
+.DS_Store
+
 # managed by sku
 .eslintrc
 .prettierrc

--- a/fe/example/src/App/App.tsx
+++ b/fe/example/src/App/App.tsx
@@ -2,7 +2,7 @@ import 'braid-design-system/reset';
 
 import { Box, BraidLoadableProvider, ToastProvider } from 'braid-design-system';
 import React from 'react';
-import { Route, Switch } from 'react-router-dom';
+import { Redirect, Route, Switch } from 'react-router-dom';
 import { useStyles } from 'sku/react-treat';
 
 import { BrowserTokenProvider } from 'lib/hooks';
@@ -34,6 +34,10 @@ const Content = () => {
 
       <Box flexGrow={1} overflow="auto">
         <Switch>
+          <Route path="/storybook">
+            <Redirect to="https://seek-oss.github.io/wingman/storybook/index.html" />
+          </Route>
+
           <Route path="*">
             <OopsPage />
           </Route>

--- a/fe/example/src/App/Sidebar.tsx
+++ b/fe/example/src/App/Sidebar.tsx
@@ -4,22 +4,93 @@ import {
   Heading,
   IconAdd,
   IconDocument,
+  IconEducation,
   IconHome,
   IconImage,
+  IconNewWindow,
   IconPeople,
   IconSecurity,
   IconShare,
+  IconSocialGitHub,
   IconWorkExperience,
+  Link,
   Stack,
   Text,
 } from 'braid-design-system';
-import React, { ReactNode } from 'react';
+import React, { Fragment, ReactNode } from 'react';
 import { NavLink } from 'react-router-dom';
 import { useStyles } from 'sku/react-treat';
 
 import { ClientOnly } from '../components/ClientOnly';
 
 import * as styleRefs from './Sidebar.treat';
+
+interface LinkProps {
+  children: ReactNode;
+  to: string;
+}
+
+const ExternalLink = ({ children, to }: LinkProps) => {
+  const styles = useStyles(styleRefs);
+
+  return (
+    <Link className={styles.link} href={to} rel="noreferrer" target="_blank">
+      {children}
+    </Link>
+  );
+};
+
+const InternalLink = ({ children, to }: LinkProps) => {
+  const styles = useStyles(styleRefs);
+
+  return (
+    <NavLink
+      activeClassName={styles.activeLink}
+      className={styles.link}
+      exact
+      to={to}
+    >
+      {children}
+    </NavLink>
+  );
+};
+
+interface SidebarLinkProps {
+  children: ReactNode;
+  size?: 'small';
+  to: string;
+}
+
+const SidebarLink = ({ children, size, to }: SidebarLinkProps) => {
+  const styles = useStyles(styleRefs);
+
+  // Very naive switch, but we shouldn't be using other protocols
+  const isExternal = to.startsWith('https://');
+
+  const LinkWrapper = isExternal ? ExternalLink : InternalLink;
+
+  return (
+    <LinkWrapper to={to}>
+      <Box
+        className={styles.linkContainer}
+        paddingX="gutter"
+        paddingY={size ?? 'gutter'}
+      >
+        <Text size={size} tone="link">
+          {children}
+          {isExternal ? (
+            <Fragment>
+              {' '}
+              <IconNewWindow />
+            </Fragment>
+          ) : (
+            ''
+          )}
+        </Text>
+      </Box>
+    </LinkWrapper>
+  );
+};
 
 export const Sidebar = () => (
   <Box height="full">
@@ -78,9 +149,19 @@ export const Sidebar = () => (
                 />
               </Box>
               {preferences.devTools ? (
-                <SidebarLink to="/admin">
-                  <IconSecurity /> Admin
-                </SidebarLink>
+                <Fragment>
+                  <SidebarLink to="/admin">
+                    <IconSecurity /> Admin
+                  </SidebarLink>
+
+                  <SidebarLink to="https://seek-oss.github.io/wingman/storybook/index.html">
+                    <IconEducation /> Storybook
+                  </SidebarLink>
+
+                  <SidebarLink to="https://github.com/seek-oss/wingman">
+                    <IconSocialGitHub /> Source code
+                  </SidebarLink>
+                </Fragment>
               ) : undefined}
             </Box>
           )}
@@ -89,34 +170,3 @@ export const Sidebar = () => (
     </Stack>
   </Box>
 );
-
-const SidebarLink = ({
-  children,
-  size,
-  to,
-}: {
-  children: ReactNode;
-  size?: 'small';
-  to: string;
-}) => {
-  const styles = useStyles(styleRefs);
-
-  return (
-    <NavLink
-      activeClassName={styles.activeLink}
-      className={styles.link}
-      exact
-      to={to}
-    >
-      <Box
-        className={styles.linkContainer}
-        paddingX="gutter"
-        paddingY={size ?? 'gutter'}
-      >
-        <Text size={size} tone="link">
-          {children}
-        </Text>
-      </Box>
-    </NavLink>
-  );
-};

--- a/fe/example/src/client.tsx
+++ b/fe/example/src/client.tsx
@@ -6,10 +6,10 @@ import { App } from './App/App';
 import { UserProvider } from './hooks/user';
 import { ClientContext } from './types';
 
-export default ({ site }: ClientContext) => {
+export default ({ basename, site }: ClientContext) => {
   hydrate(
     <UserProvider server={false}>
-      <BrowserRouter>
+      <BrowserRouter basename={basename}>
         <App site={site} />
       </BrowserRouter>
     </UserProvider>,

--- a/fe/example/src/render.tsx
+++ b/fe/example/src/render.tsx
@@ -8,15 +8,20 @@ import { UserProvider } from './hooks/user';
 import { ClientContext } from './types';
 
 interface RenderContext {
-  appHtml: string;
+  basename: string;
+  html: string;
 }
 
 const skuRender: Render<RenderContext> = {
   renderApp: ({ SkuProvider, route, site }) => {
-    const appHtml = ReactDOM.renderToString(
+    const isGitHubPages = Boolean(process.env.IS_GITHUB_PAGES);
+
+    const basename = isGitHubPages ? 'wingman' : '';
+
+    const html = ReactDOM.renderToString(
       <SkuProvider>
         <UserProvider server={true}>
-          <StaticRouter location={route}>
+          <StaticRouter basename={basename} location={route}>
             <App site={site} />
           </StaticRouter>
         </UserProvider>
@@ -24,11 +29,13 @@ const skuRender: Render<RenderContext> = {
     );
 
     return {
-      appHtml,
+      basename,
+      html,
     };
   },
 
-  provideClientContext: ({ site }): ClientContext => ({
+  provideClientContext: ({ app, site }): ClientContext => ({
+    basename: app.basename,
     site,
   }),
 
@@ -41,7 +48,7 @@ const skuRender: Render<RenderContext> = {
         ${headTags}
       </head>
       <body>
-        <div id="app">${app.appHtml}</div>
+        <div id="app">${app.html}</div>
         ${bodyTags}
       </body>
     </html>

--- a/fe/example/src/types.ts
+++ b/fe/example/src/types.ts
@@ -1,3 +1,4 @@
 export interface ClientContext {
+  basename: string;
   site: string;
 }

--- a/fe/package.json
+++ b/fe/package.json
@@ -19,7 +19,6 @@
     "yup": "^0.29.1"
   },
   "devDependencies": {
-    "@storybook/storybook-deployer": "2.8.6",
     "@testing-library/react": "10.4.4",
     "@types/faker": "4.1.12",
     "@types/react": "16.9.41",
@@ -54,14 +53,13 @@
   },
   "scripts": {
     "build": "sku build",
+    "build-storybook": "sku build-storybook",
     "format": "sku format",
     "lint": "sku lint",
     "serve": "sku serve",
     "start": "sku start",
-    "test": "sku test",
-    "storybook:start": "sku storybook",
-    "storybook:build": "sku build-storybook",
-    "storybook:deploy": "storybook-to-ghpages --existing-output-dir=dist-storybook"
+    "start-storybook": "sku storybook",
+    "test": "sku test"
   },
   "version": "0.11.0"
 }

--- a/fe/sku.config.js
+++ b/fe/sku.config.js
@@ -1,9 +1,11 @@
-module.exports = {
-  clientEntry: 'example/src/client.tsx',
-  renderEntry: 'example/src/render.tsx',
-  srcPaths: ['example/src', 'lib'],
+const isGitHubPages = Boolean(process.env.IS_GITHUB_PAGES);
 
-  publicPath: '/',
+module.exports = {
+  clientEntry: './example/src/client.tsx',
+  renderEntry: './example/src/render.tsx',
+  srcPaths: ['./example/src', './lib'],
+
+  publicPath: isGitHubPages ? '/wingman/static/' : '/',
   routes: [
     '/',
     '/accounts',

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "stage": "changeset version && yarn format",
     "release": "yarn be build && changeset publish",
     "test": "yarn workspaces run test",
-    "codegen": "graphql-codegen --config codegen.yml"
+    "codegen": "graphql-codegen --config codegen.yml",
+    "deploy": "scripts/deploy"
   },
   "workspaces": [
     "be",

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+set -e
+
+echo '=> Building...'
+
+rm -rf dist
+
+yarn concurrently 'yarn fe build' 'yarn fe build-storybook'
+
+echo '=> Packaging...'
+
+mkdir -p dist
+
+mv fe/dist/ dist/static/
+
+mv dist/static/apac/* dist/
+
+mv fe/dist-storybook/ dist/storybook/
+
+cd dist
+
+git init
+
+git add --all
+
+git \
+-c 'user.email=<>' \
+-c 'user.name=Wingman' \
+commit \
+--author 'Wingman <>' \
+--message 'Deploy to GitHub Pages' \
+--quiet
+
+echo '=> Deploying...'
+
+{
+  GIT_URL="git@github.com:seek-oss/wingman.git"
+
+  if [ "${IS_GITHUB_PAGES:-}" = 'true' ]; then
+    GIT_URL="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/seek-oss/wingman.git"
+  fi
+
+  git push --force --quiet "${GIT_URL}" 'master:gh-pages'
+}
+
+cd ..
+rm -rf dist
+
+echo "=> Deployed: https://seek-oss.github.io/wingman"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3086,17 +3086,6 @@
     qs "^6.6.0"
     util-deprecate "^1.0.2"
 
-"@storybook/storybook-deployer@2.8.6":
-  version "2.8.6"
-  resolved "https://registry.yarnpkg.com/@storybook/storybook-deployer/-/storybook-deployer-2.8.6.tgz#00c2e84f27dfaa88cb0785361453f23b1ebb4ea3"
-  integrity sha512-Bpe7ZtsR5NUuohK3VsQa+nxEHtVxMZZo3DRlRUZW5IZOmzmvSID3i+jkizloG9xO7sw5zUvlD31YMHm7OtdrMA==
-  dependencies:
-    git-url-parse "^11.1.2"
-    glob "^7.1.3"
-    parse-repo "^1.0.4"
-    shelljs "^0.8.1"
-    yargs "^15.0.0"
-
 "@storybook/theming@5.3.19":
   version "5.3.19"
   resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-5.3.19.tgz#177d9819bd64f7a1a6ea2f1920ffa5baf9a5f467"
@@ -9959,21 +9948,6 @@ git-log-parser@^1.2.0:
     through2 "~2.0.0"
     traverse "~0.6.6"
 
-git-up@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/git-up/-/git-up-4.0.1.tgz#cb2ef086653640e721d2042fe3104857d89007c0"
-  integrity sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==
-  dependencies:
-    is-ssh "^1.3.0"
-    parse-url "^5.0.0"
-
-git-url-parse@^11.1.2:
-  version "11.1.2"
-  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-11.1.2.tgz#aff1a897c36cc93699270587bea3dbcbbb95de67"
-  integrity sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==
-  dependencies:
-    git-up "^4.0.0"
-
 github-slugger@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.3.0.tgz#9bd0a95c5efdfc46005e82a906ef8e2a059124c9"
@@ -11680,13 +11654,6 @@ is-set@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.1.tgz#d1604afdab1724986d30091575f54945da7e5f43"
   integrity sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA==
-
-is-ssh@^1.3.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/is-ssh/-/is-ssh-1.3.1.tgz#f349a8cadd24e65298037a522cf7520f2e81a0f3"
-  integrity sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==
-  dependencies:
-    protocols "^1.1.0"
 
 is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
@@ -14990,7 +14957,7 @@ normalize-url@1.9.1:
     query-string "^4.1.0"
     sort-keys "^1.0.0"
 
-normalize-url@^3.0.0, normalize-url@^3.3.0:
+normalize-url@^3.0.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
@@ -15888,33 +15855,10 @@ parse-passwd@^1.0.0:
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
   integrity sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
 
-parse-path@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/parse-path/-/parse-path-4.0.1.tgz#0ec769704949778cb3b8eda5e994c32073a1adff"
-  integrity sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==
-  dependencies:
-    is-ssh "^1.3.0"
-    protocols "^1.4.0"
-
 parse-prop-types@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/parse-prop-types/-/parse-prop-types-0.3.0.tgz#c0d3ccff4e3baabed6ec498974a657314a8f18d8"
   integrity sha512-HAvQ2sGc2Y+OLWddBG+KKlxU/F931Vq0GPSqKVaRJb6bUVdkIYxk63mJ/ZwX1VTjZ0h34qrCXE3tmSVUHB1zxQ==
-
-parse-repo@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/parse-repo/-/parse-repo-1.0.4.tgz#74b91d2cb8675d11b99976a0065f6ce17fa1bcc8"
-  integrity sha1-dLkdLLhnXRG5mXagBl9s4X+hvMg=
-
-parse-url@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-5.0.1.tgz#99c4084fc11be14141efa41b3d117a96fcb9527f"
-  integrity sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==
-  dependencies:
-    is-ssh "^1.3.0"
-    normalize-url "^3.3.0"
-    parse-path "^4.0.0"
-    protocols "^1.4.0"
 
 parse5@4.0.0:
   version "4.0.0"
@@ -16896,11 +16840,6 @@ proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
-
-protocols@^1.1.0, protocols@^1.4.0:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.7.tgz#95f788a4f0e979b291ffefcf5636ad113d037d32"
-  integrity sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==
 
 protoduck@^5.0.1:
   version "5.0.1"
@@ -18691,7 +18630,7 @@ shell-quote@1.7.2:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
 
-shelljs@^0.8.1, shelljs@^0.8.3:
+shelljs@^0.8.3:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
   integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
@@ -21875,7 +21814,7 @@ yargs@12.0.5:
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
 
-yargs@15.4.0, yargs@^15.0.0, yargs@^15.0.1, yargs@^15.1.0, yargs@^15.3.1:
+yargs@15.4.0, yargs@^15.0.1, yargs@^15.1.0, yargs@^15.3.1:
   version "15.4.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.0.tgz#53949fb768309bac1843de9b17b80051e9805ec2"
   integrity sha512-D3fRFnZwLWp8jVAAhPZBsmeIHY8tTsb8ItV9KaAaopmC6wde2u6Yw29JBIZHXw14kgkRnYmDgmQU4FVMDlIsWw==


### PR DESCRIPTION
This drops the Storybook deployer in favour of a simple script with plenty of hardcoding. This allows us to trivially customise the directory structure of the `gh-pages` branch and add in our mock site.

<https://seek-oss.github.io/wingman>

I initially thought of running a script after the Storybook deployer, but unfortunately it deletes its working directory after deployment.