### PR TITLE
Fix rehydration issue with `ClientOnly`

### DIFF
--- a/fe/example/src/components/ClientOnly.tsx
+++ b/fe/example/src/components/ClientOnly.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 
 import { ExtendedClientContext, augmentClient, useUser } from '../hooks/user';
 
@@ -7,11 +7,17 @@ interface Props {
 }
 
 export const ClientOnly = ({ children }: Props) => {
+  const [hasMounted, setHasMounted] = useState(false);
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
+
   const client = useUser();
 
   const [ctx] = client;
 
-  if (ctx.server) {
+  if (ctx.server || !hasMounted) {
     return null;
   }
 


### PR DESCRIPTION
React yells in the console when the hydrated client output doesn't match the server render, and a mismatch can lead to weird rendering issues. Instead, we defer client-side changes to a follow-up render.