### PR TITLE
Fix: JobCategorySuggest ID overwritten preventing label selection

### DIFF
--- a/.changeset/plenty-dolls-whisper.md
+++ b/.changeset/plenty-dolls-whisper.md
@@ -2,4 +2,4 @@
 'wingman-fe': patch
 ---
 
-Fixes JobCategorySuggest radio checklist's ID being overwritten. This would prevent a user clicking the radio lable to change their selection.
+Fixes JobCategorySuggest radio checklist's ID being overwritten. This would prevent a user from clicking the radio label to change their selection.

--- a/.changeset/plenty-dolls-whisper.md
+++ b/.changeset/plenty-dolls-whisper.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': patch
+---
+
+Fixes JobCategorySuggest radio checklist's ID being overwritten. This would prevent a user clicking the radio lable to change their selection.

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
@@ -19,7 +19,7 @@ import { JOB_CATEGORY_SUGGESTION } from './queries';
 
 interface RadioProps extends ComponentPropsWithRef<typeof Radio> {}
 
-interface Props extends Partial<RadioProps> {
+interface Props extends Partial<Omit<RadioProps, 'id'>> {
   client?: ApolloClient<unknown>;
   schemeId: string;
   debounceDelay?: number;

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -46,14 +46,14 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
           const { id } = jobCategory;
           return (
             <Radio
+              {...restProps}
               key={id.value}
               checked={id.value === selectedJobCategory?.id.value}
               onChange={() => handleChoiceSelect(choice)}
               value={id.value}
-              id={id.value}
               label={getJobCategoryName(jobCategory)}
               ref={forwardedRef}
-              {...restProps}
+              id={id.value}
             >
               {showConfidence && (
                 <Text tone="secondary" size="small">


### PR DESCRIPTION
### Issue this fixes
Right now if you use a JobCategorySuggest component and supply it an ID, due to type inheritance from Braids Radio component it will use that instead of the supplied job category ID. From our use cases, we don't actually need control over the ID as any external control/listening is done by the forwarded ref or the name attribute. 

### Changes
- Omits the ID from the type of JobCategorySuggest 
- Re-orders props on Radio component to enforce the others are not overwritten. 