### PR TITLE
Upgrade to Apollo Client 3

### DIFF
--- a/.changeset/pretty-swans-dress.md
+++ b/.changeset/pretty-swans-dress.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': patch
+---
+
+Avoid GraphQL queries during SSR

--- a/.changeset/tidy-birds-relax.md
+++ b/.changeset/tidy-birds-relax.md
@@ -1,0 +1,7 @@
+---
+'wingman-fe': minor
+---
+
+**deps:** Apollo Client 3
+
+Breaking: widgets require an Apollo Client 3 instance to be passed in.

--- a/codegen.yml
+++ b/codegen.yml
@@ -14,6 +14,13 @@ generates:
     config:
       module: es2015
 
+  ./fe/lib/types/seekSchema.graphql:
+    schema: ${SEEK_SCHEMA_PATH:https://graphql.seek.com/graphql}
+    plugins:
+      - schema-ast
+    config:
+      includeDirectives: true
+
 config:
   scalars:
     DateTime: string

--- a/fe/lib/components/JobCategorySelect/JobCategoriesSelect.stories.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategoriesSelect.stories.tsx
@@ -1,31 +1,30 @@
 import 'braid-design-system/reset';
 
 import { Box, BraidLoadableProvider } from 'braid-design-system';
-import { createMockClient } from 'mock-apollo-client';
 import React from 'react';
-import { ApolloProvider } from 'react-apollo';
 import { storiesOf } from 'sku/@storybook/react';
+
+import { ApolloMockProvider } from '../../testing/ApolloMockProvider';
 
 import { JobCategorySelect } from './JobCategorySelect';
 import { mockJobCategories } from './__fixtures__/jobCategories';
-import { JOB_CATEGORIES } from './queries';
-
-const mockClient = createMockClient();
-
-mockClient.setRequestHandler(JOB_CATEGORIES, () =>
-  Promise.resolve({ data: mockJobCategories }),
-);
 
 storiesOf('JobCategories', module)
   .add('Job Category Select', () => (
     <JobCategorySelect id="jobCategories" schemeId="seekAnz" />
   ))
   .addDecorator((story) => (
-    <ApolloProvider client={mockClient}>
+    <ApolloMockProvider
+      resolvers={{
+        Query: {
+          jobCategories: () => mockJobCategories,
+        },
+      }}
+    >
       <BraidLoadableProvider themeName="apac">
         <Box paddingX="gutter" paddingY="large">
           {story()}
         </Box>
       </BraidLoadableProvider>
-    </ApolloProvider>
+    </ApolloMockProvider>
   ));

--- a/fe/lib/components/JobCategorySelect/JobCategorySelect.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelect.tsx
@@ -1,5 +1,4 @@
-import { useQuery } from '@apollo/react-hooks';
-import ApolloClient from 'apollo-client';
+import { ApolloClient, useQuery } from '@apollo/client';
 import {
   Dropdown,
   FieldMessage,
@@ -36,6 +35,7 @@ export const JobCategorySelect = forwardRef<HTMLInputElement, Props>(
     } = useQuery(JOB_CATEGORIES, {
       ...(client && { client }),
       fetchPolicy: 'no-cache',
+      ssr: false,
       variables: {
         schemeId,
       },

--- a/fe/lib/components/JobCategorySelect/README.md
+++ b/fe/lib/components/JobCategorySelect/README.md
@@ -43,7 +43,7 @@ import { JobCategorySelect } from 'wingman-fe';
 #### Default usage with Apollo Client
 
 ```javascript
-import { ApolloClient } from 'apollo-client';
+import { ApolloClient } from '@apollo/client';
 import { JobCategorySelect } from 'wingman-fe';
 
 // cache and link set-up as required

--- a/fe/lib/components/JobCategorySelect/__fixtures__/jobCategories.ts
+++ b/fe/lib/components/JobCategorySelect/__fixtures__/jobCategories.ts
@@ -1,68 +1,66 @@
-export const mockJobCategories = {
-  jobCategories: [
-    {
-      id: {
-        value: 'seekAnz:jobCategory:seek:2WejkktVM',
-      },
-      name: 'Accounting',
-      children: [
-        {
-          id: {
-            value: 'seekAnz:jobCategory:seek:CTriSTrf',
-          },
-          name: 'Accounts Payable',
-          parent: {
-            id: {
-              value: 'seekAnz:jobCategory:seek:2WejkktVM',
-            },
-            name: 'Accounting',
-          },
-        },
-        {
-          id: {
-            value: 'seekAnz:jobCategory:seek:2cdSPDcy5',
-          },
-          name: 'Payroll',
-          parent: {
-            id: {
-              value: 'seekAnz:jobCategory:seek:2WejkktVM',
-            },
-            name: 'Accounting',
-          },
-        },
-      ],
+export const mockJobCategories = [
+  {
+    id: {
+      value: 'seekAnz:jobCategory:seek:2WejkktVM',
     },
-    {
-      id: {
-        value: 'seekAnz:jobCategory:seek:2Ze2oDqf5',
+    name: 'Accounting',
+    children: [
+      {
+        id: {
+          value: 'seekAnz:jobCategory:seek:CTriSTrf',
+        },
+        name: 'Accounts Payable',
+        parent: {
+          id: {
+            value: 'seekAnz:jobCategory:seek:2WejkktVM',
+          },
+          name: 'Accounting',
+        },
       },
-      name: 'Construction',
-      children: [
-        {
-          id: {
-            value: 'seekAnz:jobCategory:seek:vHyJwnCo',
-          },
-          name: 'Estimating',
-          parent: {
-            id: {
-              value: 'seekAnz:jobCategory:seek:2Ze2oDqf5',
-            },
-            name: 'Construction',
-          },
+      {
+        id: {
+          value: 'seekAnz:jobCategory:seek:2cdSPDcy5',
         },
-        {
+        name: 'Payroll',
+        parent: {
           id: {
-            value: 'seekAnz:jobCategory:seek:2w67bem51',
+            value: 'seekAnz:jobCategory:seek:2WejkktVM',
           },
-          name: 'Contracts Management',
-          parent: {
-            id: {
-              value: 'seekAnz:jobCategory:seek:2Ze2oDqf5',
-            },
-            name: 'Construction',
-          },
+          name: 'Accounting',
         },
-      ],
+      },
+    ],
+  },
+  {
+    id: {
+      value: 'seekAnz:jobCategory:seek:2Ze2oDqf5',
     },
-  ],
-};
+    name: 'Construction',
+    children: [
+      {
+        id: {
+          value: 'seekAnz:jobCategory:seek:vHyJwnCo',
+        },
+        name: 'Estimating',
+        parent: {
+          id: {
+            value: 'seekAnz:jobCategory:seek:2Ze2oDqf5',
+          },
+          name: 'Construction',
+        },
+      },
+      {
+        id: {
+          value: 'seekAnz:jobCategory:seek:2w67bem51',
+        },
+        name: 'Contracts Management',
+        parent: {
+          id: {
+            value: 'seekAnz:jobCategory:seek:2Ze2oDqf5',
+          },
+          name: 'Construction',
+        },
+      },
+    ],
+  },
+];

--- a/fe/lib/components/JobCategorySelect/queries.ts
+++ b/fe/lib/components/JobCategorySelect/queries.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-boost';
+import { gql } from '@apollo/client';
 
 const JOB_CATEGORY_ATTRIBUTES = gql`
   fragment jobCategoryAttributes on JobCategory {

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.stories.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.stories.tsx
@@ -1,21 +1,14 @@
 import 'braid-design-system/reset';
 
 import { Box, BraidLoadableProvider } from 'braid-design-system';
-import { createMockClient } from 'mock-apollo-client';
 import React from 'react';
-import { ApolloProvider } from 'react-apollo';
 import { select, text } from 'sku/@storybook/addon-knobs';
 import { storiesOf } from 'sku/@storybook/react';
 
+import { ApolloMockProvider } from '../../testing/ApolloMockProvider';
+
 import { JobCategorySuggest } from './JobCategorySuggest';
 import { mockJobCategorySuggest } from './__fixtures__/jobCategorySuggest';
-import { JOB_CATEGORY_SUGGESTION } from './queries';
-
-const mockClient = createMockClient();
-
-mockClient.setRequestHandler(JOB_CATEGORY_SUGGESTION, () =>
-  Promise.resolve({ data: mockJobCategorySuggest }),
-);
 
 storiesOf('JobCategories', module)
   .add('Job Category Suggest', () => (
@@ -30,11 +23,17 @@ storiesOf('JobCategories', module)
     />
   ))
   .addDecorator((story) => (
-    <ApolloProvider client={mockClient}>
+    <ApolloMockProvider
+      resolvers={{
+        Query: {
+          jobCategorySuggestions: () => mockJobCategorySuggest,
+        },
+      }}
+    >
       <BraidLoadableProvider themeName="apac">
         <Box paddingX="gutter" paddingY="large">
           {story()}
         </Box>
       </BraidLoadableProvider>
-    </ApolloProvider>
+    </ApolloMockProvider>
   ));

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
@@ -1,5 +1,4 @@
-import { useLazyQuery } from '@apollo/react-hooks';
-import ApolloClient from 'apollo-client';
+import { ApolloClient, useLazyQuery } from '@apollo/client';
 import { FieldMessage, Loader, Radio, Stack, Text } from 'braid-design-system';
 import React, {
   ComponentProps,
@@ -50,6 +49,7 @@ export const JobCategorySuggest = forwardRef<HTMLInputElement, Props>(
     ] = useLazyQuery(JOB_CATEGORY_SUGGESTION, {
       client,
       fetchPolicy: 'no-cache',
+      ssr: false,
     });
 
     const [debounceJobCategorySuggestInput] = useDebounce(

--- a/fe/lib/components/JobCategorySuggest/README.md
+++ b/fe/lib/components/JobCategorySuggest/README.md
@@ -52,7 +52,7 @@ const positionProfile = {
 #### Default usage with Apollo Client
 
 ```javascript
-import { ApolloClient } from 'apollo-client';
+import { ApolloClient } from '@apollo/client';
 import { JobCategorySuggest } from 'wingman-fe';
 
 // cache and link set-up as required

--- a/fe/lib/components/JobCategorySuggest/__fixtures__/jobCategorySuggest.ts
+++ b/fe/lib/components/JobCategorySuggest/__fixtures__/jobCategorySuggest.ts
@@ -1,34 +1,32 @@
-export const mockJobCategorySuggest = {
-  jobCategorySuggestions: [
-    {
-      jobCategory: {
-        id: {
-          value: 'seekAnzPublicTest:jobCategory:seek:2EFstqFvP',
-        },
-        name: 'Developers/Programmers',
-        parent: {
-          id: {
-            value: 'seekAnzPublicTest:jobCategory:seek:2BGarNJkf',
-          },
-          name: 'Information & Communication Technology',
-        },
+export const mockJobCategorySuggest = [
+  {
+    jobCategory: {
+      id: {
+        value: 'seekAnzPublicTest:jobCategory:seek:2EFstqFvP',
       },
-      confidence: 0.80588377,
-    },
-    {
-      jobCategory: {
+      name: 'Developers/Programmers',
+      parent: {
         id: {
-          value: 'seekAnzPublicTest:jobCategory:seek:2FkXR4jWF',
+          value: 'seekAnzPublicTest:jobCategory:seek:2BGarNJkf',
         },
-        name: 'Engineering - Software',
-        parent: {
-          id: {
-            value: 'seekAnzPublicTest:jobCategory:seek:2BGarNJkf',
-          },
-          name: 'Information & Communication Technology',
-        },
+        name: 'Information & Communication Technology',
       },
-      confidence: 0.1529567,
     },
-  ],
-};
+    confidence: 0.80588377,
+  },
+  {
+    jobCategory: {
+      id: {
+        value: 'seekAnzPublicTest:jobCategory:seek:2FkXR4jWF',
+      },
+      name: 'Engineering - Software',
+      parent: {
+        id: {
+          value: 'seekAnzPublicTest:jobCategory:seek:2BGarNJkf',
+        },
+        name: 'Information & Communication Technology',
+      },
+    },
+    confidence: 0.1529567,
+  },
+];

--- a/fe/lib/components/JobCategorySuggest/queries.ts
+++ b/fe/lib/components/JobCategorySuggest/queries.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-boost';
+import { gql } from '@apollo/client';
 
 const JOB_CATEGORY_ATTRIBUTES = gql`
   fragment jobCategoryAttributes on JobCategory {

--- a/fe/lib/components/LocationSuggest/LocationSuggest.stories.tsx
+++ b/fe/lib/components/LocationSuggest/LocationSuggest.stories.tsx
@@ -1,35 +1,32 @@
 import 'braid-design-system/reset';
 
 import { Box, BraidLoadableProvider } from 'braid-design-system';
-import { createMockClient } from 'mock-apollo-client';
 import React from 'react';
-import { ApolloProvider } from 'react-apollo';
 import { storiesOf } from 'sku/@storybook/react';
+
+import { ApolloMockProvider } from '../../testing/ApolloMockProvider';
 
 import { LocationSuggest } from './LocationSuggest';
 import { mockLocationSuggest } from './__fixtures__/locationSuggest';
 import { mockNearestLocations } from './__fixtures__/nearestLocations';
-import { LOCATION_SUGGEST, NEAREST_LOCATIONS } from './queries';
-
-const mockClient = createMockClient();
-
-mockClient.setRequestHandler(LOCATION_SUGGEST, () =>
-  Promise.resolve({ data: mockLocationSuggest }),
-);
-mockClient.setRequestHandler(NEAREST_LOCATIONS, () =>
-  Promise.resolve({ data: mockNearestLocations }),
-);
 
 storiesOf('Locations', module)
   .add('Locations Suggest', () => (
     <LocationSuggest id="locationSuggest" schemeId="seekAnz" />
   ))
   .addDecorator((story) => (
-    <ApolloProvider client={mockClient}>
+    <ApolloMockProvider
+      resolvers={{
+        Query: {
+          nearestLocations: () => mockNearestLocations,
+          locationSuggestions: () => mockLocationSuggest,
+        },
+      }}
+    >
       <BraidLoadableProvider themeName="apac">
         <Box paddingX="gutter" paddingY="large">
           {story()}
         </Box>
       </BraidLoadableProvider>
-    </ApolloProvider>
+    </ApolloMockProvider>
   ));

--- a/fe/lib/components/LocationSuggest/LocationSuggest.tsx
+++ b/fe/lib/components/LocationSuggest/LocationSuggest.tsx
@@ -1,5 +1,4 @@
-import { useLazyQuery } from '@apollo/react-hooks';
-import ApolloClient from 'apollo-client';
+import { ApolloClient, useLazyQuery } from '@apollo/client';
 import { FieldMessage, Stack, TextField } from 'braid-design-system';
 import React, {
   ComponentPropsWithRef,
@@ -57,6 +56,7 @@ export const LocationSuggest = forwardRef<HTMLInputElement, Props>(
       {
         ...(client && { client }),
         fetchPolicy: 'no-cache',
+        ssr: false,
       },
     );
 
@@ -72,6 +72,7 @@ export const LocationSuggest = forwardRef<HTMLInputElement, Props>(
       {
         ...(client && { client }),
         fetchPolicy: 'no-cache',
+        ssr: false,
       },
     );
 

--- a/fe/lib/components/LocationSuggest/README.md
+++ b/fe/lib/components/LocationSuggest/README.md
@@ -51,7 +51,7 @@ import { LocationSuggest } from 'wingman-fe';
 #### Default usage with Apollo Client
 
 ```javascript
-import { ApolloClient } from 'apollo-client';
+import { ApolloClient } from '@apollo/client';
 import { LocationSuggest } from 'wingman-fe';
 
 // cache and link set-up as required

--- a/fe/lib/components/LocationSuggest/__fixtures__/locationSuggest.ts
+++ b/fe/lib/components/LocationSuggest/__fixtures__/locationSuggest.ts
@@ -1,90 +1,88 @@
-export const mockLocationSuggest = {
-  locationSuggestions: [
-    {
-      location: {
+export const mockLocationSuggest = [
+  {
+    location: {
+      id: {
+        value: 'seekAnz:location:seek:2FqwWaaMV',
+      },
+      name: 'Melbourne',
+      contextualName: 'Melbourne VIC 3000 AU',
+      countryCode: 'AU',
+      parent: {
         id: {
-          value: 'seekAnz:location:seek:2FqwWaaMV',
+          value: 'seekAnz:location:seek:2m81wybwV',
         },
-        name: 'Melbourne',
-        contextualName: 'Melbourne VIC 3000 AU',
+        name: 'CBD & Inner Suburbs',
+        contextualName: 'CBD & Inner Suburbs, Melbourne VIC AU',
         countryCode: 'AU',
         parent: {
           id: {
-            value: 'seekAnz:location:seek:2m81wybwV',
+            value: 'seekAnz:location:seek:31XoHiay5',
           },
-          name: 'CBD & Inner Suburbs',
-          contextualName: 'CBD & Inner Suburbs, Melbourne VIC AU',
+          name: 'Melbourne',
+          contextualName: 'Melbourne VIC AU',
           countryCode: 'AU',
           parent: {
             id: {
-              value: 'seekAnz:location:seek:31XoHiay5',
+              value: 'seekAnz:location:seek:HxMS1gfR',
             },
-            name: 'Melbourne',
-            contextualName: 'Melbourne VIC AU',
+            name: 'Victoria',
+            contextualName: 'Victoria AU',
             countryCode: 'AU',
             parent: {
               id: {
-                value: 'seekAnz:location:seek:HxMS1gfR',
+                value: 'seekAnz:location:seek:2aeax6diF',
               },
-              name: 'Victoria',
-              contextualName: 'Victoria AU',
+              name: 'Australia',
+              contextualName: 'Australia',
               countryCode: 'AU',
-              parent: {
-                id: {
-                  value: 'seekAnz:location:seek:2aeax6diF',
-                },
-                name: 'Australia',
-                contextualName: 'Australia',
-                countryCode: 'AU',
-                parent: null,
-              },
+              parent: null,
             },
           },
         },
       },
     },
-    {
-      location: {
+  },
+  {
+    location: {
+      id: {
+        value: 'seekAnz:location:seek:2vArzkyio',
+      },
+      name: 'Sydney',
+      contextualName: 'Sydney NSW 1001 AU',
+      countryCode: 'AU',
+      parent: {
         id: {
-          value: 'seekAnz:location:seek:2vArzkyio',
+          value: 'seekAnz:location:seek:2QCxeiwmR',
         },
-        name: 'Sydney',
-        contextualName: 'Sydney NSW 1001 AU',
+        name: 'CBD, Inner West & Eastern Suburbs',
+        contextualName: 'CBD, Inner West & Eastern Suburbs, Sydney NSW AU',
         countryCode: 'AU',
         parent: {
           id: {
-            value: 'seekAnz:location:seek:2QCxeiwmR',
+            value: 'seekAnz:location:seek:2zY2wZbuq',
           },
-          name: 'CBD, Inner West & Eastern Suburbs',
-          contextualName: 'CBD, Inner West & Eastern Suburbs, Sydney NSW AU',
+          name: 'Sydney',
+          contextualName: 'Sydney NSW AU',
           countryCode: 'AU',
           parent: {
             id: {
-              value: 'seekAnz:location:seek:2zY2wZbuq',
+              value: 'seekAnz:location:seek:FTwZdE2K',
             },
-            name: 'Sydney',
-            contextualName: 'Sydney NSW AU',
+            name: 'New South Wales',
+            contextualName: 'New South Wales AU',
             countryCode: 'AU',
             parent: {
               id: {
-                value: 'seekAnz:location:seek:FTwZdE2K',
+                value: 'seekAnz:location:seek:2aeax6diF',
               },
-              name: 'New South Wales',
-              contextualName: 'New South Wales AU',
+              name: 'Australia',
+              contextualName: 'Australia',
               countryCode: 'AU',
-              parent: {
-                id: {
-                  value: 'seekAnz:location:seek:2aeax6diF',
-                },
-                name: 'Australia',
-                contextualName: 'Australia',
-                countryCode: 'AU',
-                parent: null,
-              },
+              parent: null,
             },
           },
         },
       },
     },
-  ],
-};
+  },
+];

--- a/fe/lib/components/LocationSuggest/__fixtures__/nearestLocations.ts
+++ b/fe/lib/components/LocationSuggest/__fixtures__/nearestLocations.ts
@@ -1,86 +1,84 @@
-export const mockNearestLocations = {
-  nearestLocations: [
-    {
+export const mockNearestLocations = [
+  {
+    id: {
+      value: 'seekAnz:location:seek:2FqwWaaMV',
+    },
+    name: 'Melbourne',
+    contextualName: 'Melbourne VIC 3000 AU',
+    countryCode: 'AU',
+    parent: {
       id: {
-        value: 'seekAnz:location:seek:2FqwWaaMV',
+        value: 'seekAnz:location:seek:2m81wybwV',
       },
-      name: 'Melbourne',
-      contextualName: 'Melbourne VIC 3000 AU',
+      name: 'CBD & Inner Suburbs',
+      contextualName: 'CBD & Inner Suburbs, Melbourne VIC AU',
       countryCode: 'AU',
       parent: {
         id: {
-          value: 'seekAnz:location:seek:2m81wybwV',
+          value: 'seekAnz:location:seek:31XoHiay5',
         },
-        name: 'CBD & Inner Suburbs',
-        contextualName: 'CBD & Inner Suburbs, Melbourne VIC AU',
+        name: 'Melbourne',
+        contextualName: 'Melbourne VIC AU',
         countryCode: 'AU',
         parent: {
           id: {
-            value: 'seekAnz:location:seek:31XoHiay5',
+            value: 'seekAnz:location:seek:HxMS1gfR',
           },
-          name: 'Melbourne',
-          contextualName: 'Melbourne VIC AU',
+          name: 'Victoria',
+          contextualName: 'Victoria AU',
           countryCode: 'AU',
           parent: {
             id: {
-              value: 'seekAnz:location:seek:HxMS1gfR',
+              value: 'seekAnz:location:seek:2aeax6diF',
             },
-            name: 'Victoria',
-            contextualName: 'Victoria AU',
+            name: 'Australia',
+            contextualName: 'Australia',
             countryCode: 'AU',
-            parent: {
-              id: {
-                value: 'seekAnz:location:seek:2aeax6diF',
-              },
-              name: 'Australia',
-              contextualName: 'Australia',
-              countryCode: 'AU',
-              parent: null,
-            },
+            parent: null,
           },
         },
       },
     },
-    {
+  },
+  {
+    id: {
+      value: 'seekAnz:location:seek:2vArzkyio',
+    },
+    name: 'Sydney',
+    contextualName: 'Sydney NSW 1001 AU',
+    countryCode: 'AU',
+    parent: {
       id: {
-        value: 'seekAnz:location:seek:2vArzkyio',
+        value: 'seekAnz:location:seek:2QCxeiwmR',
       },
-      name: 'Sydney',
-      contextualName: 'Sydney NSW 1001 AU',
+      name: 'CBD, Inner West & Eastern Suburbs',
+      contextualName: 'CBD, Inner West & Eastern Suburbs, Sydney NSW AU',
       countryCode: 'AU',
       parent: {
         id: {
-          value: 'seekAnz:location:seek:2QCxeiwmR',
+          value: 'seekAnz:location:seek:2zY2wZbuq',
         },
-        name: 'CBD, Inner West & Eastern Suburbs',
-        contextualName: 'CBD, Inner West & Eastern Suburbs, Sydney NSW AU',
+        name: 'Sydney',
+        contextualName: 'Sydney NSW AU',
         countryCode: 'AU',
         parent: {
           id: {
-            value: 'seekAnz:location:seek:2zY2wZbuq',
+            value: 'seekAnz:location:seek:FTwZdE2K',
           },
-          name: 'Sydney',
-          contextualName: 'Sydney NSW AU',
+          name: 'New South Wales',
+          contextualName: 'New South Wales AU',
           countryCode: 'AU',
           parent: {
             id: {
-              value: 'seekAnz:location:seek:FTwZdE2K',
+              value: 'seekAnz:location:seek:2aeax6diF',
             },
-            name: 'New South Wales',
-            contextualName: 'New South Wales AU',
+            name: 'Australia',
+            contextualName: 'Australia',
             countryCode: 'AU',
-            parent: {
-              id: {
-                value: 'seekAnz:location:seek:2aeax6diF',
-              },
-              name: 'Australia',
-              contextualName: 'Australia',
-              countryCode: 'AU',
-              parent: null,
-            },
+            parent: null,
           },
         },
       },
     },
-  ],
-};
+  },
+];

--- a/fe/lib/components/LocationSuggest/queries.ts
+++ b/fe/lib/components/LocationSuggest/queries.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-boost';
+import { gql } from '@apollo/client';
 
 const LOCATION_ATTRIBUTES = gql`
   fragment locationAttributes on Location {

--- a/fe/lib/testing/ApolloMockProvider.tsx
+++ b/fe/lib/testing/ApolloMockProvider.tsx
@@ -1,0 +1,25 @@
+import { ApolloClient, ApolloProvider, InMemoryCache } from '@apollo/client';
+import { SchemaLink } from '@apollo/client/link/schema';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import React, { ReactNode } from 'react';
+
+import typeDefs from '../types/seekSchema.graphql';
+
+interface Props {
+  children: ReactNode;
+  resolvers: Parameters<typeof makeExecutableSchema>[0]['resolvers'];
+}
+
+export const ApolloMockProvider = ({ children, resolvers }: Props) => {
+  const schema = makeExecutableSchema({
+    resolvers,
+    typeDefs,
+  });
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: new SchemaLink({ schema }),
+  });
+
+  return <ApolloProvider client={client}>{children}</ApolloProvider>;
+};

--- a/fe/lib/testing/graphql.d.ts
+++ b/fe/lib/testing/graphql.d.ts
@@ -1,0 +1,5 @@
+declare module '*.graphql' {
+  const schema: string;
+
+  export default schema;
+}

--- a/fe/lib/types/seek.graphql.ts
+++ b/fe/lib/types/seek.graphql.ts
@@ -1,5 +1,7 @@
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type Exact<T extends { [key: string]: unknown }> = {
+  [K in keyof T]: T[K];
+};
 /** All built-in and custom scalars, mapped to their actual values */
 export interface Scalars {
   ID: string;
@@ -1321,7 +1323,13 @@ export interface ApplicationMethodInput {
    *
    * When this is provided, SEEK's native apply form will be disabled and the candidate will be redirected to the supplied URL.
    */
-  applicationUri: WebUrlInput;
+  applicationUri?: Maybe<WebUrlInput>;
+  /**
+   * The email address to direct candidate applications to.
+   *
+   * This is deprecated; Do not use this field. This has been replaced by application export.
+   */
+  applicationEmail?: Maybe<EmailInput>;
 }
 
 /** The input parameter for the `closePostedPositionProfile` mutation. */
@@ -2226,15 +2234,29 @@ export interface UpdatePositionOpeningPersonContactsPayload {
 /** The output of the `updatePostedPositionProfile` mutation. */
 export interface UpdatePostedPositionProfilePayload {
   __typename?: 'UpdatePostedPositionProfilePayload';
+  /** Attributes of the updated position profile. */
+  positionProfile: UpdatePostedPositionProfilePositionProfilePayload;
+}
+
+/** Attributes of the updated position profile. */
+export interface UpdatePostedPositionProfilePositionProfilePayload {
+  __typename?: 'UpdatePostedPositionProfile_PositionProfilePayload';
   /** The identifier of the updated posted position profile. */
-  id: ObjectIdentifier;
+  profileId: ObjectIdentifier;
 }
 
 /** The output of the `closePostedPositionProfile` mutation. */
 export interface ClosePostedPositionProfilePayload {
   __typename?: 'ClosePostedPositionProfilePayload';
+  /** Attributes of the closed position profile. */
+  positionProfile: ClosePostedPositionProfilePositionProfilePayload;
+}
+
+/** Attributes of the closed position profile. */
+export interface ClosePostedPositionProfilePositionProfilePayload {
+  __typename?: 'ClosePostedPositionProfile_PositionProfilePayload';
   /** The identifier of the closed posted position profile. */
-  id: ObjectIdentifier;
+  profileId: ObjectIdentifier;
 }
 
 /** The output parameter for the `updateUnpostedPositionProfile` mutation. */
@@ -2529,7 +2551,12 @@ export interface ApplicationMethod {
    *
    * When this is provided, SEEK's native apply form will be disabled and the candidate will be redirected to the supplied URL.
    */
-  applicationUri: WebUrl;
+  applicationUri?: Maybe<WebUrl>;
+  /**
+   * The email address to direct candidate applications to.
+   * @deprecated Do not use this field. This has been replaced by application export.
+   */
+  applicationEmail?: Maybe<Email>;
 }
 
 /** A collection of information about the video to display alongside advertisement details. */
@@ -2563,6 +2590,15 @@ export interface PositionOpeningsFilterInput {
    * - `Closed` indicates the position opening has been closed.
    */
   statusCode?: Maybe<Scalars['String']>;
+}
+
+/** An action that can be executed as part of a workflow process. */
+export interface ProcessAction {
+  __typename?: 'ProcessAction';
+  /** The code of the action. */
+  code: Scalars['String'];
+  /** A deep link to the action. */
+  seekUrl?: Maybe<WebUrl>;
 }
 
 /** Information about a person not specific to a candidate profile. */
@@ -2753,14 +2789,32 @@ export interface PersonCompetency {
   competencyName: Scalars['String'];
 }
 
-/** Structured information about a candidate related to a particular application. */
+/** A source from which the candidate was obtained from. */
+export interface CandidateSource {
+  __typename?: 'CandidateSource';
+  /** Free text description of the source. */
+  name: Scalars['String'];
+  /**
+   * The grouping that the source falls under.
+   *
+   * Currently, two types are defined:
+   *
+   * - `PartnerUpload` indicates that the candidate was uploaded to SEEK from a
+   *   partner system.
+   * - `SeekApplication` indicates that the candidate applied for a position on
+   *   the SEEK candidate site.
+   */
+  type: Scalars['String'];
+}
+
+/** Structured information about a candidate in relation to a particular position. */
 export interface CandidateProfile {
   __typename?: 'CandidateProfile';
   /**
-   * The `Candidate` that submitted this application.
+   * The `Candidate` that this profile relates to.
    *
-   * This contains the candidate's personal details along with all their
-   * applications to the same hirer.
+   * This contains the candidate's personal details along with all their profiles
+   * for the same hirer.
    */
   candidate: Candidate;
   /**
@@ -2770,7 +2824,7 @@ export interface CandidateProfile {
    * to `candidateProfile`.
    */
   profileId: ObjectIdentifier;
-  /** The date & time the candidate applied for the position. */
+  /** The date & time the candidate was associated with the position. */
   createDateTime: Scalars['DateTime'];
   /** The positions this candidate has applied for. */
   associatedPositionOpenings: Array<AssociatedPositionOpening>;
@@ -2782,6 +2836,12 @@ export interface CandidateProfile {
   education: Array<EducationAttendance>;
   /** The skills or competencies of the candidate. */
   qualifications: Array<PersonCompetency>;
+  /** The sources from which the candidate was obtained from. */
+  candidateSources: Array<CandidateSource>;
+  /** The date & time the candidate profile was last updated. */
+  updateDateTime: Scalars['DateTime'];
+  /** A list of executable actions linked to the candidate profile. */
+  seekActions: Array<ProcessAction>;
   /** The completed candidate submission for the position profile's questionnaire. */
   seekQuestionnaireSubmission?: Maybe<ApplicationQuestionnaireSubmission>;
 }

--- a/fe/lib/types/seekSchema.graphql
+++ b/fe/lib/types/seekSchema.graphql
@@ -1,0 +1,3421 @@
+schema {
+  query: Query
+  mutation: Mutation
+}
+"""The schema's entry-point for queries. This acts as the public, top-level API from which all queries must start."""
+type Query {
+  """The API version."""
+  version: String!
+  """
+  An application questionnaire with the given `id`.
+  
+  Questionnaires can be associated with a `PositionProfile`.
+  
+  This query accepts browser tokens that include the `query:application-questionnaires` scope.
+  """
+  applicationQuestionnaire(
+    """The identifier of the application questionnaire to retrieve."""
+    id: String!
+  ): ApplicationQuestionnaire
+  """Ad products available when creating an advertisement."""
+  advertisementCreationProducts(
+    """The hirer identifier."""
+    hirerId: String!
+    """The current ad with possible field changes"""
+    draftAdvertisement: AdProductAdvertisementDraftInput!
+  ): [AdProduct!] @deprecated(reason: "Use `seekAnzHirerAdvertisementCreationProducts`.")
+  """Ad products available when updating an advertisement."""
+  advertisementModificationProducts(
+    """The hirer identifier."""
+    hirerId: String!
+    """The current ad when the client was initialised."""
+    advertisement: AdProductAdvertisementInput!
+    """The current ad with possible field changes"""
+    draftAdvertisement: AdProductAdvertisementDraftInput!
+  ): [AdProduct!] @deprecated(reason: "Use `seekAnzHirerAdvertisementModificationProducts`.")
+  """Ad products available when creating an advertisement."""
+  seekAnzHirerAdvertisementCreationProducts(
+    """The hirer identifier."""
+    hirerId: String!
+    """The current ad with possible field changes"""
+    draftAdvertisement: SeekAnzAdProductAdvertisementDraftInput!
+  ): [SeekAnzAdProduct!]
+  """Ad products available when updating an advertisement."""
+  seekAnzHirerAdvertisementModificationProducts(
+    """The hirer identifier."""
+    hirerId: String!
+    """The advertisement identifier."""
+    advertisementId: String!
+    """The advertisement with possible field changes."""
+    draftAdvertisement: SeekAnzAdProductAdvertisementDraftInput!
+  ): [SeekAnzAdProduct!]
+  """
+  Ad products available when updating an advertisement.
+  
+  Use this query when you don't have the live advertisement identifier.
+  """
+  seekAnzHirerAdvertisementModificationProductsAlt(
+    """The hirer identifier."""
+    hirerId: String!
+    """The advertisement before any field changes."""
+    advertisement: SeekAnzAdProductAdvertisementInput!
+    """The advertisement with possible field changes."""
+    draftAdvertisement: SeekAnzAdProductAdvertisementDraftInput!
+  ): [SeekAnzAdProduct!]
+  """
+  The job category for the given `id`.
+  
+  This query accepts browser tokens that include the `query:ontologies` scope.
+  """
+  jobCategory(
+    """The job category identifier."""
+    id: String!
+  ): JobCategory
+  """
+  A list of top-level job categories for the provided scheme.
+  
+  This query accepts browser tokens that include the `query:ontologies` scope.
+  """
+  jobCategories(
+    """
+    The scheme of the job categories.
+    
+    Currently, only `seekAnz` and `seekAnzPublicTest` are supported.
+    """
+    schemeId: String!
+  ): [JobCategory!]!
+  """
+  An array of suggested job categories for the provided partial `PositionProfile`.
+  
+  This query accepts browser tokens that include the `query:ontologies` scope.
+  """
+  jobCategorySuggestions(
+    """
+    The partial position profile to suggest a job category for.
+    
+    This should include the same field values that will eventually be used to create or post the `PositionProfile`.
+    """
+    positionProfile: JobCategorySuggestionPositionProfileInput!
+    """
+    The scheme of the suggested job categories.
+    
+    Currently, only `seekAnz` and `seekAnzPublicTest` are supported.
+    """
+    schemeId: String!
+    """
+    The identifier for the organization hiring for the position.
+    
+    This is deprecated; use `positionProfile.positionOrganizations` instead.
+    """
+    hirerId: String
+    """
+    A non-negative limit to the number of job categories to return.
+    
+    Defaults to 10.
+    """
+    first: Int
+  ): [JobCategorySuggestionChoice!]!
+  """
+  A location node with the given location `id`.
+  
+  This query accepts browser tokens that include the `query:ontologies` scope.
+  """
+  location(
+    """The location identifier."""
+    id: String!
+  ): Location
+  """
+  An array of location nodes relevant to the text provided.
+  
+  This query accepts browser tokens that include the `query:ontologies` scope.
+  """
+  locationSuggestions(
+    """
+    The context that the location suggestions will be used for.
+    
+    The only supported value is `PositionPosting` which returns locations for the purposes of posting a position profile.
+    Additional values will be added in the future.
+    """
+    usageTypeCode: String!
+    """
+    The scheme for the location dataset to query.
+    
+    Currently, only `seekAnz` and `seekAnzPublicTest` are supported.
+    """
+    schemeId: String!
+    """
+    The hirer identifier for relevant locations result.
+    
+    `hirerId` is ignored when its scheme doesn't match `schemeId`.
+    """
+    hirerId: String
+    """The input used for the location suggestions."""
+    text: String!
+    """
+    A non-negative limit to the number of locations to return.
+    
+    Defaults to 20.
+    """
+    first: Int
+  ): [LocationSuggestion!]
+  """
+  An array of locations relevant to the provided geolocation ordered by distance.
+  
+  This query accepts browser tokens that include the `query:ontologies` scope.
+  """
+  nearestLocations(
+    """
+    The scheme for the location dataset to query.
+    
+    Currently, only `seekAnz` and `seekAnzPublicTest` are supported.
+    """
+    schemeId: String!
+    """The geolocation coordinates input used for the location suggestions."""
+    geoLocation: GeoLocationInput!
+    """
+    A non-negative limit to the number of locations to return.
+    
+    Defaults to the maximum value of 10.
+    """
+    first: Int
+  ): [Location!]
+  """
+  The hiring organization for the given `id`.
+  
+  This query accepts browser tokens that include the `query:organizations` scope.
+  """
+  hiringOrganization(
+    """The hiring organization identifier."""
+    id: String!
+  ): HiringOrganization
+  """
+  A hiring organization corresponding to the given SEEK ANZ advertiser ID.
+  
+  This query accepts browser tokens that include the `query:organizations` scope.
+  """
+  seekAnzAdvertiser(
+    """
+    The legacy SEEK ANZ advertiser ID.
+    
+    This is a numeric identifier used by SEEK ANZ's legacy Job Posting & Application Export APIs.
+    """
+    id: Int!
+  ): HiringOrganization
+  """A page of advertisement brandings associated with the specified `hirerId`."""
+  advertisementBrandings(
+    """
+    An opaque cursor to the earlier bounding advertisement brandings.
+    
+    Resulting advertisement brandings will _succeed_ this cursor.
+    """
+    after: String
+    """
+    An opaque cursor to the later bounding advertisement brandings.
+    
+    Resulting advertisement brandings will _precede_ this cursor.
+    """
+    before: String
+    """
+    The upper limit of advertisement brandings to return from the start of the list.
+    
+    Defaults to 10 if neither `first` nor `last` are specified.
+    Excess advertisement brandings will be trimmed from the end of the list.
+    
+    `first` and `last` cannot be specified in the same query.
+    """
+    first: Int
+    """
+    The upper limit of advertisement brandings to return from the end of the list.
+    
+    Excess advertisement brandings will be trimmed from the start of the list.
+    
+    `first` and `last` cannot be specified in the same query.
+    """
+    last: Int
+    """The hirer identifier."""
+    hirerId: String!
+  ): AdvertisementBrandingsConnection!
+  """The advertisement branding for the given `id`."""
+  advertisementBranding(
+    """The advertisement branding identifier."""
+    id: String!
+  ): AdvertisementBranding
+  """A position opening with the given `id`."""
+  positionOpening(
+    """
+    The position opening identifier.
+    
+    This is the `documentId` of the returned `PositionOpening` object.
+    """
+    id: String!
+  ): PositionOpening
+  """A position profile with its position opening, given the position profile `id`."""
+  positionOpeningWithPositionProfile(
+    """
+    The position profile identifier.
+    
+    This is the `profileId` of the returned `PositionProfile` object.
+    """
+    id: String!
+  ): PositionOpening
+  """A position profile with the given `id`."""
+  positionProfile(
+    """
+    The position profile identifier.
+    
+    This is the `profileId` of the returned `PositionProfile` object.
+    """
+    id: String!
+  ): PositionProfile
+  """A page of position openings for the given `hirerId`."""
+  positionOpenings(
+    """The opaque identifier of the hiring organization to retrieve position openings for."""
+    hirerId: String!
+    """
+    An opaque cursor to the earlier bounding page.
+    
+    Resulting position openings will _succeed_ this cursor.
+    """
+    after: String
+    """
+    The upper limit of position openings to return from the start of the list.
+    
+    Defaults to 10 if `first` is not specified.
+    Excess position openings will be trimmed from the end of the list.
+    """
+    first: Int
+    """The additional `PositionOpening`-specific criteria to filter by."""
+    filter: PositionOpeningsFilterInput
+  ): PositionOpeningConnection!
+  """
+  A candidate with the given `applicationProfileId` with only that
+  profile included.
+  
+  This will include the candidate's personal details along with the
+  profile they've elected to represent them for this application.
+  """
+  candidateWithApplicationProfile(
+    """The application profile identifier to retrieve."""
+    applicationProfileId: String!
+  ): Candidate @deprecated(reason: "Use `candidateProfile` and select the `candidate` field.")
+  """The `CandidateProfile` for the given `id`."""
+  candidateProfile(
+    """
+    The profile identifier.
+    
+    This is the `profileId` of the returned `CandidateProfile` object.
+    """
+    id: String!
+  ): CandidateProfile
+  """
+  The candidate for the given `id`.
+  
+  This will include the candidate's personal details along with all
+  application profiles for a single hirer.
+  """
+  candidate(
+    """
+    The candidate identifier.
+    
+    This is the `documentId` of the returned `Candidate` object.
+    """
+    id: String!
+  ): Candidate
+  """
+  A page of webhook attempts matching the specified criteria generated by a selected subscription.
+  
+  The result list is returned in ascending creation date & time order.
+  It starts from the earliest known attempt if no pagination arguments are provided.
+  """
+  webhookAttemptsForSubscription(
+    """
+    An opaque cursor to the earlier bounding webhook attempt.
+    
+    Resulting webhook attempts will _succeed_ this cursor.
+    """
+    after: String
+    """
+    An opaque cursor to the later bounding webhook attempt.
+    
+    Resulting webhook attempts will _precede_ this cursor.
+    """
+    before: String
+    """
+    The upper limit of webhook attempts to return from the start of the list.
+    
+    Defaults to 10 if neither `first` nor `last` are specified.
+    Excess webhook attempts will be trimmed from the end of the list.
+    
+    `first` and `last` cannot be specified in the same query.
+    """
+    first: Int
+    """
+    The upper limit of webhook attempts to return from the end of the list.
+    
+    Excess webhook attempts will be trimmed from the start of the list.
+    
+    `first` and `last` cannot be specified in the same query.
+    """
+    last: Int
+    """The additional `WebhookAttempt`-specific criteria to filter by."""
+    filter: WebhookAttemptsFilterInput
+    """The subscription opaque identifier that generated the attempts."""
+    subscriptionId: String!
+  ): WebhookAttemptsConnection!
+  """
+  A page of webhook attempts matching the specified criteria generated by a selected event.
+  
+  The result list is returned in ascending creation date & time order.
+  It starts from the earliest known attempt if no pagination arguments are provided.
+  """
+  webhookAttemptsForEvent(
+    """
+    An opaque cursor to the earlier bounding webhook attempt.
+    
+    Resulting webhook attempts will _succeed_ this cursor.
+    """
+    after: String
+    """
+    An opaque cursor to the later bounding webhook attempt.
+    
+    Resulting webhook attempts will _precede_ this cursor.
+    """
+    before: String
+    """
+    The upper limit of webhook attempts to return from the start of the list.
+    
+    Defaults to 10 if neither `first` nor `last` are specified.
+    Excess webhook attempts will be trimmed from the end of the list.
+    
+    `first` and `last` cannot be specified in the same query.
+    """
+    first: Int
+    """
+    The upper limit of webhook attempts to return from the end of the list.
+    
+    Excess webhook attempts will be trimmed from the start of the list.
+    
+    `first` and `last` cannot be specified in the same query.
+    """
+    last: Int
+    """The additional `WebhookAttempt`-specific criteria to filter by."""
+    filter: WebhookAttemptsFilterInput
+    """The event opaque identifier that generated the attempts."""
+    eventId: String!
+  ): WebhookAttemptsConnection!
+  """The webhook subscription for the given `id`."""
+  webhookSubscription(
+    """The webhook subscription identifier."""
+    id: String!
+  ): WebhookSubscription
+  """
+  A page of webhook subscriptions matching the specified criteria.
+  
+  The result list is returned in ascending creation date & time order.
+  It starts from the earliest known subscription if no pagination arguments are provided.
+  """
+  webhookSubscriptions(
+    """
+    An opaque cursor to the earlier bounding webhook subscription.
+    
+    Resulting webhook subscriptions will _succeed_ this cursor.
+    """
+    after: String
+    """
+    An opaque cursor to the later bounding webhook subscription.
+    
+    Resulting webhook subscriptions will _precede_ this cursor.
+    """
+    before: String
+    """
+    The upper limit of webhook subscriptions to return from the start of the list.
+    
+    Defaults to 10 if neither `first` nor `last` are specified.
+    Excess webhook subscriptions will be trimmed from the end of the list.
+    
+    `first` and `last` cannot be specified in the same query.
+    """
+    first: Int
+    """
+    The upper limit of webhook subscriptions to return from the end of the list.
+    
+    Excess webhook subscriptions will be trimmed from the start of the list.
+    
+    `first` and `last` cannot be specified in the same query.
+    """
+    last: Int
+    """The additional `WebhookSubscription`-specific criteria to filter by."""
+    filter: WebhookSubscriptionsFilterInput
+    """
+    The data source for the webhook subscription.
+    
+    This commonly refers to a SEEK brand.
+    See the relevant `WebhookSubscription` implementation for a list of supported schemes.
+    """
+    schemeId: String!
+  ): WebhookSubscriptionsConnection!
+  """The event for the given `id`."""
+  event(
+    """The event identifier."""
+    id: String!
+  ): Event
+  """
+  A page of events matching the specified criteria.
+  
+  The result list is returned in ascending stream date & time order.
+  It starts from the earliest known event if no pagination arguments are provided.
+  """
+  events(
+    """
+    An opaque cursor to the earlier bounding event.
+    
+    Resulting events will _succeed_ this cursor.
+    """
+    after: String
+    """
+    An opaque cursor to the later bounding event.
+    
+    Resulting events will _precede_ this cursor.
+    """
+    before: String
+    """
+    The upper limit of events to return from the start of the list.
+    
+    Defaults to 10 if neither `first` nor `last` are specified.
+    Excess events will be trimmed from the end of the list.
+    
+    `first` and `last` cannot be specified in the same query.
+    """
+    first: Int
+    """
+    The upper limit of events to return from the end of the list.
+    
+    Excess events will be trimmed from the start of the list.
+    
+    `first` and `last` cannot be specified in the same query.
+    """
+    last: Int
+    """The additional `Event`-specific criteria to filter by."""
+    filter: EventsFilterInput
+    """
+    The data source for the event.
+    
+    This commonly refers to a SEEK brand.
+    See the relevant `Event` implementation for a list of supported schemes.
+    """
+    schemeId: String!
+  ): EventsConnection!
+}
+"""The schema's entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start."""
+type Mutation {
+  _empty: String
+  """
+  Creates a new questionnaire.
+  
+  This mutation accepts browser tokens that include the `mutate:questionnaires` scope.
+  """
+  createApplicationQuestionnaire(input: CreateApplicationQuestionnaireInput!): CreateApplicationQuestionnairePayload!
+  """
+  Creates a new position opening.
+  
+  Every position profile belongs to a position opening.
+  Multiple position profiles may belong to the same position opening.
+  """
+  createPositionOpening(input: CreatePositionOpeningInput!): CreatePositionOpeningPayload!
+  """Replaces an existing position opening's person contacts."""
+  updatePositionOpeningPersonContacts(input: UpdatePositionOpeningPersonContactsInput!): UpdatePositionOpeningPersonContactsPayload
+  """
+  Update the status of a position opening.
+  
+  This status is provided to help hirers manage position openings.
+  The SEEK API does not use the position opening's status itself.
+  """
+  updatePositionOpeningStatus(input: UpdatePositionOpeningStatusInput!): UpdatePositionOpeningStatusPayload
+  """
+  Deletes an empty position opening.
+  
+  Each position profile that belongs to a position opening must be deleted before the position opening can be deleted.
+  """
+  deletePositionOpening(input: DeletePositionOpeningInput!): DeletePositionOpeningPayload
+  """Creates a new position profile for an opening and posts it."""
+  postPositionProfileForOpening(input: PostPositionProfileForOpeningInput!): PostPositionProfileForOpeningPayload!
+  """
+  Updates an existing posted position profile.
+  
+  The position profile's existing fields will be replaced with the provided input fields.
+  This will update the position's live job ad under its current URL.
+  """
+  updatePostedPositionProfile(input: UpdatePostedPositionProfileInput!): UpdatePostedPositionProfilePayload
+  """
+  Closes an existing posted position profile.
+  
+  The job ad will be removed from the job board and no refund will be issued.
+  The `PositionProfile` and its associated candidate applications will be available for 6 months after its close date.
+  """
+  closePostedPositionProfile(input: ClosePostedPositionProfileInput!): ClosePostedPositionProfilePayload
+  """Posts a live job ad for a new position."""
+  postPosition(input: PostPositionInput!): PostPositionPayload!
+  """Creates a new unposted position profile for an opening."""
+  createUnpostedPositionProfileForOpening(input: CreateUnpostedPositionProfileForOpeningInput!): CreateUnpostedPositionProfileForOpeningPayload!
+  """Updates an existing unposted position profile."""
+  updateUnpostedPositionProfile(input: UpdateUnpostedPositionProfileInput!): UpdateUnpostedPositionProfilePayload
+  """Deletes an unposted position profile."""
+  deleteUnpostedPositionProfile(input: DeleteUnpostedPositionProfileInput!): DeleteUnpostedPositionProfilePayload
+  """Creates a new webhook subscription."""
+  createWebhookSubscription(input: CreateWebhookSubscriptionInput!): CreateWebhookSubscriptionPayload!
+  """
+  Updates an existing webhook subscription's delivery configuration.
+  
+  This modifies fields related to the URL, payload & signature of an existing webhook subscription.
+  Changes may take up to half an hour to take effect.
+  
+  The fields that determine which events are to be delivered are immutable.
+  A new webhook subscription should be created for such cases.
+  """
+  updateWebhookSubscriptionDeliveryConfiguration(input: UpdateWebhookSubscriptionDeliveryConfigurationInput!): UpdateWebhookSubscriptionDeliveryConfigurationPayload
+  """Deletes an existing webhook subscription."""
+  deleteWebhookSubscription(input: DeleteWebhookSubscriptionInput!): DeleteWebhookSubscriptionPayload
+}
+"""An address of a human-accessible web page."""
+type WebUrl {
+  """The URL of the web page."""
+  url: String!
+}
+"""An email address."""
+type Email {
+  """The email address."""
+  address: String!
+}
+"""An email address."""
+input EmailInput {
+  """The email address."""
+  address: String!
+}
+"""The phone number of a person."""
+type Phone {
+  """The phone number represented as a human readable string."""
+  formattedNumber: String!
+}
+"""The phone number of a person."""
+input PhoneInput {
+  """The phone number represented as a human readable string."""
+  formattedNumber: String!
+}
+"""Communication channels for a person."""
+type Communication {
+  """
+  An array of phone numbers for the person.
+  
+  The phone numbers are ordered in descending preference.
+  """
+  phone: [Phone!]!
+  """
+  An array of email addresses for the person.
+  
+  The email addresses are ordered in descending preference.
+  """
+  email: [Email!]!
+}
+"""Communication channels for a person."""
+input CommunicationInput {
+  """
+  An array of phone numbers for the person.
+  
+  The phone numbers are ordered in descending preference.
+  """
+  phone: [PhoneInput!]!
+  """
+  An array of email addresses for the person.
+  
+  The email addresses are ordered in descending preference.
+  """
+  email: [EmailInput!]!
+}
+"""An address of a human-accessible web page."""
+input WebUrlInput {
+  """The URL of the web page."""
+  url: String!
+}
+"""A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar."""
+scalar DateTime
+"""A date string, such as 2007-12-03, compliant with the `full-date` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar."""
+scalar Date
+"""
+A date string compliant with the ISO 8601 "year", "year and month" or "complete date" formats.
+For example, `"2020"`, `"2020-05"` and `"2020-05-27"` are all valid for `HistoryDate`.
+
+This is used for dates in a candidate's position & employment histories where the precise month or day may not have been provided.
+"""
+scalar HistoryDate
+"""An opaque identifier for GraphQL objects."""
+type ObjectIdentifier {
+  """The identifier itself."""
+  value: String!
+}
+"""
+A monetary amount expressed as an integer in a specified minor currency unit.
+
+This is used to avoid floating point rounding errors when expressing prices & funds.
+"""
+type Money {
+  """
+  The three-letter ISO 4217 currency code, in uppercase.
+  
+  This must be a supported currency. Currently supported codes are: `AUD`
+  and `NZD`. Additional codes may be added in the future.
+  """
+  currencyCode: String!
+  """
+  A positive integer in the minor currency unit for the ISO currency code.
+  
+  This is the number of cents in dollar-denominated currencies e.g. 1000
+  cents for $10.00.
+  """
+  amount: Int!
+}
+"""
+Pagination metadata for a result list.
+
+This is compliant with the _Relay Cursor Connections Specification_:
+
+<https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo>
+"""
+type PageInfo {
+  """Whether there is a previous page of results at the time of retrieval."""
+  hasPreviousPage: Boolean!
+  """Whether there is a next page of results at the time of retrieval."""
+  hasNextPage: Boolean!
+  """An opaque string cursor for retrieving the previous page of results."""
+  startCursor: String
+  """An opaque string cursor for retrieving the next page of results."""
+  endCursor: String
+}
+"""
+A set of questions presented to a candidate during an application.
+
+This can be associated with one or more `PositionProfile`s when they are created.
+"""
+type ApplicationQuestionnaire {
+  """An opaque identifier for the questionnaire."""
+  id: ObjectIdentifier!
+  """The array of components in the order they are presented to the candidate."""
+  components: [ApplicationQuestionnaireComponent!]!
+}
+"""
+A component of an application questionnaire.
+
+This only contains identifying metadata;
+the `componentTypeCode` can be used to determine the concrete type of the component.
+"""
+interface ApplicationQuestionnaireComponent {
+  """An opaque identifier for the component."""
+  id: ObjectIdentifier!
+  """
+  The type of the component. Currently, this can be:
+  
+  - "Question" which corresponds to the `ApplicationQuestion` type.
+  - "PrivacyConsent" which corresponds to the `ApplicationPrivacyConsent` type.
+  """
+  componentTypeCode: String!
+  """
+  A partner provided unique reference ID to the component.
+  
+  This can be used to correlate the component with the submission.
+  """
+  value: String
+}
+"""
+A question component of an `ApplicationQuestionnaire`.
+
+This consists of label text displayed to a user and an input for them to select a response.
+"""
+type ApplicationQuestion implements ApplicationQuestionnaireComponent {
+  """An opaque identifier for the question."""
+  id: ObjectIdentifier!
+  """
+  The type of the component.
+  
+  This is always "Question".
+  """
+  componentTypeCode: String!
+  """
+  A partner provided unique reference ID to the question.
+  
+  This can be used to correlate the question with the submitted question components.
+  """
+  value: String
+  """
+  The HTML snippet of the question being asked to the candidate.
+  
+  Unsupported tags will be silently stripped when creating a questionnaire.
+  """
+  questionHtml: String!
+  """
+  The type of the question response.
+  
+  The three possible values of this are:
+  
+  - "SingleSelect" for choosing a single response from `responseChoice`.
+  - "MultiSelect" for choosing one or more responses from `responseChoice`.
+  - "FreeText" for a free text response.
+  """
+  responseTypeCode: String!
+  """
+  The collection of possible responses.
+  
+  For "SingleSelect" and "MultiSelect" this must contain at least one element.
+  """
+  responseChoice: [ApplicationQuestionChoice!]
+}
+"""
+A privacy policy consent component of an `ApplicationQuestionnaire`.
+
+This consists of a URL for candidates to view the privacy policy and text to prompt the candidate as to whether or not they agree.
+
+The privacy policy consent component presents the candidate with a 'Yes' or 'No' choice.
+"""
+type ApplicationPrivacyConsent implements ApplicationQuestionnaireComponent {
+  """An opaque identifier for the question."""
+  id: ObjectIdentifier!
+  """
+  The type of the component.
+  
+  This is always "PrivacyConsent".
+  """
+  componentTypeCode: String!
+  """
+  A partner provided unique reference ID to the question.
+  
+  This can be used to correlate the question with the submitted question components.
+  """
+  value: String
+  """The URL of the privacy policy to show to the candidate."""
+  privacyPolicyUrl: WebUrl!
+  """
+  The HTML snippet to prompt the candidate for consent.
+  
+  Unsupported tags will be silently stripped when creating a questionnaire.
+  
+  This is optional and will default to 'Do you agree to the privacy policy?'
+  """
+  descriptionHtml: String
+}
+"""A possible response to an `ApplicationQuestion`."""
+type ApplicationQuestionChoice {
+  """An opaque identifier for the question choice."""
+  id: ObjectIdentifier!
+  """Text of the choice displayed to the candidate."""
+  text: String!
+  """
+  A partner provided unique reference ID to the question choice.
+  
+  This can be used to correlate the question with the submitted answers.
+  """
+  value: String
+  """
+  Indicates if this choice is preferred when scoring the answers.
+  
+  This is not displayed to the candidate.
+  """
+  preferredIndicator: Boolean!
+}
+"""
+A response to a component in a questionnaire.
+
+This only contains metadata related to the component responded to in the questionnaire.
+The implementation of a response is based on the `componentTypeCode` of its component.
+"""
+interface ApplicationQuestionnaireComponentResponse {
+  """The component this is responding to."""
+  component: ApplicationQuestionnaireComponent!
+  """
+  The type of the component. Currently, this can be:
+  
+  - "Question" which corresponds to the `ApplicationQuestion` type.
+  - "PrivacyConsent" which corresponds to the `ApplicationPrivacyConsent` type.
+  """
+  componentTypeCode: String!
+}
+"""A single answer to a question in the questionnaire."""
+type ApplicationQuestionAnswer {
+  """
+  The questionnaire choice for the current answer.
+  
+  For `FreeText` questions this will be `null`.
+  """
+  choice: ApplicationQuestionChoice
+  """The text value of the selected answer."""
+  answer: String!
+}
+"""A candidate's response to a question in the questionnaire."""
+type ApplicationQuestionResponse implements ApplicationQuestionnaireComponentResponse {
+  """The question this is responding to."""
+  component: ApplicationQuestion!
+  """
+  The type of the component.
+  
+  This is always "Question".
+  """
+  componentTypeCode: String!
+  """
+  The answers provided by the candidate.
+  
+  For "SingleSelect" and "FreeText" this will be a single element array.
+  """
+  answers: [ApplicationQuestionAnswer!]!
+  """
+  How well the candidate answered the question against the hirer's preferences.
+  
+  Score is calculated based off the `responseTypeCode`:
+  - For a `SingleSelect` question the score will be either 1 or 0 based off whether or not the candidate selected a preferred answer.
+  - For a `MultiSelect` question the score will be between 0 and 1 as a floating point. For example, if the candidate selected half of the preferred answers, the score would be 0.5.
+  - For a `FreeText` the score will be null.
+  """
+  score: Float
+}
+"""A candidate's response to a privacy policy consent component in the questionnaire."""
+type ApplicationPrivacyConsentResponse implements ApplicationQuestionnaireComponentResponse {
+  """The privacy consent component this is responding to."""
+  component: ApplicationPrivacyConsent!
+  """
+  The type of the component.
+  
+  This is always "PrivacyConsent".
+  """
+  componentTypeCode: String!
+  """This indicates whether or not the candidate agrees to the provided privacy policy."""
+  consentGivenIndicator: Boolean!
+}
+"""A completed candidate submission for an `ApplicationQuestionnaire`."""
+type ApplicationQuestionnaireSubmission {
+  """The set of questions presented to the candidate during the application."""
+  questionnaire: ApplicationQuestionnaire!
+  """The candidate's responses to the application's questionnaire."""
+  responses: [ApplicationQuestionnaireComponentResponse!]!
+  """
+  The indication of how well the candidate scored on all questions in the questionnaire.
+  
+  The score is a calculation between 0 and 1 as a floating point.
+  For example, if the candidate received a score of 1 on one question, and a score of 0 on another, this overall score would be calculated as 0.5.
+  If there are no scored questions this score will be null.
+  """
+  score: Float
+}
+"""
+A privacy policy consent component of an `ApplicationQuestionnaire`.
+
+This consists of a URL for candidates to view the privacy policy and text to prompt the candidate as to whether or not they agree.
+
+The privacy policy consent component always defaults the available response choices for the candidate to 'Yes' and 'No'.
+"""
+input ApplicationPrivacyConsentInput {
+  """
+  The type of the component.
+  
+  This is always "PrivacyConsent".
+  """
+  componentTypeCode: String!
+  """
+  A partner provided unique reference ID to the consent component.
+  
+  This can be used to correlate the consent component with the submitted response.
+  """
+  value: String
+  """The URL of the privacy policy to show to the candidate."""
+  privacyPolicyUrl: WebUrlInput!
+  """
+  The HTML snippet to prompt the candidate for consent.
+  
+  Unsupported tags will be silently stripped when creating a questionnaire.
+  
+  This is optional and will default to 'Do you agree to the privacy policy?'
+  """
+  descriptionHtml: String
+}
+"""
+A question component of an `ApplicationQuestionnaire`.
+
+This consists of label text displayed to a user and an input for them to select a response.
+"""
+input ApplicationQuestionInput {
+  """
+  The type of the component.
+  
+  This is always "Question".
+  """
+  componentTypeCode: String!
+  """
+  The HTML snippet of the question being asked to the candidate.
+  
+  Unsupported tags will be silently stripped when creating a questionnaire.
+  """
+  questionHtml: String!
+  """
+  The type of the question response.
+  
+  The three possible values of this are:
+  
+  - "SingleSelect" for choosing a single response from `responseChoice`.
+  - "MultiSelect" for choosing one or more responses from `responseChoice`.
+  - "FreeText" for a free text response.
+  """
+  responseTypeCode: String!
+  """
+  A unique ID for this question.
+  
+  This can be used to correlate the question with the provided answers.
+  This must be unique within the questionnaire.
+  """
+  value: String!
+  """
+  The collection of possible responses.
+  
+  For "SingleSelect" and "MultiSelect" this must contain at least one element.
+  """
+  responseChoice: [ApplicationQuestionChoiceInput!]
+}
+"""A possible response to an `ApplicationQuestion`."""
+input ApplicationQuestionChoiceInput {
+  """Text of the choice displayed to the candidate."""
+  text: String!
+  """
+  A unique ID for this choice.
+  
+  This can be used to correlate the choice with the provided answers.
+  This must be unique within the questionnaire.
+  """
+  value: String!
+  """
+  Indicates if this choice is preferred when scoring the answers.
+  
+  This is not displayed to the candidate.
+  """
+  preferredIndicator: Boolean!
+}
+"""A component of the questionnaire to be created."""
+input ApplicationQuestionnaireComponentInput {
+  """
+  The type of the component. Currently, this can be:
+  
+  - "Question" which corresponds to the `question` property.
+  - "PrivacyConsent" which corresponds to the `privacyConsent` property.
+  """
+  componentTypeCode: String!
+  """
+  A question component of an `ApplicationQuestionnaire`.
+  
+  This must be provided if the `componentTypeCode` is `Question`.
+  """
+  question: ApplicationQuestionInput
+  """
+  A privacy consent component of an `ApplicationQuestionnaire`.
+  
+  This must be provided if the `componentTypeCode` is `PrivacyConsent`.
+  """
+  privacyConsent: ApplicationPrivacyConsentInput
+}
+"""The details of the questionnaire to be created."""
+input CreateApplicationQuestionnaire_ApplicationQuestionnaireInput {
+  """
+  The identifier for the hirer that will own the questionnaire.
+  
+  Hirers can only associate position profiles with questionnaires they own.
+  """
+  hirerId: String!
+  """The array of components in the order they are presented to the candidate."""
+  components: [ApplicationQuestionnaireComponentInput!]!
+}
+"""The input parameter for the `createApplicationQuestionnaire` mutation."""
+input CreateApplicationQuestionnaireInput {
+  """The details of the questionnaire to be created."""
+  applicationQuestionnaire: CreateApplicationQuestionnaire_ApplicationQuestionnaireInput!
+}
+"""The output parameter for the `createApplicationQuestionnaire` mutation."""
+type CreateApplicationQuestionnairePayload {
+  """The details of the created questionnaire."""
+  applicationQuestionnaire: ApplicationQuestionnaire!
+}
+"""The types of ads which can be placed."""
+enum AdvertisementType {
+  """A standard ad."""
+  CLASSIC
+  """Ad with branding."""
+  STANDOUT
+  """Featured ad"""
+  PREMIUM
+}
+type AdProduct {
+  """The type of the ad product."""
+  advertisementType: AdvertisementType!
+  """The name of the ad product."""
+  name: String!
+  """The description of the ad product."""
+  description: String!
+  """The price component of the ad product."""
+  price: AdProductPrice!
+  """Whether the ad product is enabled."""
+  enabled: Boolean!
+  """How the ad product would be paid."""
+  checkoutEstimate: AdProductCheckoutEstimate!
+  """Disclosures related to the ad product."""
+  disclosures: [Disclosure!]!
+  """Information messages"""
+  messages: [String!]!
+}
+type AdProductPrice {
+  """The product price without tax"""
+  amountExcludingTax: Money
+  """Descriptive summary of the Product Price"""
+  summary: String!
+  """Indicates whether the price can be shown to the hirer"""
+  canBeShownToHirer: Boolean!
+  """Specifies whether taxes will be added when purchased."""
+  taxable: Boolean!
+}
+type AdProductCheckoutEstimate {
+  """The amount left to be paid."""
+  paymentDueExcludingTax: Money
+  """Checkout estimate summary"""
+  summary: String!
+  """Contract component of the checkout estimate"""
+  contractConsumption: AdProductContractConsumption
+}
+type AdProductContractConsumption {
+  """Summary of contract consumption"""
+  summary: String!
+  """Type of contract consumption."""
+  type: AdProductContractConsumptionType!
+}
+input AdProductAdvertisementInput {
+  """The type of the ad product. Classic, StandOut or Premium"""
+  type: AdvertisementType!
+  """The advertisement identifier."""
+  id: String
+  """The hirer's job reference"""
+  hirerJobReference: String
+  """The position title"""
+  positionTitle: String!
+  """The job category identifier"""
+  jobCategoryId: String!
+  """The position location identifier"""
+  positionLocationId: String!
+}
+input AdProductAdvertisementDraftInput {
+  """The type of the ad product. Classic, StandOut or Premium"""
+  type: AdvertisementType
+  """The advertisement identifier."""
+  id: String
+  """The hirer's job reference"""
+  hirerJobReference: String
+  """The position title"""
+  positionTitle: String
+  """The job category identifier"""
+  jobCategoryId: String
+  """The position location identifer"""
+  positionLocationId: String
+}
+enum AdProductContractConsumptionType {
+  """A contract will be consumed of the same ad type as the product."""
+  SAME_ADTYPE
+  """A contract will be consumed of a different ad type than the product."""
+  OTHER_ADTYPE
+  """A contract will be consumed of the same ad type as the product and an invoice will be generated."""
+  SAME_ADTYPE_PLUS_INVOICE
+}
+"""A disclosure shown to the hirer for the current ad product."""
+type Disclosure {
+  """The type of the disclosure message."""
+  type: DisclosureType!
+  """The content of the disclosure message."""
+  message: String!
+}
+"""The type of disclosure message."""
+enum DisclosureType {
+  """A disclosure relating to a pricing error."""
+  PRICING_ERROR
+  """A disclosure relating to an impact on premium ad performance."""
+  PREMIUM_PERFORMANCE_CHANGE
+  """A disclosure relating to a price increase in update mode for SEEK contracts."""
+  UPDATE_PRICING_INCREASE
+}
+type SeekAnzAdProduct {
+  """
+  The type of the ad product.
+  
+  Currently, three codes are defined:
+  - `Classic` indicates a Classic ad.
+  - `StandOut` indicates a StandOut ad.
+  - `Premium` indicates a Premium ad.
+  """
+  advertisementTypeCode: String!
+  """The ad product name."""
+  name: String!
+  """The description of the ad product."""
+  description: String!
+  """The price component of the ad product."""
+  price: SeekAnzAdProductPrice!
+  """Indicates whether the ad product is enabled."""
+  enabledIndicator: Boolean!
+  """How the ad product would be paid."""
+  checkoutEstimate: SeekAnzAdProductCheckoutEstimate!
+  """Messages that may be shown to hirer."""
+  messages: [SeekAnzAdProductMessage!]!
+}
+type SeekAnzAdProductPrice {
+  """The product price without tax"""
+  amountExcludingTax: CurrencyMinorUnit
+  """Descriptive summary of the Product Price"""
+  summary: String!
+  """Indicates whether the price can be shown to the hirer"""
+  visibleForHirerIndicator: Boolean!
+  """Indicates whether taxes will be added when purchased."""
+  taxedIndicator: Boolean!
+}
+type SeekAnzAdProductCheckoutEstimate {
+  """The amount left to be paid."""
+  paymentDueExcludingTax: CurrencyMinorUnit
+  """Checkout estimate summary"""
+  summary: String!
+  """Contract component of the checkout estimate"""
+  contractConsumption: SeekAnzAdProductContractConsumption
+}
+type SeekAnzAdProductContractConsumption {
+  """Summary of contract consumption"""
+  summary: String!
+  """
+  Type of contract consumption.
+  
+  Currently, three codes are defined:
+  - `SameAdType` indicates payment due will be consumed from a contract of the same ad type as this product.
+  - `OtherAdType` indicates payment due will be consumed from a contract of a different ad type to this product.
+  - `SameAdTypePlusInvoice` indicates payment due will be consumed from a contract of the same ad type as this product and an invoice will be generated.
+  """
+  typeCode: String!
+}
+input SeekAnzAdProductAdvertisementInput {
+  """
+  The type of ad product.
+  
+  Currently, three codes are defined:
+  - `Classic` indicates a Classic ad.
+  - `StandOut` indicates a StandOut ad.
+  - `Premium` indicates a Premium ad.
+  """
+  typeCode: String!
+  """The advertisement identifier."""
+  id: String
+  """The hirer's job reference"""
+  hirerJobReference: String
+  """The position title"""
+  positionTitle: String!
+  """The job category identifier"""
+  jobCategoryId: String!
+  """The position location identifier"""
+  positionLocationId: String!
+}
+input SeekAnzAdProductAdvertisementDraftInput {
+  """
+  The type of ad product.
+  
+  Currently, three codes are defined:
+  - `Classic` indicates a Classic ad.
+  - `StandOut` indicates a StandOut ad.
+  - `Premium` indicates a Premium ad.
+  """
+  typeCode: String
+  """The advertisement identifier."""
+  id: String
+  """The hirer's job reference"""
+  hirerJobReference: String
+  """The position title"""
+  positionTitle: String
+  """The job category identifier"""
+  jobCategoryId: String
+  """The position location identifer"""
+  positionLocationId: String
+}
+"""A message shown to the hirer for the current ad product."""
+type SeekAnzAdProductMessage {
+  """
+  The severity of the message.
+  
+  Currently, two codes are defined:
+  - `Informational` indicates a message with helpful information for a hirer.
+  - `Critical` indicates a message with critical information for a hirer.
+  """
+  severityCode: String!
+  """The content of the message."""
+  content: String!
+}
+"""
+A monetary amount expressed as an integer in a specified minor currency unit.
+
+This is used to avoid floating point rounding errors when expressing prices & funds.
+"""
+type CurrencyMinorUnit {
+  """
+  A non-negative integer in the minor currency unit for the ISO currency code.
+  
+  For example, this is the number of cents in dollar-denominated currencies.
+  """
+  value: Int!
+  """The three-letter ISO 4217 currency code, in uppercase."""
+  currency: String!
+}
+"""The name of a person including a breakdown of name components."""
+type PersonName {
+  """The formatted name of a person, as it would be written out together."""
+  formattedName: String!
+  """The given name of a person, if provided."""
+  given: String
+  """The family name (or surname) of a person, if provided."""
+  family: String
+}
+"""A reference to a person associated with an object."""
+type SpecifiedPerson {
+  """The person's name"""
+  name: PersonName
+  """Methods of communication with the person."""
+  communication: Communication!
+  """
+  The role of the person.
+  
+  Currently, two codes are defined:
+  - `Recruiter` indicates a person recruiting for the position.
+  - `HiringManager` indicates an employee that requested the position to be filled.
+  """
+  roleCode: String
+}
+"""The name of a person associated with an object."""
+input PersonNameInput {
+  """The formatted name of a person, as it would be written out together."""
+  formattedName: String!
+  """The optional given name of a person."""
+  given: String
+  """The optional family name (or surname) of a person."""
+  family: String
+}
+"""A reference to a person associated with an object."""
+input SpecifiedPersonInput {
+  """The person's name."""
+  name: PersonNameInput
+  """Methods of communication with the person."""
+  communication: CommunicationInput!
+  """
+  The role of the person.
+  
+  Currently, two codes are defined:
+  - `Recruiter` indicates a person recruiting for the position.
+  - `HiringManager` indicates an employee that requested the position to be filled.
+  """
+  roleCode: String
+}
+"""A method of applying to a position."""
+input ApplicationMethodInput {
+  """
+  A URL of an external application form.
+  
+  When this is provided, SEEK's native apply form will be disabled and the candidate will be redirected to the supplied URL.
+  """
+  applicationUri: WebUrlInput
+  """
+  The email address to direct candidate applications to.
+  
+  This is deprecated; Do not use this field. This has been replaced by application export.
+  """
+  applicationEmail: EmailInput
+}
+"""The input parameter for the `closePostedPositionProfile` mutation."""
+input ClosePostedPositionProfileInput {
+  """The details of the position profile to be closed."""
+  positionProfile: ClosePostedPositionProfile_PositionProfileInput!
+}
+"""The details of the position profile to be closed."""
+input ClosePostedPositionProfile_PositionProfileInput {
+  """The unique identifier for the posted position profile."""
+  profileId: String!
+}
+"""A collection of information about where and how to post a job ad."""
+input CreatePostingInstructionInput {
+  """
+  A SEEK ANZ advertisement type code.
+  
+  Currently, three codes are defined:
+  
+  - `Classic` indicates a Classic advertisement.
+  - `StandOut` indicates a StandOut advertisement.
+  - `Premium` indicates a Premium advertisement.
+  
+  Scheme requirements:
+  
+  - For the `seekAnz` scheme, this field is required.
+  - For other schemes, set this to `null`.
+  """
+  seekAnzAdvertisementType: String
+  """
+  The end date of the posting.
+  
+  Scheme requirements:
+  
+  - For the `seekAnz` scheme this must be no more than 30 days in the future.
+    If the end date is not specified it will default to the maximum period of 30 days.
+  """
+  end: DateTime
+  """
+  An identifier to ensure that multiple ads are not created on retries.
+  
+  The identifier should be unique in the partner system for each position profile created.
+  The same identifier must be provided when retrying after create failures.
+  """
+  idempotencyId: String!
+  """
+  An array of methods for applying to the position.
+  
+  If no methods are provided, SEEK's native apply form will be used to receive candidate applications.
+  Native applications will raise a `CandidateApplicationCreated` event that points to a `CandidateProfile` object.
+  
+  Scheme requirements:
+  
+  - For the `seekAnz` scheme, this field is limited to a single element. Requests with more than 1 element will fail.
+  """
+  applicationMethods: [ApplicationMethodInput!]
+  """The identifier of the branding to apply to the posted job ad."""
+  brandingId: String
+}
+"""A formatted description of the position profile."""
+input PositionFormattedDescriptionInput {
+  """
+  The description type.
+  
+  Currently, four description identifiers are defined:
+  1. `AdvertisementDetails` is the detailed description of the position that appears on the job ad.
+  2. `ContactDetails` is a free-text description of a contact person for the position.
+     The use of this field is discouraged in SEEK ANZ but it is still used by certain advertisement templates.
+  3. `SearchBulletPoint` is a highlight or selling point of the position that appears in search results.
+     SEEK ANZ allows up to three search bullet points for Premium or StandOut ad products.
+  4. `SearchSummary` is a short description that appears in search results.
+  
+  Scheme requirements:
+  
+  - The `seekAnz` scheme requires `AdvertisementDetails` and `SearchSummary` to be included and non-empty.
+  """
+  descriptionId: String!
+  """The HTML content of the description."""
+  content: String!
+}
+"""The input parameter for the `createPositionOpening` mutation."""
+input CreatePositionOpeningInput {
+  """The details of the position opening to be created."""
+  positionOpening: CreatePositionOpening_PositionOpeningInput!
+}
+"""The details of the position opening to be created."""
+input CreatePositionOpening_PositionOpeningInput {
+  """The party that owns the position opening."""
+  postingRequester: PostingRequesterInput!
+  """
+  The status of the position opening.
+  
+  Defaults to `Active` if no value is provided.
+  
+  Currently three codes are defined:
+  - `Incomplete` indicates the position opening is in draft.
+  - `Active` indicates the position opening is open.
+  - `Closed` indicates the position opening has been closed.
+  """
+  statusCode: String
+}
+"""The input parameter for the `updatePositionOpeningPersonContacts` mutation."""
+input UpdatePositionOpeningPersonContactsInput {
+  """The details of the position opening to be updated."""
+  positionOpening: UpdatePositionOpeningPersonContactsPositionOpeningInput!
+}
+"""The details of the position opening to be updated."""
+input UpdatePositionOpeningPersonContactsPositionOpeningInput {
+  """The unique identifier for the position opening to update."""
+  documentId: String!
+  """Specific contact people for the position opening at the party."""
+  personContacts: [SpecifiedPersonInput!]!
+}
+"""The input parameter for the `updatePositionOpeningStatus` mutation."""
+input UpdatePositionOpeningStatusInput {
+  """The details of the position opening to be updated."""
+  positionOpening: UpdatePositionOpeningStatusPositionOpeningInput!
+}
+"""The details of the position opening to have its status updated."""
+input UpdatePositionOpeningStatusPositionOpeningInput {
+  """The unique identifier for the position opening to update."""
+  documentId: String!
+  """
+  The status of the position opening.
+  
+  Currently three codes are defined:
+  - `Incomplete` indicates the position opening is in a draft state.
+  - `Active` indicates the position opening is open.
+  - `Closed` indicates the position opening has been closed.
+  """
+  statusCode: String!
+}
+"""The input parameter for the `deletePositionOpening` mutation."""
+input DeletePositionOpeningInput {
+  """The details of the position opening to be deleted."""
+  positionOpening: DeletePositionOpening_PositionOpeningInput!
+}
+"""The details of the position opening to be deleted."""
+input DeletePositionOpening_PositionOpeningInput {
+  """The unique identifier for the position opening."""
+  documentId: String!
+}
+"""
+The party that owns the position opening.
+
+This may be different from the hiring organization if the position opening is created by a recruitment agency.
+"""
+input PostingRequesterInput {
+  """An opaque identifier for hirer or agency owning the position opening."""
+  id: String!
+  """
+  The role of the owner of the position opening.
+  
+  Currently two codes are defined:
+  - `Agency` indicates a recruitment agency hiring on behalf of another company.
+  - `Company` indicates a company hiring on behalf of themselves.
+  """
+  roleCode: String!
+  """Specific contact people for the position opening at the party."""
+  personContacts: [SpecifiedPersonInput!]!
+}
+"""The information required to post a job ad for a newly created position."""
+input PostPositionInput {
+  """The details of the position opening to be created."""
+  positionOpening: CreatePositionOpening_PositionOpeningInput!
+  """A profile of a position opening."""
+  positionProfile: PostPosition_PositionProfileInput!
+}
+input PostPosition_PositionProfileInput {
+  """A short phrase describing the position as it would be listed on a business card or in a company directory."""
+  positionTitle: String!
+  """
+  An array of identifiers for the organizations that have the position.
+  
+  Scheme requirements:
+  
+  - The `seekAnz` scheme requires exactly one element.
+  """
+  positionOrganizations: [String!]!
+  """An optional hirer-provided opaque job reference."""
+  seekHirerJobReference: String
+  """An array of formatted position profile descriptions."""
+  positionFormattedDescriptions: [PositionFormattedDescriptionInput!]!
+  """
+  An array of codes for the offered schedules for the position.
+  
+  Currently, two codes are defined:
+  
+  - `FullTime` indicates a full-time schedule.
+  - `PartTime` indicates a part-time schedule.
+  
+  For the `seekAnz` scheme, this field is not supported and should be set to `null`.
+  """
+  positionScheduleTypeCodes: [String!]
+  """The salary or compensation offered for the position."""
+  offeredRemunerationPackage: RemunerationPackageInput!
+  """
+  A SEEK ANZ work type code.
+  
+  For positions in `seekAnz` scheme, this field is used instead of `positionScheduleTypeCodes`.
+  
+  Currently, four work type codes are defined:
+  
+  - `FullTime` indicates a full-time position.
+  - `PartTime` indicates a part-time position.
+  - `ContractTemp` indicates a fixed-length contract position.
+  - `Casual` indicates a casual position.
+  
+  Scheme requirements:
+  
+  - Required for the `seekAnz` scheme when `postingInstructions` are provided.
+  - Set to `null` for other schemes.
+  """
+  seekAnzWorkTypeCode: String
+  """
+  An array of `JobCategory` identifiers.
+  
+  Scheme requirements:
+  
+  - The `seekAnz` scheme requires exactly one element.
+  """
+  jobCategories: [String!]!
+  """
+  An array of `Location` identifiers.
+  
+  Scheme requirements:
+  
+  - The `seekAnz` scheme requires exactly one element.
+  """
+  positionLocation: [String!]!
+  """
+  The identifier of the questionnaire with the set of questions to present to candidates during an application.
+  
+  The questionnaire responses will be available as `seekQuestionnaireSubmission` on the application's `CandidateProfile`.
+  """
+  seekApplicationQuestionnaireId: String
+  """The video to render within the advertisement."""
+  seekVideo: SeekVideoInput
+  """
+  The instructions related to posting the job ad.
+  
+  Scheme requirements:
+  
+  - The `seekAnz` scheme requires exactly one element.
+  """
+  postingInstructions: [CreatePostingInstructionInput!]!
+}
+"""The input parameter for the `postPositionProfileForOpening` mutation."""
+input PostPositionProfileForOpeningInput {
+  """
+  A profile for posting a job ad against an existing position opening.
+  
+  This contains information of how a position opening is presented on a given channel or job board.
+  """
+  positionProfile: PostPositionProfileForOpeningPositionProfileInput!
+}
+"""
+A profile for posting a job ad against an existing position opening.
+
+This contains information of how a position opening is presented on a given channel or job board.
+"""
+input PostPositionProfileForOpeningPositionProfileInput {
+  """The identifier of the position opening that this position profile belongs to."""
+  positionOpeningId: String!
+  """A short phrase describing the position as it would be listed on a business card or in a company directory."""
+  positionTitle: String!
+  """
+  An array of identifiers for the organizations that have the position.
+  
+  Scheme requirements:
+  
+  - The `seekAnz` scheme requires exactly one element.
+  """
+  positionOrganizations: [String!]!
+  """An optional hirer-provided opaque job reference."""
+  seekHirerJobReference: String
+  """An array of formatted position profile descriptions."""
+  positionFormattedDescriptions: [PositionFormattedDescriptionInput!]!
+  """
+  An array of codes for the offered schedules for the position.
+  
+  Currently, two codes are defined:
+  
+  - `FullTime` indicates a full-time schedule.
+  - `PartTime` indicates a part-time schedule.
+  
+  For the `seekAnz` scheme, this field is not supported and should be set to `null`.
+  """
+  positionScheduleTypeCodes: [String!]
+  """The salary or compensation offered for the position."""
+  offeredRemunerationPackage: RemunerationPackageInput!
+  """
+  A SEEK ANZ work type code.
+  
+  For positions in `seekAnz` scheme, this field is used instead of `positionScheduleTypeCodes`.
+  
+  Currently, four work type codes are defined:
+  
+  - `FullTime` indicates a full-time position.
+  - `PartTime` indicates a part-time position.
+  - `ContractTemp` indicates a fixed-length contract position.
+  - `Casual` indicates a casual position.
+  
+  Scheme requirements:
+  
+  - Required for the `seekAnz` scheme when `postingInstructions` are provided.
+  - Set to `null` for other schemes.
+  """
+  seekAnzWorkTypeCode: String
+  """
+  An array of `JobCategory` identifiers.
+  
+  Scheme requirements:
+  
+  - The `seekAnz` scheme requires exactly one element.
+  """
+  jobCategories: [String!]!
+  """
+  An array of `Location` identifiers.
+  
+  Scheme requirements:
+  
+  - The `seekAnz` scheme requires exactly one element.
+  """
+  positionLocation: [String!]!
+  """
+  The identifier of the questionnaire with the set of questions to present to candidates during an application.
+  
+  The questionnaire responses will be available as `seekQuestionnaireSubmission` on the application's `CandidateProfile`.
+  """
+  seekApplicationQuestionnaireId: String
+  """The video to render within the advertisement."""
+  seekVideo: SeekVideoInput
+  """
+  The instructions related to posting the job ad.
+  
+  Scheme requirements:
+  
+  - The `seekAnz` scheme requires exactly one element.
+  """
+  postingInstructions: [CreatePostingInstructionInput!]!
+}
+"""The salary or compensation for a position."""
+input RemunerationPackageInput {
+  """
+  A code classifying the primary method of payment for a position.
+  
+  Currently, four basis codes are defined:
+  
+  1. `Hourly` employment is paid for the number of hours worked.
+  2. `Salaried` employment is paid on an annual basis.
+  3. `SalariedPlusCommission` employment is paid on an annual basis plus a results-based commission.
+  4. `CommissionOnly` employment is paid exclusively a results-based commission.
+  """
+  basisCode: String!
+  """
+  An array of offered salary ranges.
+  
+  Scheme requirements:
+  
+  - The `seekAnz` scheme is limited to a single element containing the amount for the `basisCode`.
+  """
+  ranges: [RemunerationRangeInput!]!
+  """Human readable descriptions of the remuneration package."""
+  descriptions: [String!]!
+}
+"""A salary or compensation range for a position."""
+input RemunerationRangeInput {
+  """The minimum amount an organization is willing to pay for a position."""
+  minimumAmount: RemunerationAmountInput!
+  """
+  The maximum amount an organization is willing to pay for a position.
+  
+  A `null` value indicates the organization has not specified an upper bound for the range.
+  
+  Scheme requirements:
+  
+  - Required for the `seekAnz` scheme when `postingInstructions` are provided.
+  """
+  maximumAmount: RemunerationAmountInput
+  """
+  The interval the remuneration amounts are calculated over.
+  
+  Currently two interval codes are defined:
+  
+  - `Hour` is used to express hourly rates.
+  - `Year` is used to express annual salaries or commissions.
+  """
+  intervalCode: String!
+}
+"""A monetary amount of remuneration in a specified currency."""
+input RemunerationAmountInput {
+  """
+  A non-negative float in the major currency unit for the ISO currency code.
+  
+  For example, this is the number of dollars in dollar-denominated currencies.
+  """
+  value: Float!
+  """The three-letter ISO 4217 currency code, in uppercase."""
+  currency: String!
+}
+"""The input parameter for the `createUnpostedPositionProfile` mutation."""
+input CreateUnpostedPositionProfileForOpeningInput {
+  """An unposted profile of a position opening to create."""
+  positionProfile: CreateUnpostedPositionProfileForOpeningPositionProfileInput!
+}
+"""An unposted profile of a position opening to create."""
+input CreateUnpostedPositionProfileForOpeningPositionProfileInput {
+  """The identifier of the position opening that this position profile belongs to."""
+  positionOpeningId: String!
+  """A short phrase describing the position as it would be listed on a business card or in a company directory."""
+  positionTitle: String!
+  """An array of identifiers for the organizations that have the position."""
+  positionOrganizations: [String!]!
+  """An optional hirer-provided opaque job reference."""
+  seekHirerJobReference: String
+  """An optional agency-provided opaque job reference."""
+  seekAgencyJobReference: String
+  """An array of formatted position profile descriptions."""
+  positionFormattedDescriptions: [PositionFormattedDescriptionInput!]!
+  """
+  An array of codes for the offered schedules for the position.
+  
+  Currently, two codes are defined:
+  
+  - `FullTime` indicates a full-time schedule.
+  - `PartTime` indicates a part-time schedule.
+  """
+  positionScheduleTypeCodes: [String!]
+  """The salary or compensation offered for the position."""
+  offeredRemunerationPackage: RemunerationPackageInput!
+  """An array of `JobCategory` identifiers."""
+  jobCategories: [String!]!
+  """An array of `Location` identifiers."""
+  positionLocation: [String!]!
+}
+"""The input parameter for the `updateUnpostedPositionProfile` mutation."""
+input UpdateUnpostedPositionProfileInput {
+  """An unposted profile of a position opening to update."""
+  positionProfile: UpdateUnpostedPositionProfile_PositionProfileInput!
+}
+"""An unposted profile of a position opening to update."""
+input UpdateUnpostedPositionProfile_PositionProfileInput {
+  """The identifier of the unposted position profile to update."""
+  profileId: String!
+  """A short phrase describing the position as it would be listed on a business card or in a company directory."""
+  positionTitle: String!
+  """An array of identifiers for the organizations that have the position."""
+  positionOrganizations: [String!]!
+  """An optional hirer-provided opaque job reference."""
+  seekHirerJobReference: String
+  """An optional agency-provided opaque job reference."""
+  seekAgencyJobReference: String
+  """An array of formatted position profile descriptions."""
+  positionFormattedDescriptions: [PositionFormattedDescriptionInput!]!
+  """
+  An array of codes for the offered schedules for the position.
+  
+  Currently, two codes are defined:
+  
+  - `FullTime` indicates a full-time schedule.
+  - `PartTime` indicates a part-time schedule.
+  """
+  positionScheduleTypeCodes: [String!]
+  """The salary or compensation offered for the position."""
+  offeredRemunerationPackage: RemunerationPackageInput!
+  """An array of `JobCategory` identifiers."""
+  jobCategories: [String!]!
+  """An array of `Location` identifiers."""
+  positionLocation: [String!]!
+}
+"""The input parameter for the `deleteUnpostedPositionProfile` mutation."""
+input DeleteUnpostedPositionProfileInput {
+  """The details of the unposted position profile to be deleted."""
+  positionProfile: DeleteUnpostedPositionProfile_PositionProfileInput!
+}
+"""The details of the unposted position profile to be deleted."""
+input DeleteUnpostedPositionProfile_PositionProfileInput {
+  """The unique identifier for the unposted position profile."""
+  profileId: String!
+}
+"""The input parameter for the `updatePostedPositionProfile` mutation."""
+input UpdatePostedPositionProfileInput {
+  """The values to replace on a posted position profile."""
+  positionProfile: UpdatePostedPositionProfile_PositionProfileInput!
+}
+"""The values to replace on a posted position profile."""
+input UpdatePostedPositionProfile_PositionProfileInput {
+  """The identifier of the posted position profile to update."""
+  profileId: String!
+  """A short phrase describing the position as it would be listed on a business card or in a company directory."""
+  positionTitle: String!
+  """
+  An array of identifiers for the organizations that have the position.
+  
+  Scheme requirements:
+  
+  - The `seekAnz` scheme requires exactly one element.
+  """
+  positionOrganizations: [String!]!
+  """An optional hirer-provided opaque job reference."""
+  seekHirerJobReference: String
+  """An array of formatted position profile descriptions."""
+  positionFormattedDescriptions: [PositionFormattedDescriptionInput!]!
+  """
+  An array of codes for the offered schedules for the position.
+  
+  Currently, two codes are defined:
+  
+  - `FullTime` indicates a full-time schedule.
+  - `PartTime` indicates a part-time schedule.
+  
+  For the `seekAnz` scheme, this field is not supported and should be set to `null`.
+  """
+  positionScheduleTypeCodes: [String!]
+  """The salary or compensation offered for the position."""
+  offeredRemunerationPackage: RemunerationPackageInput!
+  """
+  A SEEK ANZ work type code.
+  
+  For positions in `seekAnz` scheme, this field is used instead of `positionScheduleTypeCodes`.
+  
+  Currently, four work type codes are defined:
+  
+  - `FullTime` indicates a full-time position.
+  - `PartTime` indicates a part-time position.
+  - `ContractTemp` indicates a fixed-length contract position.
+  - `Casual` indicates a casual position.
+  
+  Scheme requirements:
+  
+  - Required for the `seekAnz` scheme when `postingInstructions` are provided.
+  - Set to `null` for other schemes.
+  """
+  seekAnzWorkTypeCode: String
+  """
+  An array of `JobCategory` identifiers.
+  
+  Scheme requirements:
+  
+  - The `seekAnz` scheme requires exactly one element.
+  """
+  jobCategories: [String!]!
+  """
+  An array of `Location` identifiers.
+  
+  Scheme requirements:
+  
+  - The `seekAnz` scheme requires exactly one element.
+  """
+  positionLocation: [String!]!
+  """
+  The identifier of the questionnaire with the set of questions to present to candidates during an application.
+  
+  The questionnaire responses will be available as `seekQuestionnaireSubmission` on the application's `CandidateProfile`.
+  
+  Scheme requirements:
+  
+  - For the `seekAnz` scheme, this field is ignored.
+  """
+  seekApplicationQuestionnaireId: String
+  """The video to render within the advertisement."""
+  seekVideo: SeekVideoInput
+  """
+  The instructions related to posting the job ad.
+  
+  Scheme requirements:
+  
+  - The `seekAnz` scheme requires exactly one element.
+  """
+  postingInstructions: [UpdatePostingInstructionInput!]!
+}
+"""A collection of information about where and how to post a job ad."""
+input UpdatePostingInstructionInput {
+  """
+  A SEEK ANZ advertisement type code.
+  
+  Currently, three codes are defined:
+  
+  - `Classic` indicates a Classic advertisement.
+  - `StandOut` indicates a StandOut advertisement.
+  - `Premium` indicates a Premium advertisement.
+  
+  Scheme requirements:
+  
+  - For the `seekAnz` scheme, this field is required.
+  - For other schemes, set this to `null`.
+  """
+  seekAnzAdvertisementType: String
+  """The end date of the posting."""
+  end: DateTime
+  """
+  An array of methods for applying to the position.
+  
+  If no methods are provided, SEEK's native apply form will be used to receive candidate applications.
+  Native applications will raise a `CandidateApplicationCreated` event that points to a `CandidateProfile` object.
+  
+  Scheme requirements:
+  
+  - For the `seekAnz` scheme, this field is limited to a single element. Requests with more than 1 element will fail.
+  """
+  applicationMethods: [ApplicationMethodInput!]
+  """The identifier of the branding to apply to the posted job ad."""
+  brandingId: String
+}
+"""A collection of information about the video to display alongside advertisement details."""
+input SeekVideoInput {
+  """
+  The URL of the video to display.
+  
+  Scheme requirements:
+  
+   - The `seekAnz` scheme requires URLs to be YouTube embed URLs less than 255 characters e.g. `https://www.youtube.com/embed/aAgePQvHBQM`.
+  """
+  url: String!
+  """
+  The position relative to the advertisement details where the video should be rendered.
+  
+  Currently, two codes are defined:
+  
+  - `Above` indicates the video will render above the advertisement details.
+  - `Below` indicates the video will render below the advertisement details.
+  """
+  seekAnzPositionCode: String
+}
+"""
+The category of a job's occupation.
+
+This query accepts browser tokens that include the `query:ontologies` scope.
+"""
+type JobCategory {
+  """An opaque identifier for the job category."""
+  id: ObjectIdentifier!
+  """
+  The parent job category.
+  
+  This is a more general classification that this category belongs to.
+  It will be `null` for root categories that do not belong to a more general classification.
+  """
+  parent: JobCategory
+  """
+  An array of child job categories.
+  
+  These are more specific categories that belong to this general classification.
+  """
+  children: [JobCategory!]
+  """Name of the job category."""
+  name: String!
+}
+"""A job category with information of the suggested choice."""
+type JobCategorySuggestionChoice {
+  """The job category information of the suggestion choice."""
+  jobCategory: JobCategory!
+  """
+  A floating point value ranging from 0 (lowest) to 1 (highest)
+  that indicates confidence of the job category returned based on the suggestion input.
+  """
+  confidence: Float!
+}
+"""The input parameter for the `jobCategorySuggestions` query."""
+input JobCategorySuggestionPositionProfileInput {
+  """The position title."""
+  positionTitle: String!
+  """An array of location identifiers of the position."""
+  positionLocation: [String!]!
+  """
+  An array of identifiers for the organizations that have the position.
+  
+  Information such as the organization's domicile can be used to refine the returned suggestions.
+  """
+  positionOrganizations: [String!]
+  """
+  The descriptions for the position profile.
+  
+  Currently, only the `AdvertisementDetails` description is used. Other
+  descriptions will be accepted but are ignored when determining the
+  relevance of suggestion.
+  """
+  positionFormattedDescriptions: [PositionFormattedDescriptionInput!]
+}
+type Location {
+  """An opaque identifier of the location."""
+  id: ObjectIdentifier!
+  """The parent location."""
+  parent: Location
+  """An array of child locations."""
+  children: [Location!]
+  """The location name."""
+  name: String!
+  """Contextual name of the location."""
+  contextualName: String!
+  """The two-letter ISO 3166-1:2013 country code, in uppercase."""
+  countryCode: String!
+}
+type LocationSuggestion {
+  """Location information of the choice."""
+  location: Location!
+}
+"""A geographical coordinate."""
+input GeoLocationInput {
+  """The latitude of the geographical location."""
+  latitude: Float!
+  """The longitude of the geographical location."""
+  longitude: Float!
+}
+"""An organization hiring for an open position."""
+type HiringOrganization {
+  """The opaque identifier of the hiring organization."""
+  id: ObjectIdentifier!
+  """The name of the hiring organization."""
+  name: String!
+  """
+  The legacy SEEK ANZ advertiser ID.
+  
+  This is a numeric identifier used by SEEK ANZ's legacy Job Posting & Application Export APIs.
+  For organizations in other schemes this will be `null`.
+  """
+  seekAnzAdvertiserId: Int
+}
+"""
+Advertisement branding.
+
+This can be associated with one or more `PositionProfile`s when they are created.
+"""
+type AdvertisementBranding {
+  """An opaque identifier for advertisement branding."""
+  id: ObjectIdentifier!
+  """The advertisement branding name."""
+  name: String!
+  """A list of images associated with the advertisement branding."""
+  images: [AdvertisementBrandingImage!]!
+  """The organization that has the advertisement branding."""
+  hirer: HiringOrganization!
+}
+"""A visual representation of advertisement branding."""
+type AdvertisementBrandingImage {
+  """
+  The type of advertisement branding image.
+  
+  Currently, only one code is defined:
+  - `OriginalLogo` indicates the original advertisement branding logo image from which other logo images are derived.
+  """
+  typeCode: String!
+  """
+  The URL of the advertisement branding image.
+  
+  This can be retrieved to visually identify an advertisement branding in a partner system.
+  """
+  url: String!
+}
+"""A page of advertisement brandings for a hirer."""
+type AdvertisementBrandingsConnection {
+  """
+  The page of advertisement brandings and their corresponding cursors.
+  
+  This list may be empty.
+  """
+  edges: [AdvertisementBrandingEdge!]!
+  """The pagination metadata for this page of advertisement brandings."""
+  pageInfo: PageInfo!
+}
+type AdvertisementBrandingEdge {
+  """
+  The opaque cursor to advertisement branding.
+  
+  This can be used as a subsequent pagination argument.
+  """
+  cursor: String!
+  """The actual advertisement branding."""
+  node: AdvertisementBranding!
+}
+"""The output parameter for the `createPositionOpening` mutation."""
+type CreatePositionOpeningPayload {
+  """The details of the created position opening."""
+  positionOpening: PositionOpening!
+}
+"""The output parameter for the `postPositionProfileForOpening` mutation."""
+type PostPositionProfileForOpeningPayload {
+  """Attributes of the newly created position profile."""
+  positionProfile: PostPositionProfileForOpening_PositionProfilePayload!
+}
+type PostPositionProfileForOpening_PositionProfilePayload {
+  """The identifier for the created position profile."""
+  profileId: ObjectIdentifier!
+}
+"""The output parameter for the `postPosition` mutation."""
+type PostPositionPayload {
+  """Attributes of the newly created position opening."""
+  positionOpening: PostPosition_PositionOpeningPayload!
+  """Attributes of the newly created position profile."""
+  positionProfile: PostPosition_PositionProfilePayload!
+}
+type PostPosition_PositionOpeningPayload {
+  """
+  The identifier for the created position opening.
+  
+  Scheme restrictions:
+  
+  - The `seekAnz` scheme creates the position opening asynchronously.
+    This identifier will initially reference an missing object;
+    the object should be created within a few minutes.
+  """
+  documentId: ObjectIdentifier!
+}
+type PostPosition_PositionProfilePayload {
+  """
+  The identifier for the created position profile.
+  
+  Scheme restrictions:
+  
+  - The `seekAnz` scheme creates the position profile asynchronously.
+    This identifier will initially reference an missing object;
+    the object should be created within a few minutes.
+  """
+  profileId: ObjectIdentifier!
+}
+"""The output parameter for the `UpdatePositionOpeningStatus` mutation."""
+type UpdatePositionOpeningStatusPayload {
+  """The details of the updated position opening."""
+  positionOpening: PositionOpening!
+}
+"""The output parameter for the `createUnpostedPositionProfileForOpening` mutation."""
+type CreateUnpostedPositionProfileForOpeningPayload {
+  """Attributes of the newly created unposted position profile."""
+  unpostedPositionProfile: PositionProfile!
+}
+"""The output parameter for the `updatePositionOpeningPersonContacts` mutation."""
+type UpdatePositionOpeningPersonContactsPayload {
+  """The details of the updated position opening."""
+  positionOpening: PositionOpening!
+}
+"""The output of the `updatePostedPositionProfile` mutation."""
+type UpdatePostedPositionProfilePayload {
+  """Attributes of the updated position profile."""
+  positionProfile: UpdatePostedPositionProfile_PositionProfilePayload!
+}
+"""Attributes of the updated position profile."""
+type UpdatePostedPositionProfile_PositionProfilePayload {
+  """The identifier of the updated posted position profile."""
+  profileId: ObjectIdentifier!
+}
+"""The output of the `closePostedPositionProfile` mutation."""
+type ClosePostedPositionProfilePayload {
+  """Attributes of the closed position profile."""
+  positionProfile: ClosePostedPositionProfile_PositionProfilePayload!
+}
+"""Attributes of the closed position profile."""
+type ClosePostedPositionProfile_PositionProfilePayload {
+  """The identifier of the closed posted position profile."""
+  profileId: ObjectIdentifier!
+}
+"""The output parameter for the `updateUnpostedPositionProfile` mutation."""
+type UpdateUnpostedPositionProfilePayload {
+  """Attributes of the unposted position profile."""
+  unpostedPositionProfile: PositionProfile!
+}
+"""The output parameter for the `deletePositionOpening` mutation."""
+type DeletePositionOpeningPayload {
+  """The details of the deleted position opening."""
+  positionOpening: PositionOpening!
+}
+"""The output parameter for the `deleteUnpostedPositionProfile` mutation."""
+type DeleteUnpostedPositionProfilePayload {
+  """The details of the deleted unposted position profile."""
+  unpostedPositionProfile: PositionProfile!
+}
+"""A position opening in a paginated list."""
+type PositionOpeningEdge {
+  """
+  The opaque cursor to the position opening.
+  
+  This can be used as a subsequent pagination argument.
+  """
+  cursor: String!
+  """The actual position opening."""
+  node: PositionOpening!
+}
+"""A page of position openings."""
+type PositionOpeningConnection {
+  """
+  The page of position openings and their corresponding cursors.
+  
+  This list may be empty.
+  """
+  edges: [PositionOpeningEdge!]!
+  """The pagination metadata for this page of position openings."""
+  pageInfo: PageInfo!
+}
+"""
+A job requisition or position opening within an organization.
+
+This is a container object that groups multiple `PositionProfile`s together along with their owner.
+"""
+type PositionOpening {
+  """
+  The status of the position opening.
+  
+  Currently three codes are defined:
+  - `Incomplete` indicates the position opening is in a draft state.
+  - `Active` indicates the position opening is open.
+  - `Closed` indicates the position opening has been closed.
+  """
+  statusCode: String!
+  """An opaque identifier for the position opening."""
+  documentId: ObjectIdentifier!
+  """
+  The party that owns the position opening.
+  
+  This may be different from the hiring organization if the position opening is created by a recruitment agency.
+  """
+  postingRequester: PostingRequester!
+  """
+  An array of profiles for the position opening.
+  
+  Each profile represents a posted job ad or an unposted internal requisition associated with this opening.
+  """
+  positionProfiles: [PositionProfile!]!
+}
+"""The party that owns the position opening."""
+type PostingRequester {
+  """An opaque identifier for hirer or agency owning the position opening."""
+  id: ObjectIdentifier!
+  """The name of the party that owns the position opening."""
+  name: String!
+  """
+  The legacy SEEK ANZ advertiser ID.
+  
+  This is a numeric identifier used by SEEK ANZ's legacy Job Posting & Application Export APIs.
+  For hirers or agencies in other schemes this will be `null`.
+  """
+  seekAnzAdvertiserId: Int
+  """
+  The role of the owner of the position opening.
+  
+  Currently two codes are defined:
+  - `Agency` indicates a recruitment agency hiring on behalf of another company.
+  - `Company` indicates a company hiring on behalf of themselves.
+  """
+  roleCode: String!
+  """Specific contact people for the position opening at the party."""
+  personContacts: [SpecifiedPerson!]!
+}
+"""
+A profile of a position opening.
+
+This contains information of how a position opening is presented on a job board or as an internal requisition.
+"""
+type PositionProfile {
+  """An opaque identifier for the position profile."""
+  profileId: ObjectIdentifier!
+  """The `PositionOpening` that this profile was created under."""
+  positionOpening: PositionOpening!
+  """A short phrase describing the position as it would be listed on a business card or in a company directory."""
+  positionTitle: String!
+  """The organization which has the position."""
+  positionOrganizations: [HiringOrganization!]!
+  """An optional hirer-provided opaque job reference."""
+  seekHirerJobReference: String
+  """An optional agency-provided opaque job reference."""
+  seekAgencyJobReference: String
+  """
+  The public web URL of the posted job ad.
+  
+  This will be `null` for unposted position profiles.
+  """
+  positionUri: String
+  """An array of formatted position profile descriptions."""
+  positionFormattedDescriptions: [PositionFormattedDescription!]!
+  """
+  An array of codes for the offered schedules for the position.
+  
+  Currently, two codes are defined:
+  - `FullTime` indicates a full-time schedule.
+  - `PartTime` indicates a part-time schedule.
+  
+  If the offered schedule isn't known this will be `null`.
+  """
+  positionScheduleTypeCodes: [String!]
+  """The salary or compensation offered for the position."""
+  offeredRemunerationPackage: RemunerationPackage!
+  """
+  A SEEK ANZ work type code.
+  
+  Four work type codes are defined:
+  - `FullTime` indicates a full-time position.
+  - `PartTime` indicates a part-time position.
+  - `ContractTemp` indicates a fixed-length contract position.
+  - `Casual` indicates a casual position.
+  
+  For positions in other schemes this will be `null`.
+  """
+  seekAnzWorkTypeCode: String
+  """The occupational categories of the job."""
+  jobCategories: [JobCategory!]!
+  """The locations of the position."""
+  positionLocation: [Location!]!
+  """
+  The set of questions presented to candidates during an application.
+  
+  The questionnaire responses will be available as `seekQuestionnaireSubmission` on the application's `CandidateProfile`.
+  """
+  seekApplicationQuestionnaire: ApplicationQuestionnaire
+  """The video to render within the advertisement."""
+  seekVideo: SeekVideo
+  """The instructions related to posting the job ad."""
+  postingInstructions: [PostingInstruction!]!
+}
+"""
+A description type identifier.
+
+This specifies the meaning of the description and determines where it's
+presented to the candidate.
+"""
+type PositionFormattedDescriptionIdentifier {
+  """
+  The description type.
+  
+  Currently, three description identifiers are defined:
+  1. `AdvertisementDetails` is the detailed description of the position that appears on the job ad.
+  2. `SearchSummary` is a short description that appears in search results.
+  3. `SearchBulletPoint` is a highlight or selling point of the position that appears in search results.
+     SEEK ANZ allows up to three search bullet points for Premium or StandOut ad products.
+  """
+  value: String!
+}
+"""A formatted description of the position profile."""
+type PositionFormattedDescription {
+  """The description type."""
+  descriptionId: PositionFormattedDescriptionIdentifier!
+  """The HTML content of the description."""
+  content: String!
+}
+"""The salary or compensation for a position."""
+type RemunerationPackage {
+  """
+  A code classifying the primary method of payment for a position.
+  
+  Currently, four basis codes are defined:
+  
+  1. `Hourly` employment is paid for the number of hours worked.
+  2. `Salaried` employment is paid on an annual basis.
+  3. `SalariedPlusCommission` employment is paid on an annual basis plus a results-based commission.
+  4. `CommissionOnly` employment is paid exclusively a results-based commission.
+  """
+  basisCode: String!
+  """
+  An array of offered salary ranges.
+  
+  The scheme `seekAnz` will always have a single element containing the amount for the `basisCode`.
+  """
+  ranges: [RemunerationRange!]!
+  """Human readable descriptions of the remuneration package."""
+  descriptions: [String!]!
+}
+"""A salary or compensation range for a position."""
+type RemunerationRange {
+  """The minimum amount an organization is willing to pay for a position."""
+  minimumAmount: RemunerationAmount!
+  """
+  The maximum amount an organization is willing to pay for a position.
+  
+  A 'null' value indicates the organization has not specified an upper bound for the range.
+  """
+  maximumAmount: RemunerationAmount
+  """
+  The interval the remuneration amounts are calculated over.
+  
+  Currently two interval codes are defined:
+  
+  - `Hourly` is used to express hourly rates.
+  - `Year` is used to express annual salaries or commissions.
+  """
+  intervalCode: String!
+}
+"""A monetary amount of remuneration in a specified currency."""
+type RemunerationAmount {
+  """
+  A non-negative float in the major currency unit for the ISO currency code.
+  
+  For example, this is the number of dollars in dollar-denominated currencies.
+  """
+  value: Float!
+  """The three-letter ISO 4217 currency code, in uppercase."""
+  currency: String!
+}
+"""A collection of information about where and how to post a job ad."""
+type PostingInstruction {
+  """The start date of the posting."""
+  start: DateTime!
+  """The end date of the posting."""
+  end: DateTime!
+  """
+  An array of methods for applying to the position.
+  
+  If no methods are provided, SEEK's native apply form will be used to receive candidate applications.
+  Native applications will raise a `CandidateApplicationCreated` event that points to a `CandidateProfile` object.
+  """
+  applicationMethods: [ApplicationMethod!]!
+  """
+  The identifier of the branding applied to the posted job ad.
+  
+  This is included for HR-JSON compatibility; GraphQL users should use the `branding` nested object instead.
+  """
+  brandingId: String
+  """The branding applied to the posted job ad."""
+  branding: AdvertisementBranding
+}
+"""A method of applying to a position."""
+type ApplicationMethod {
+  """
+  A URL of an external application form.
+  
+  When this is provided, SEEK's native apply form will be disabled and the candidate will be redirected to the supplied URL.
+  """
+  applicationUri: WebUrl
+  """The email address to direct candidate applications to."""
+  applicationEmail: Email @deprecated(reason: "Do not use this field. This has been replaced by application export.")
+}
+"""A collection of information about the video to display alongside advertisement details."""
+type SeekVideo {
+  """The URL of the video."""
+  url: String!
+  """
+  The position relative to the advertisement details where the video is rendered.
+  
+  Currently, two codes are defined:
+  
+  - `Above` indicates the video will render above the advertisement details.
+  - `Below` indicates the video will render below the advertisement details.
+  """
+  seekAnzPositionCode: String
+}
+"""
+The criteria to filter position openings by.
+
+These are `PositionOpening`-specific extensions on top of the standard pagination arguments `after` and `first`.
+"""
+input PositionOpeningsFilterInput {
+  """
+  Optionally filter results to only include position openings with the specified status code.
+  
+  Currently three codes are defined:
+  - `Incomplete` indicates the position opening is in a draft state.
+  - `Active` indicates the position opening is open.
+  - `Closed` indicates the position opening has been closed.
+  """
+  statusCode: String
+}
+"""An action that can be executed as part of a workflow process."""
+type ProcessAction {
+  """The code of the action."""
+  code: String!
+  """A deep link to the action."""
+  seekUrl: WebUrl
+}
+"""Information about a person not specific to a candidate profile."""
+type CandidatePerson {
+  """The person's name."""
+  name: PersonName!
+  """Methods of communication with the person."""
+  communication: Communication!
+}
+"""
+A person who applied for a position at a company.
+
+If the same person applies to multiple hirers they will have distinct
+`Candidate` objects created.
+"""
+type Candidate {
+  """
+  An opaque identifier for the candidate
+  
+  This is unique for a given hirer & person.
+  """
+  documentId: ObjectIdentifier!
+  """
+  Information to identify the person, including their name and methods of
+  communicating with the person.
+  """
+  person: CandidatePerson!
+  """
+  The list of profiles associated with with the candidate.
+  Each submitted application for a position will have an associated profile.
+  """
+  profiles: [CandidateProfile!]!
+}
+"""The role of an attachment within a profile."""
+enum SeekAttachmentRole {
+  """A resume or CV."""
+  RESUME @deprecated(reason: "Use Attachment.seekRoleCode")
+  """A cover letter specific to a position opening."""
+  COVER_LETTER @deprecated(reason: "Use Attachment.seekRoleCode")
+  """A document supporting a position-specific selection criteria."""
+  SELECTION_CRITERIA @deprecated(reason: "Use Attachment.seekRoleCode")
+}
+"""The details of a position the candidate applied for."""
+type AssociatedPositionOpening {
+  """
+  The identifier for the position opening the candidate applied for.
+  
+  This is included for HR-JSON compatibility; GraphQL users should use the
+  `positionOpening` nested object instead.
+  """
+  positionOpeningId: ObjectIdentifier!
+  """The position opening this candidate applied for."""
+  positionOpening: PositionOpening!
+  """
+  The public web URL of the posted job ad.
+  
+  This will be `null` for unposted position profiles.
+  """
+  positionUri: String
+  """
+  An indicator that the candidate applied to this associated position.
+  
+  This is always `true` until proactive sourcing is supported.
+  """
+  candidateAppliedIndicator: Boolean
+}
+"""A profile attachment stored at an external URL."""
+type Attachment {
+  """
+  The opaque identifier for the attachment.
+  This is unique across all attachments.
+  """
+  id: ObjectIdentifier!
+  """
+  A download URL for the attachment.
+  
+  This URL accepts partner tokens or browser tokens that include the `download:candidate-profile-attachments` scope.
+  This is guaranteed to be an absolute URL with an origin of `https://graphql.seek.com`.
+  """
+  url: String!
+  """
+  An array of human readable descriptions of the attachment.
+  
+  Resumes & cover letters can be programmatically identified using the  `seekRoleCode` field.
+  """
+  descriptions: [String!]!
+  """
+  The role of the attachment within a profile.
+  
+  Currently, two codes are defined:
+  
+  - `Resume` is used for a candidate's resume or CV.
+  - `CoverLetter` is used for a candidate's cover letter for a specific position.
+  
+  Additional documents will have a `null` role code.
+  They can be distinguished by their free text `descriptions`.
+  """
+  seekRoleCode: String
+  """The role of the attachment within a profile."""
+  seekRole: SeekAttachmentRole @deprecated(reason: "Use seekRoleCode")
+}
+"""Basic information to identify and reference a specific organization."""
+type Organization {
+  """The human readable name of the organization."""
+  name: String!
+}
+"""The details about a person's tenure within the position."""
+type PositionHistory {
+  """
+  The start date of the position.
+  
+  This may only contain the year and month, e.g. `2019-01`.
+  """
+  start: HistoryDate!
+  """
+  The end date of the position if known.
+  
+  This may only contain the year and month, e.g. `2020-01`.
+  """
+  end: HistoryDate
+  """Indicates whether the person is still working at the organization, if known."""
+  current: Boolean
+  """The title that the person held for this position."""
+  title: String!
+  """An array of descriptions of the person's responsibilities, skills and achievements in the position."""
+  descriptions: [String!]!
+}
+"""The details of a person's employment, work, or relevant experience."""
+type EmployerHistory {
+  """The specific organization to which the person held positions."""
+  organization: Organization!
+  """The set of positions that the person held."""
+  positionHistories: [PositionHistory!]!
+}
+"""The details of a student's degree."""
+type EducationDegree {
+  """The name of the degree."""
+  name: String!
+  """
+  The granted status of the degree.
+  
+  Currently, two statuses are defined:
+  - `InProgress` indicates the student is still completing the degree.
+  - `Granted` indicates the degree has been granted to the student.
+  """
+  degreeGrantedStatus: String!
+  """
+  The date the degree was granted or is expected to be granted.
+  
+  This may only contain a year and optional month, e.g. `2020` or `2020-06`.
+  If the date isn't known this will be `null`.
+  """
+  date: HistoryDate
+}
+"""The details documenting a person's attendance at an educational institution."""
+type EducationAttendance {
+  """The institution the person attended."""
+  institution: Organization!
+  """The degrees which were awarded or in process at the institution."""
+  educationDegrees: [EducationDegree!]!
+}
+"""A skill or competency asserted by the candidate."""
+type PersonCompetency {
+  """The human readable name of the competency."""
+  competencyName: String!
+}
+"""A source from which the candidate was obtained from."""
+type CandidateSource {
+  """Free text description of the source."""
+  name: String!
+  """
+  The grouping that the source falls under.
+  
+  Currently, two types are defined:
+  
+  - `PartnerUpload` indicates that the candidate was uploaded to SEEK from a
+    partner system.
+  - `SeekApplication` indicates that the candidate applied for a position on
+    the SEEK candidate site.
+  """
+  type: String!
+}
+"""Structured information about a candidate in relation to a particular position."""
+type CandidateProfile {
+  """
+  The `Candidate` that this profile relates to.
+  
+  This contains the candidate's personal details along with all their profiles
+  for the same hirer.
+  """
+  candidate: Candidate!
+  """
+  An opaque identifier for the profile.
+  
+  This profile can be queried at any time by passing this identifier string
+  to `candidateProfile`.
+  """
+  profileId: ObjectIdentifier!
+  """The date & time the candidate was associated with the position."""
+  createDateTime: DateTime!
+  """The positions this candidate has applied for."""
+  associatedPositionOpenings: [AssociatedPositionOpening!]!
+  """The attachments related to the candidate's profile."""
+  attachments: [Attachment!]!
+  """The employment history of the candidate."""
+  employment: [EmployerHistory!]!
+  """The education history of the candidate."""
+  education: [EducationAttendance!]!
+  """The skills or competencies of the candidate."""
+  qualifications: [PersonCompetency!]!
+  """The sources from which the candidate was obtained from."""
+  candidateSources: [CandidateSource!]!
+  """The date & time the candidate profile was last updated."""
+  updateDateTime: DateTime!
+  """A list of executable actions linked to the candidate profile."""
+  seekActions: [ProcessAction!]!
+  """The completed candidate submission for the position profile's questionnaire."""
+  seekQuestionnaireSubmission: ApplicationQuestionnaireSubmission
+}
+"""A webhook attempt."""
+type WebhookAttempt {
+  """An opaque identifier for the webhook attempt."""
+  id: ObjectIdentifier!
+  """The date & time that the webhook attempt was acknowledged or timed out."""
+  createDateTime: DateTime!
+  """The event opaque identifier that generated the attempt."""
+  eventId: ObjectIdentifier!
+  """The subscription opaque identifier that generated the attempt."""
+  subscriptionId: ObjectIdentifier!
+  """The HTTP status for the webhook attempt."""
+  statusCode: Int!
+  """
+  The result description for the webhook attempt.
+  
+  Currently, four codes are defined:
+  
+  1. `BadResponse` indicates that the webhook attempt received a non-2xx HTTP response
+  2. `InvalidUrl` indicates that the subscription URL did not pass validation
+  3. `RequestTimeout` indicates that the webhook attempt did not receive a timely response
+  4. `Success` indicates that the webhook attempt received a 2xx HTTP response
+  """
+  descriptionCode: String!
+  """
+  The identifier of the HTTP request for the webhook attempt.
+  
+  This identifier is included in the request as an `X-Request-Id` custom header.
+  """
+  requestId: String!
+}
+"""A webhook attempt in a paginated list."""
+type WebhookAttemptEdge {
+  """
+  The opaque cursor to the webhook attempt.
+  
+  This can be used as a subsequent pagination argument.
+  """
+  cursor: String!
+  """The actual webhook attempt."""
+  node: WebhookAttempt!
+}
+"""A page of webhook attempts."""
+type WebhookAttemptsConnection {
+  """
+  The page of webhook attempts and their corresponding cursors.
+  
+  This is always a non-empty list.
+  """
+  edges: [WebhookAttemptEdge!]!
+  """The pagination metadata for this page of webhook attempts."""
+  pageInfo: PageInfo!
+}
+"""
+The criteria to filter webhook attempts by.
+
+These are `WebhookAttempt`-specific extensions on top of the standard pagination arguments `before`, `after`, `first` and `last`.
+"""
+input WebhookAttemptsFilterInput {
+  """
+  The creation date & time that resulting webhook attempts must succeed.
+  
+  This can be used to initiate the retrieval of paginated results.
+  Subsequent queries should use the opaque cursors returned from `WebhookAttemptsConnection`.
+  """
+  afterDateTime: DateTime
+  """
+  The creation date & time that resulting webhook attempts must precede.
+  
+  This can be used to initiate the retrieval of paginated results.
+  Subsequent queries should use the opaque cursors returned from `WebhookAttemptsConnection`.
+  """
+  beforeDateTime: DateTime
+  """
+  The types of webhook attempts to retrieve.
+  
+  See the relevant `WebhookAttempt` implementation for a list of supported description types.
+  """
+  descriptionCodes: [String!]
+}
+"""The details of the webhook subscription to be created."""
+input CreateWebhookSubscription_SubscriptionInput {
+  """
+  The type of event to subscribe to.
+  
+  See `Event` implementations for a list of supported values.
+  """
+  eventTypeCode: String!
+  """
+  The data source for the event.
+  
+  This commonly refers to a SEEK brand.
+  See the relevant `Event` implementation for a list of supported schemes.
+  """
+  schemeId: String!
+  """
+  The optional hirer ID to receive events from.
+  
+  By default webhook subscriptions will send events from all hirers the partner has access to.
+  Providing a hirer ID will filter events to the specified hirer.
+  """
+  hirerId: String
+  """The subscriber-owned URL where events will be sent to."""
+  url: String!
+  """
+  The maximum number of events that will be sent in each HTTP request.
+  
+  This number must be between 1 and 10 inclusive. Defaults to 10.
+  """
+  maxEventsPerAttempt: Int
+  """
+  The algorithm for signing webhooks.
+  
+  Currently, two codes are defined:
+  
+  - `None` indicates no signature will be attached.
+  - `SeekHmacSha512` indicates a HMAC SHA-512 hex digest will be attached to
+    each request as a `Seek-Signature` header.
+  
+  A webhook's signature can be used to validate that the request originated
+  from SEEK.
+  
+  Use a constant-time algorithm to validate the signature. Regular comparison
+  methods like the `==` operator are susceptible to timing attacks.
+  """
+  signingAlgorithmCode: String!
+  """
+  The secret for signing webhooks.
+  
+  This must be specified if `signingAlgorithmCode` is not `None`. It is
+  used as the key to generate a message authentication code for each request.
+  
+  The secret should be a random string with high entropy that is not reused
+  for any other purpose.
+  """
+  secret: String
+}
+"""The details of the webhook subscription delivery configuration to be updated."""
+input UpdateWebhookSubscriptionDeliveryConfigurationSubscriptionInput {
+  """The unique identifier for the subscription."""
+  id: String!
+  """The subscriber-owned URL where events will be sent to."""
+  url: String!
+  """
+  The maximum number of events that will be sent in each HTTP request.
+  
+  This number must be between 1 and 10 inclusive. Defaults to 10.
+  """
+  maxEventsPerAttempt: Int
+  """
+  The algorithm for signing webhooks.
+  
+  Currently, two codes are defined:
+  
+  - `None` indicates no signature will be attached.
+  - `SeekHmacSha512` indicates a HMAC SHA-512 hex digest will be attached to
+    each request as a `Seek-Signature` header.
+  
+  A webhook's signature can be used to validate that the request originated
+  from SEEK.
+  
+  Use a constant-time algorithm to validate the signature. Regular comparison
+  methods like the `==` operator are susceptible to timing attacks.
+  """
+  signingAlgorithmCode: String!
+  """
+  The secret for signing webhooks.
+  
+  This must be specified if `signingAlgorithmCode` is not `None`. It is
+  used as the key to generate a message authentication code for each request.
+  
+  The secret should be a random string with high entropy that is not reused
+  for any other purpose.
+  """
+  secret: String
+}
+"""The details of the webhook subscription to be deleted."""
+input DeleteWebhookSubscription_SubscriptionInput {
+  """The unique identifier for the subscription."""
+  id: String!
+}
+"""
+A subscription for a given event type and scheme to be delivered via webhook.
+
+Events are delivered in batches with a HTTP POST request to the specified subscription URL.
+"""
+type WebhookSubscription {
+  """The unique identifier for the subscription."""
+  id: ObjectIdentifier!
+  """
+  The type of event.
+  
+  See `Event` implementations for a list of supported values.
+  """
+  eventTypeCode: String!
+  """
+  The data source for the event.
+  
+  This commonly refers to a SEEK brand.
+  See the relevant `Event` implementation for a list of supported schemes.
+  """
+  schemeId: String!
+  """
+  The optional hirer ID to receive events from.
+  
+  By default webhook subscriptions will send events from all hirers the partner has access to.
+  A non-null `hirerId` indicates that this subscription is filtered to a single hirer.
+  """
+  hirerId: ObjectIdentifier
+  """The subscriber-owned URL where events are sent to."""
+  url: String!
+  """
+  The maximum number of events that will be sent in each HTTP request.
+  
+  This number is between 1 and 10 inclusive. Defaults to 10.
+  """
+  maxEventsPerAttempt: Int!
+  """
+  The algorithm for signing webhooks.
+  
+  Currently, two codes are defined:
+  
+  - `None` indicates no signature will be attached.
+  - `SeekHmacSha512` indicates a HMAC SHA-512 hex digest will be attached to
+    each request as a `Seek-Signature` header.
+  
+  A webhook's signature can be used to validate that the request originated
+  from SEEK.
+  
+  Use a constant-time algorithm to validate the signature. Regular comparison
+  methods like the `==` operator are susceptible to timing attacks.
+  """
+  signingAlgorithmCode: String!
+  """
+  The date & time the webhook subscription was created.
+  
+  Initial `afterDateTime` and `beforeDateTime` filters apply to this field.
+  """
+  createDateTime: DateTime!
+  """The date & time the webhook subscription was last updated."""
+  updateDateTime: DateTime!
+  """
+  A page of webhook attempts for the current subscription matching the specified criteria.
+  
+  The result list is returned in ascending creation date & time order.
+  It starts from the earliest known attempt if no pagination arguments are provided.
+  """
+  webhookAttempts(
+    """
+    An opaque cursor to the earlier bounding webhook attempt.
+    
+    Resulting webhook attempts will _succeed_ this cursor.
+    """
+    after: String
+    """
+    An opaque cursor to the later bounding webhook attempt.
+    
+    Resulting webhook attempts will _precede_ this cursor.
+    """
+    before: String
+    """
+    The upper limit of webhook attempts to return from the start of the list.
+    
+    Defaults to 10 if neither `first` nor `last` are specified.
+    Excess webhook attempts will be trimmed from the end of the list.
+    
+    `first` and `last` cannot be specified in the same query.
+    """
+    first: Int
+    """
+    The upper limit of webhook attempts to return from the end of the list.
+    
+    Excess webhook attempts will be trimmed from the start of the list.
+    
+    `first` and `last` cannot be specified in the same query.
+    """
+    last: Int
+    """The additional `WebhookAttempts`-specific criteria to filter by."""
+    filter: WebhookAttemptsFilterInput
+  ): WebhookAttemptsConnection!
+}
+"""The input parameter for the `createWebhookSubscription` mutation."""
+input CreateWebhookSubscriptionInput {
+  """The details of the webhook subscription to be created."""
+  webhookSubscription: CreateWebhookSubscription_SubscriptionInput!
+}
+"""The output parameter for the `createWebhookSubscription` mutation."""
+type CreateWebhookSubscriptionPayload {
+  """The details of the created webhook subscription."""
+  webhookSubscription: WebhookSubscription!
+}
+"""The input parameter for the `updateWebhookSubscriptionDeliveryConfiguration` mutation."""
+input UpdateWebhookSubscriptionDeliveryConfigurationInput {
+  """The details of the webhook subscription to be updated."""
+  webhookSubscription: UpdateWebhookSubscriptionDeliveryConfigurationSubscriptionInput!
+}
+"""The output parameter for the `updateWebhookSubscriptionDeliveryConfiguration` mutation."""
+type UpdateWebhookSubscriptionDeliveryConfigurationPayload {
+  """The details of the updated webhook subscription."""
+  webhookSubscription: WebhookSubscription!
+}
+"""The input parameter for the `deleteWebhookSubscription` mutation."""
+input DeleteWebhookSubscriptionInput {
+  """The details of the webhook subscription to be deleted."""
+  webhookSubscription: DeleteWebhookSubscription_SubscriptionInput!
+}
+"""The output parameter for the `deleteWebhookSubscription` mutation."""
+type DeleteWebhookSubscriptionPayload {
+  """The details of the deleted webhook subscription."""
+  webhookSubscription: WebhookSubscription!
+}
+"""A webhook subscription in a paginated list."""
+type WebhookSubscriptionEdge {
+  """
+  The opaque cursor to the webhook subscription.
+  
+  This can be used as a subsequent pagination argument.
+  """
+  cursor: String!
+  """The actual webhook subscription."""
+  node: WebhookSubscription!
+}
+"""A page of webhook subscriptions."""
+type WebhookSubscriptionsConnection {
+  """
+  The page of webhook subscriptions and their corresponding cursors.
+  
+  This is always a non-empty list.
+  """
+  edges: [WebhookSubscriptionEdge!]!
+  """The pagination metadata for this page of subscriptions."""
+  pageInfo: PageInfo!
+}
+"""
+The criteria to filter webhook subscriptions by.
+
+These are `WebhookSubscription`-specific extensions on top of the standard pagination arguments `before`, `after`, `first` and `last`.
+"""
+input WebhookSubscriptionsFilterInput {
+  """
+  The creation date & time that resulting webhook subscriptions must succeed.
+  
+  This can be used to initiate the retrieval of paginated results.
+  Subsequent queries should use the opaque cursors returned from `WebhookSubscriptionsConnection`.
+  """
+  afterDateTime: DateTime
+  """
+  The creation date & time that resulting webhook subscriptions must precede.
+  
+  This can be used to initiate the retrieval of paginated results.
+  Subsequent queries should use the opaque cursors returned from `WebhookSubscriptionsConnection`.
+  """
+  beforeDateTime: DateTime
+  """
+  The event types of webhook subscriptions to retrieve.
+  
+  See the relevant `WebhookSubscription` implementation for a list of supported event types.
+  """
+  eventTypeCodes: [String!]
+  """
+  The hirer IDs of the hirer-filtered webhook subscriptions to retrieve.
+  
+  If this is not provided then both hirer-filtered and unfiltered subscriptions will be returned.
+  """
+  hirerIds: [String!]
+}
+"""A page of events from a stream."""
+type EventsConnection {
+  """
+  The page of events and their corresponding cursors.
+  
+  This is always a non-empty list.
+  """
+  edges: [EventEdge!]!
+  """The pagination metadata for this page of events."""
+  pageInfo: PageInfo!
+}
+"""An event in a stream."""
+type EventEdge {
+  """
+  The opaque cursor to the event in the stream.
+  
+  This can be used as a subsequent pagination argument.
+  """
+  cursor: String!
+  """The actual event."""
+  node: Event!
+  """
+  The date & time the event was added to the stream.
+  
+  Initial `afterDateTime` and `beforeDateTime` filters apply to this field.
+  """
+  streamDateTime: DateTime!
+}
+"""
+A signal that an action has been performed on the SEEK platform that may be of interest to an integration partner.
+
+Events can be delivered via:
+
+- Webhook, using the `createWebhookSubscription` mutation
+- GraphQL polling, using the paginated `events` query
+"""
+interface Event {
+  """The unique identifier of the event."""
+  id: ObjectIdentifier!
+  """
+  The data source for the event.
+  
+  This commonly refers to a SEEK brand.
+  See the relevant `Event` implementation for a list of supported schemes.
+  """
+  schemeId: String!
+  """
+  The type of event.
+  
+  See `Event` implementations for a list of supported values.
+  """
+  typeCode: String!
+  """
+  The date & time the event was created.
+  
+  This is commonly linked to the creation of an object that can be retrieved from the SEEK API.
+  
+  The data source for this field differs by event type and scheme.
+  This field has weak ordering guarantees, so it should not be used as a pagination argument.
+  """
+  createDateTime: DateTime!
+  """
+  A page of webhook attempts for the current event matching the specified criteria.
+  
+  The result list is returned in ascending creation date & time order.
+  It starts from the earliest known attempt if no pagination arguments are provided.
+  """
+  webhookAttempts(
+    """
+    An opaque cursor to the earlier bounding webhook attempt.
+    
+    Resulting webhook attempts will _succeed_ this cursor.
+    """
+    after: String
+    """
+    An opaque cursor to the later bounding webhook attempt.
+    
+    Resulting webhook attempts will _precede_ this cursor.
+    """
+    before: String
+    """
+    The upper limit of webhook attempts to return from the start of the list.
+    
+    Defaults to 10 if neither `first` nor `last` are specified.
+    Excess webhook attempts will be trimmed from the end of the list.
+    
+    `first` and `last` cannot be specified in the same query.
+    """
+    first: Int
+    """
+    The upper limit of webhook attempts to return from the end of the list.
+    
+    Excess webhook attempts will be trimmed from the start of the list.
+    
+    `first` and `last` cannot be specified in the same query.
+    """
+    last: Int
+    """The additional `WebhookAttempt`-specific criteria to filter by."""
+    filter: WebhookAttemptsFilterInput
+  ): WebhookAttemptsConnection!
+}
+"""
+The event signaling that a candidate has applied for a `PositionOpening`.
+
+A candidate may apply for the same position opening more than once.
+Each application will trigger a new event with a distinct `id`.
+"""
+type CandidateApplicationCreatedEvent implements Event {
+  """The unique identifier of the event."""
+  id: ObjectIdentifier!
+  """
+  The data source for the event.
+  
+  The following schemes are supported for this event type:
+  
+  - seekAnz
+  """
+  schemeId: String!
+  """The type of event, i.e. `CandidateApplicationCreated`."""
+  typeCode: String!
+  """
+  The date & time the application was accepted from the candidate.
+  
+  This field has weak ordering guarantees, so it should not be used as a pagination argument.
+  """
+  createDateTime: DateTime!
+  """
+  The identifier for the specific `CandidateProfile` associated with the application.
+  
+  This can be used to retrieve structured candidate details with the `candidateWithApplicationProfile` query.
+  """
+  candidateApplicationProfileId: String!
+  """The identifier for the `Candidate` that applied for the position opening."""
+  candidateId: String!
+  """
+  The `Candidate` that applied for the position opening.
+  
+  This will include the candidate's personal details along with all
+  application profiles for a single hirer.
+  """
+  candidate: Candidate!
+  """The `CandidateProfile` associated with the application."""
+  candidateApplicationProfile: CandidateProfile!
+  """
+  A page of webhook attempts for the current event matching the specified criteria.
+  
+  The result list is returned in ascending creation date & time order.
+  It starts from the earliest known attempt if no pagination arguments are provided.
+  """
+  webhookAttempts(
+    """
+    An opaque cursor to the earlier bounding webhook attempt.
+    
+    Resulting webhook attempts will _succeed_ this cursor.
+    """
+    after: String
+    """
+    An opaque cursor to the later bounding webhook attempt.
+    
+    Resulting webhook attempts will _precede_ this cursor.
+    """
+    before: String
+    """
+    The upper limit of webhook attempts to return from the start of the list.
+    
+    Defaults to 10 if neither `first` nor `last` are specified.
+    Excess webhook attempts will be trimmed from the end of the list.
+    
+    `first` and `last` cannot be specified in the same query.
+    """
+    first: Int
+    """
+    The upper limit of webhook attempts to return from the end of the list.
+    
+    Excess webhook attempts will be trimmed from the start of the list.
+    
+    `first` and `last` cannot be specified in the same query.
+    """
+    last: Int
+    """The additional `WebhookAttempt`-specific criteria to filter by."""
+    filter: WebhookAttemptsFilterInput
+  ): WebhookAttemptsConnection!
+}
+"""
+The event signaling that a `PositionProfile` has been posted.
+
+Corresponding events for the `updatePostedPositionProfile` and `closePostedPositionProfile` mutations are not currently available.
+"""
+type PositionProfilePostedEvent implements Event {
+  """The unique identifier of the event."""
+  id: ObjectIdentifier!
+  """
+  The data source for the event.
+  
+  The following schemes are supported for this event type:
+  
+  - seekAnz
+  """
+  schemeId: String!
+  """The type of event, i.e. `PositionProfilePosted`."""
+  typeCode: String!
+  """
+  The date & time the `PositionProfile` was considered as successfully posted inside of SEEK's internal systems.
+  
+  This field has weak ordering guarantees, so it should not be used as a pagination argument.
+  """
+  createDateTime: DateTime!
+  """The identifier for the `PositionProfile` that was posted."""
+  positionProfileId: String!
+  """
+  The `PositionProfile` that was posted.
+  
+  This may return null if the `PositionProfile` has been closed for an extended period of time.
+  """
+  positionProfile: PositionProfile
+  """
+  A page of webhook attempts for the current event matching the specified criteria.
+  
+  The result list is returned in ascending creation date & time order.
+  It starts from the earliest known attempt if no pagination arguments are provided.
+  """
+  webhookAttempts(
+    """
+    An opaque cursor to the earlier bounding webhook attempt.
+    
+    Resulting webhook attempts will _succeed_ this cursor.
+    """
+    after: String
+    """
+    An opaque cursor to the later bounding webhook attempt.
+    
+    Resulting webhook attempts will _precede_ this cursor.
+    """
+    before: String
+    """
+    The upper limit of webhook attempts to return from the start of the list.
+    
+    Defaults to 10 if neither `first` nor `last` are specified.
+    Excess webhook attempts will be trimmed from the end of the list.
+    
+    `first` and `last` cannot be specified in the same query.
+    """
+    first: Int
+    """
+    The upper limit of webhook attempts to return from the end of the list.
+    
+    Excess webhook attempts will be trimmed from the start of the list.
+    
+    `first` and `last` cannot be specified in the same query.
+    """
+    last: Int
+    """The additional `WebhookAttempt`-specific criteria to filter by."""
+    filter: WebhookAttemptsFilterInput
+  ): WebhookAttemptsConnection!
+}
+"""The event signaling that a `CandidateProfile` has been purchased."""
+type CandidateProfilePurchasedEvent implements Event {
+  """The unique identifier of the event."""
+  id: ObjectIdentifier!
+  """
+  The data source for the event.
+  
+  The following schemes are supported for this event type:
+  
+  - seekAnz
+  """
+  schemeId: String!
+  """The type of event, i.e. `CandidateProfilePurchased`."""
+  typeCode: String!
+  """
+  The date & time the `CandidateProfile` was purchased.
+  
+  This field has weak ordering guarantees, so it should not be used as a pagination argument.
+  """
+  createDateTime: DateTime!
+  """The identifier for the `CandidateProfile` that was purchased."""
+  candidateProfileId: String!
+  """
+  A page of webhook attempts for the current event matching the specified criteria.
+  
+  The result list is returned in ascending creation date & time order.
+  It starts from the earliest known attempt if no pagination arguments are provided.
+  """
+  webhookAttempts(
+    """
+    An opaque cursor to the earlier bounding webhook attempt.
+    
+    Resulting webhook attempts will _succeed_ this cursor.
+    """
+    after: String
+    """
+    An opaque cursor to the later bounding webhook attempt.
+    
+    Resulting webhook attempts will _precede_ this cursor.
+    """
+    before: String
+    """
+    The upper limit of webhook attempts to return from the start of the list.
+    
+    Defaults to 10 if neither `first` nor `last` are specified.
+    Excess webhook attempts will be trimmed from the end of the list.
+    
+    `first` and `last` cannot be specified in the same query.
+    """
+    first: Int
+    """
+    The upper limit of webhook attempts to return from the end of the list.
+    
+    Excess webhook attempts will be trimmed from the start of the list.
+    
+    `first` and `last` cannot be specified in the same query.
+    """
+    last: Int
+    """The additional `WebhookAttempt`-specific criteria to filter by."""
+    filter: WebhookAttemptsFilterInput
+  ): WebhookAttemptsConnection!
+}
+"""
+The criteria to filter events by.
+
+These are `Event`-specific extensions on top of the standard pagination arguments `before`, `after`, `first` and `last`.
+"""
+input EventsFilterInput {
+  """
+  The stream date & time that resulting events must succeed.
+  
+  This can be used to initiate the retrieval of paginated results.
+  Subsequent queries should use the opaque cursors returned from `EventsConnection`.
+  """
+  afterDateTime: DateTime
+  """
+  The stream date & time that resulting events must precede.
+  
+  This can be used to initiate the retrieval of paginated results.
+  Subsequent queries should use the opaque cursors returned from `EventsConnection`.
+  """
+  beforeDateTime: DateTime
+  """
+  An indicator that the event was successfully delivered via the specified webhook `subscriptionId`.
+  
+  This filter does not apply if `subscriptionId` is not specified.
+  """
+  deliveredIndicator: Boolean
+  """
+  The types of events to retrieve.
+  
+  See `Event` implementations for a list of supported values.
+  """
+  eventTypeCodes: [String!]
+  """
+  The subscription stream to retrieve events from.
+  
+  This can be used in combination with `deliveredIndicator` to identify events that were not successfully delivered through a particular webhook subscription.
+  
+  To consume events solely through GraphQL polling, do not specify this field.
+  This will retrieve events from a persistent stream that is not associated with a webhook subscription.
+  """
+  subscriptionId: String
+}

--- a/fe/package.json
+++ b/fe/package.json
@@ -3,15 +3,13 @@
     "url": "https://github.com/seek-oss/wingman/issues"
   },
   "dependencies": {
-    "@apollo/react-hooks": "^3.1.5",
+    "@apollo/client": "^3.1.1",
     "@hookform/resolvers": "^0.1.0",
     "@types/uuid": "^8.0.0",
     "@types/yup": "^0.29.2",
-    "apollo-boost": "^0.4.9",
     "autosuggest-highlight": "^3.1.1",
     "content-disposition": "^0.5.3",
     "graphql": "^15.0.0",
-    "react-apollo": "^3.1.5",
     "react-hook-form": "^6.0.2",
     "runtypes": "^5.0.0",
     "use-debounce": "^3.4.2",
@@ -19,7 +17,6 @@
     "yup": "^0.29.1"
   },
   "devDependencies": {
-    "@graphql-codegen/typescript-operations": "1.17.6",
     "@testing-library/react": "10.4.7",
     "@types/faker": "4.1.12",
     "@types/react": "16.9.43",
@@ -28,14 +25,14 @@
     "classnames": "2.2.6",
     "date-fns": "2.15.0",
     "faker": "4.1.0",
-    "graphql-tools": "6.0.15",
-    "mock-apollo-client": "0.4.0",
+    "@graphql-tools/schema": "6.0.15",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-router-dom": "5.2.0",
     "scoobie": "3.11.0",
     "sku": "10.5.0",
-    "use-query-params": "1.1.6"
+    "use-query-params": "1.1.6",
+    "webpack-merge": "5.1.0"
   },
   "files": [
     "lib"

--- a/fe/sku.config.js
+++ b/fe/sku.config.js
@@ -1,3 +1,5 @@
+const { merge } = require('webpack-merge');
+
 const isGitHubPages = Boolean(process.env.IS_GITHUB_PAGES);
 
 module.exports = {
@@ -40,4 +42,20 @@ module.exports = {
       ],
     },
   }),
+
+  dangerouslySetWebpackConfig: (skuWebpackConfig) =>
+    merge(skuWebpackConfig, {
+      module: {
+        rules: [
+          {
+            test: /\.graphql?$/i,
+            use: [
+              {
+                loader: 'raw-loader',
+              },
+            ],
+          },
+        ],
+      },
+    }),
 };

--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
   ],
   "version": "0.0.0",
   "devDependencies": {
-    "@graphql-codegen/cli": "1.17.6",
-    "@graphql-codegen/fragment-matcher": "1.17.6",
-    "@graphql-codegen/typescript": "1.17.6",
+    "@graphql-codegen/cli": "1.17.7",
+    "@graphql-codegen/fragment-matcher": "1.17.7",
+    "@graphql-codegen/schema-ast": "1.17.7",
+    "@graphql-codegen/typescript": "1.17.7",
+    "@graphql-codegen/typescript-operations": "1.17.7",
     "graphql": "15.3.0",
     "skuba": "3.7.6"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,16 +2,16 @@
 # yarn lockfile v1
 
 
-"@apollo/client@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.0.2.tgz#fadb2b39a0e32950baaef2566442cb3f6de74a52"
-  integrity sha512-4ighan5Anlj4tK/tdUHs4Mi1njqXZ7AxRCVolz/H702DjPphAJfm+FRkIadPTmwz+OLO+d+tX+6V1VBshf02rg==
+"@apollo/client@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.1.1.tgz#7d57d037be8ee93694fbf82579f703e635c836c1"
+  integrity sha512-c5DxrU81p0B5BsyBXm+5uPJqLCX2epnBsd87PXfRwzDLbp/NiqnWp6a6c5vT5EV2LwJuCq1movmKthoy0gFb0w==
   dependencies:
     "@types/zen-observable" "^0.8.0"
     "@wry/context" "^0.5.2"
-    "@wry/equality" "^0.1.9"
+    "@wry/equality" "^0.2.0"
     fast-json-stable-stringify "^2.0.0"
-    graphql-tag "^2.10.4"
+    graphql-tag "^2.11.0"
     hoist-non-react-statics "^3.3.2"
     optimism "^0.12.1"
     prop-types "^15.7.2"
@@ -38,55 +38,6 @@
     "@types/long" "^4.0.0"
     "@types/node" "^10.1.0"
     long "^4.0.0"
-
-"@apollo/react-common@^3.1.4":
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/@apollo/react-common/-/react-common-3.1.4.tgz#ec13c985be23ea8e799c9ea18e696eccc97be345"
-  integrity sha512-X5Kyro73bthWSCBJUC5XYQqMnG0dLWuDZmVkzog9dynovhfiVCV4kPSdgSIkqnb++cwCzOVuQ4rDKVwo2XRzQA==
-  dependencies:
-    ts-invariant "^0.4.4"
-    tslib "^1.10.0"
-
-"@apollo/react-components@^3.1.5":
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/@apollo/react-components/-/react-components-3.1.5.tgz#040d2f35ce4947747efe16f76d59dcbd797ffdaf"
-  integrity sha512-c82VyUuE9VBnJB7bnX+3dmwpIPMhyjMwyoSLyQWPHxz8jK4ak30XszJtqFf4eC4hwvvLYa+Ou6X73Q8V8e2/jg==
-  dependencies:
-    "@apollo/react-common" "^3.1.4"
-    "@apollo/react-hooks" "^3.1.5"
-    prop-types "^15.7.2"
-    ts-invariant "^0.4.4"
-    tslib "^1.10.0"
-
-"@apollo/react-hoc@^3.1.5":
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/@apollo/react-hoc/-/react-hoc-3.1.5.tgz#6552d2fb4aafc59fdc8f4e353358b98b89cfab6f"
-  integrity sha512-jlZ2pvEnRevLa54H563BU0/xrYSgWQ72GksarxUzCHQW85nmn9wQln0kLBX7Ua7SBt9WgiuYQXQVechaaCulfQ==
-  dependencies:
-    "@apollo/react-common" "^3.1.4"
-    "@apollo/react-components" "^3.1.5"
-    hoist-non-react-statics "^3.3.0"
-    ts-invariant "^0.4.4"
-    tslib "^1.10.0"
-
-"@apollo/react-hooks@^3.1.5":
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/@apollo/react-hooks/-/react-hooks-3.1.5.tgz#7e710be52461255ae7fc0b3b9c2ece64299c10e6"
-  integrity sha512-y0CJ393DLxIIkksRup4nt+vSjxalbZBXnnXxYbviq/woj+zKa431zy0yT4LqyRKpFy9ahMIwxBnBwfwIoupqLQ==
-  dependencies:
-    "@apollo/react-common" "^3.1.4"
-    "@wry/equality" "^0.1.9"
-    ts-invariant "^0.4.4"
-    tslib "^1.10.0"
-
-"@apollo/react-ssr@^3.1.5":
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/@apollo/react-ssr/-/react-ssr-3.1.5.tgz#53703cd493afcde567acc6d5512cab03dafce6de"
-  integrity sha512-wuLPkKlctNn3u8EU8rlECyktpOUCeekFfb0KhIKknpGY6Lza2Qu0bThx7D9MIbVEzhKadNNrzLcpk0Y8/5UuWg==
-  dependencies:
-    "@apollo/react-common" "^3.1.4"
-    "@apollo/react-hooks" "^3.1.5"
-    tslib "^1.10.0"
 
 "@apollographql/apollo-tools@^0.4.3":
   version "0.4.8"
@@ -1143,7 +1094,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.10.5", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.7.7", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2", "@babel/runtime@^7.9.6":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.7.7", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2", "@babel/runtime@^7.9.6":
   version "7.10.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.5.tgz#303d8bd440ecd5a491eae6117fd3367698674c5c"
   integrity sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==
@@ -1518,13 +1469,13 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@graphql-codegen/cli@1.17.6":
-  version "1.17.6"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/cli/-/cli-1.17.6.tgz#c6ff046a8aa0c29c965ed55dd937c87065a217d5"
-  integrity sha512-whJYs0+4oz40rfzUHWbSl56ZAejQdEabIhyrI8KeMUt3xzQrNjnk1rIrbPca8wadjU8gTrfEfP+QJJ2g0psA/w==
+"@graphql-codegen/cli@1.17.7":
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/cli/-/cli-1.17.7.tgz#4ba45106403a3aca36585bf04f0169fda38ac9df"
+  integrity sha512-T9b4r7WkA+VfW8nsAjOWFoFbtpfFAAjPQM6q/8aPg6Ny3rwwefH8UDVa3P3QSfdIYl2qKnBk1FG2mNjBCUYKsg==
   dependencies:
-    "@graphql-codegen/core" "1.17.6"
-    "@graphql-codegen/plugin-helpers" "1.17.6"
+    "@graphql-codegen/core" "1.17.7"
+    "@graphql-codegen/plugin-helpers" "1.17.7"
     "@graphql-tools/apollo-engine-loader" "^6.0.0"
     "@graphql-tools/code-file-loader" "^6.0.0"
     "@graphql-tools/git-loader" "^6.0.0"
@@ -1541,7 +1492,7 @@
     chokidar "3.4.1"
     common-tags "1.8.0"
     constant-case "3.0.3"
-    cosmiconfig "6.0.0"
+    cosmiconfig "7.0.0"
     debounce "1.2.0"
     dependency-graph "0.9.0"
     detect-indent "6.0.0"
@@ -1567,28 +1518,28 @@
     wrap-ansi "7.0.0"
     yargs "15.4.1"
 
-"@graphql-codegen/core@1.17.6":
-  version "1.17.6"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/core/-/core-1.17.6.tgz#8f3bd27223f47b455cdc455d768fdd6238a6199d"
-  integrity sha512-m9wWTIR5SucEtsxQZUu1UxCR+XgcGox6+5aplzOxF3q4SYVZqLRcMA3WrHkV/2s57jAYQvrHj+4l5XtY/ErCzw==
+"@graphql-codegen/core@1.17.7":
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/core/-/core-1.17.7.tgz#9f2f5798ec1c551827aa4ce6417d58cf48cd2a92"
+  integrity sha512-KfVoNtGCHvj/oN22Yl7ljPC9LkxvAAGDVPilYjJa3GjcT6YvF5k+ijyZ3GMjU8belN3g04Ls/WpKUsWA6HpkiQ==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "1.17.6"
+    "@graphql-codegen/plugin-helpers" "1.17.7"
     "@graphql-tools/merge" "^6.0.0"
     "@graphql-tools/utils" "^6.0.0"
     tslib "~2.0.0"
 
-"@graphql-codegen/fragment-matcher@1.17.6":
-  version "1.17.6"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/fragment-matcher/-/fragment-matcher-1.17.6.tgz#e4f0952b0908f852f4e2f9b036342dd6d839935c"
-  integrity sha512-h/V8QdR+lJbcK3GdYBt7vjwD/DsfHfIzdjPvjvNPRnAWjbqgxF7dyz+SAAb5RTVG9AiHRaZEofFIUfCLmCsqNg==
+"@graphql-codegen/fragment-matcher@1.17.7":
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/fragment-matcher/-/fragment-matcher-1.17.7.tgz#a7ce7411b52de80b788eaf920cdce812419b1f29"
+  integrity sha512-cyQXVgjzHRIPiLaeeNqTrOCEqm7K5OyqKA787Dk6iM4OhRqbOicM731y4wI7HTyg+48QXYE7CFCkLkMaQKH81Q==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "1.17.6"
+    "@graphql-codegen/plugin-helpers" "1.17.7"
     tslib "~2.0.0"
 
-"@graphql-codegen/plugin-helpers@1.17.6":
-  version "1.17.6"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/plugin-helpers/-/plugin-helpers-1.17.6.tgz#533eff5acdf5ddd5b361d5b4f04ed778235432b3"
-  integrity sha512-ULt9VhERutfyg2UmYLAV37MsItL1tCP16OkUrXluoEPsinRhtBmSVn2F0JeZoNdtb2ZQO/uvg6qnj1xBvTwh+Q==
+"@graphql-codegen/plugin-helpers@1.17.7":
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/plugin-helpers/-/plugin-helpers-1.17.7.tgz#5903105fda9470aafefe9da29e3a6fb3a52b8376"
+  integrity sha512-LsXS0s/ZOACZXa3W29ekcaQLzP8TsYzow6nIjW6rtkWX5T0EDooBQbDn1cdLdlpenqbUU+vtONwR6Qqc6hrq2Q==
   dependencies:
     "@graphql-tools/utils" "^6.0.0"
     camel-case "4.1.1"
@@ -1602,38 +1553,47 @@
     tslib "~2.0.0"
     upper-case "2.0.1"
 
-"@graphql-codegen/typescript-operations@1.17.6":
-  version "1.17.6"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-operations/-/typescript-operations-1.17.6.tgz#bdb94a9dd20cd46d586919bf4762c67b073758b6"
-  integrity sha512-vlwq+P+ultbUEG79jUfYFFKAziVyIQtqk2sFHYan3n5ha21oWX67SHWLzQA/nXl/bdwEb0QQKViyOF3x4eTbSw==
+"@graphql-codegen/schema-ast@1.17.7":
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/schema-ast/-/schema-ast-1.17.7.tgz#f24bd0ca6861d09d49b68f96d0198dbab8f9723e"
+  integrity sha512-fQbp8Fz0KruoZ2aTtBpk3wBUJMsSUBmRQq201eQyt+ANUIY7PoSAGIlOKgze0JRwhlU6zN8mIS95RFzDyJUPkg==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "1.17.6"
-    "@graphql-codegen/typescript" "1.17.6"
-    "@graphql-codegen/visitor-plugin-common" "1.17.6"
+    "@graphql-codegen/plugin-helpers" "1.17.7"
+    "@graphql-tools/utils" "^6.0.0"
+    tslib "~2.0.0"
+
+"@graphql-codegen/typescript-operations@1.17.7":
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-operations/-/typescript-operations-1.17.7.tgz#28bfca6bf47549971ce79fea9cecaa8727515271"
+  integrity sha512-gmY3YC0xoF8waPJKOB35xLsfqs2gG7fQiGmZ9sOJ3ck8hME0osgdNVXpKSX6GYMmbhb2nrdbynG+77JwGpxXfg==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "1.17.7"
+    "@graphql-codegen/typescript" "1.17.7"
+    "@graphql-codegen/visitor-plugin-common" "1.17.7"
     auto-bind "~4.0.0"
     tslib "~2.0.0"
 
-"@graphql-codegen/typescript@1.17.6":
-  version "1.17.6"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-1.17.6.tgz#85d9e6b391747f61bbc37b8808b7c5a0f0bd84f5"
-  integrity sha512-Wk/U/95zvaE12hzhJsQt9jra7ads+IzMJrENLb93Gv6I1fQQK6StcGTQVIoMvw4e5w+cUVzt7MFIbU0UMbBmag==
+"@graphql-codegen/typescript@1.17.7":
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-1.17.7.tgz#35d92da76d4e07b612ab1ac0bd9726fbaac1fb0d"
+  integrity sha512-itjssTRBIvZgoNwzz/mhDkaeZvoMqHaeN+PDqev+6gY+RDDGcr9fsEm/SLm9nOpBWZCAHFVc9u7wHlSPhbYGtw==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "1.17.6"
-    "@graphql-codegen/visitor-plugin-common" "1.17.6"
+    "@graphql-codegen/plugin-helpers" "1.17.7"
+    "@graphql-codegen/visitor-plugin-common" "1.17.7"
     auto-bind "~4.0.0"
     tslib "~2.0.0"
 
-"@graphql-codegen/visitor-plugin-common@1.17.6":
-  version "1.17.6"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-1.17.6.tgz#d66ab05efb36f6966b7bef688e9c115aa122482a"
-  integrity sha512-1TNOf0VncmOESeh7oZbFXSAst8GpEpiHuOdgUjGCPHYqahlehRi5tMeoKPNht9h7oHhVa93/dDhx6gM4iy+Y/Q==
+"@graphql-codegen/visitor-plugin-common@1.17.7":
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-1.17.7.tgz#3158ca4fc7d45a0f5a6ad0706061015eae481d9e"
+  integrity sha512-z5WvYqgCgPAAuMJMOE0e0nEicdaQRm59/vP+yYihKQmwrASzPlqa1BUiGDnfrPcCooB9fEUHB+cQb3gt9GRfEg==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "1.17.6"
+    "@graphql-codegen/plugin-helpers" "1.17.7"
     "@graphql-tools/relay-operation-optimizer" "6.0.15"
     array.prototype.flatmap "1.2.3"
     auto-bind "~4.0.0"
     dependency-graph "0.9.0"
-    graphql-tag "2.10.4"
+    graphql-tag "2.11.0"
     parse-filepath "1.0.2"
     pascal-case "3.1.1"
     tslib "~2.0.0"
@@ -1712,16 +1672,7 @@
     cross-fetch "3.0.4"
     tslib "~2.0.0"
 
-"@graphql-tools/batch-delegate@6.0.15":
-  version "6.0.15"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/batch-delegate/-/batch-delegate-6.0.15.tgz#2c31b2a997ef8cadd6e7d41cc2e5f3fe88a669c8"
-  integrity sha512-/wU9q/ZLdMkvxNHD2PUk3qwBleWcZfsU5Ity5a6E1wRRsxqcl74pDMoZFHZhF5uioHuGZ5ebdA+v78PpEaDOhQ==
-  dependencies:
-    "@graphql-tools/delegate" "6.0.15"
-    dataloader "2.0.0"
-    tslib "~2.0.0"
-
-"@graphql-tools/code-file-loader@6.0.15", "@graphql-tools/code-file-loader@^6.0.0":
+"@graphql-tools/code-file-loader@^6.0.0":
   version "6.0.15"
   resolved "https://registry.yarnpkg.com/@graphql-tools/code-file-loader/-/code-file-loader-6.0.15.tgz#d4c04b6493ac658da13bb115e7ed6821e2c687f1"
   integrity sha512-Z4RLnJzlHWHbfe/yRFLqWuqxd6//dSxj/87FiOwN2GR+o/7I0N7ppZIAsLleVDM0LghDO+Nnt1cacNAEmTd0Fw==
@@ -1750,7 +1701,7 @@
     "@graphql-tools/utils" "6.0.7"
     tslib "~2.0.0"
 
-"@graphql-tools/git-loader@6.0.15", "@graphql-tools/git-loader@^6.0.0":
+"@graphql-tools/git-loader@^6.0.0":
   version "6.0.15"
   resolved "https://registry.yarnpkg.com/@graphql-tools/git-loader/-/git-loader-6.0.15.tgz#b9c70e332943372f50c7ef4e1161a65d5bdac08e"
   integrity sha512-Tt33twi6oe++Hk+CeEl8A6DxETunwLG9EOkdHglxIKFn5k6yt8sd2hninwGjj8uyceC6CpeChN6jkF6Hg3N7fA==
@@ -1758,7 +1709,7 @@
     "@graphql-tools/graphql-tag-pluck" "6.0.15"
     "@graphql-tools/utils" "6.0.15"
 
-"@graphql-tools/github-loader@6.0.15", "@graphql-tools/github-loader@^6.0.0":
+"@graphql-tools/github-loader@^6.0.0":
   version "6.0.15"
   resolved "https://registry.yarnpkg.com/@graphql-tools/github-loader/-/github-loader-6.0.15.tgz#2faccd5d20de87fba4762aa0e33659edd924da54"
   integrity sha512-JYZp+u84JHJUB84dAlAHVgCxWtots6qtqMeENHPgNnpkci0cYKHAw+Mna3rZCEXR+9m4QKkM6K35U9cHODc6BA==
@@ -1767,7 +1718,7 @@
     "@graphql-tools/utils" "6.0.15"
     cross-fetch "3.0.5"
 
-"@graphql-tools/graphql-file-loader@6.0.15", "@graphql-tools/graphql-file-loader@^6.0.0":
+"@graphql-tools/graphql-file-loader@^6.0.0":
   version "6.0.15"
   resolved "https://registry.yarnpkg.com/@graphql-tools/graphql-file-loader/-/graphql-file-loader-6.0.15.tgz#e186b8147397bd7510e1b3318f5d3f7d365fc4e1"
   integrity sha512-QbCf731A2A2hrHP+cMSAKvY3D7IauFNqp5bAGdbLwSHRqaxUIfKi7Q76/9pZ3rN/e6yu/zVz+t1rkf7lT2/8OA==
@@ -1797,7 +1748,7 @@
     fs-extra "9.0.1"
     resolve-from "5.0.0"
 
-"@graphql-tools/json-file-loader@6.0.15", "@graphql-tools/json-file-loader@^6.0.0":
+"@graphql-tools/json-file-loader@^6.0.0":
   version "6.0.15"
   resolved "https://registry.yarnpkg.com/@graphql-tools/json-file-loader/-/json-file-loader-6.0.15.tgz#e341a5fed1ef3af8f8bfde17ed9a14e1a6df36c0"
   integrity sha512-SQO7w+KPxW6Q3snE3G4eNOA8CcBBDYHpk8JILj93oe4BassuPY5NCUOeZ+2PYczwZQbTNDQXeW1oQou44U1aBg==
@@ -1806,28 +1757,7 @@
     fs-extra "9.0.1"
     tslib "~2.0.0"
 
-"@graphql-tools/links@6.0.15":
-  version "6.0.15"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/links/-/links-6.0.15.tgz#21b39e7ad5c1d89734ccb2e2683736cc88514fba"
-  integrity sha512-jvSU7Ro1EM+tagnoXiGyQjB8K/EywaJq/Il4VaMdn1460DulzSNTWira/toDM64m6luKtpTkDiy7kPBlA4bwhw==
-  dependencies:
-    "@graphql-tools/utils" "6.0.15"
-    apollo-link "1.2.14"
-    apollo-upload-client "14.0.1"
-    cross-fetch "3.0.5"
-    form-data "3.0.0"
-    tslib "~2.0.0"
-
-"@graphql-tools/load-files@6.0.15":
-  version "6.0.15"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/load-files/-/load-files-6.0.15.tgz#2e8ae233817bd6aee4145e1a6fce76d95f80ca78"
-  integrity sha512-Sm09x/IxCWQmqrn5LouZ2oNqI7rwCh9HtAmpjBLc3ET6ykDSLoDD7O+fYoM62mnv9SpTyJgB4NPYcxWj6l2JlA==
-  dependencies:
-    fs-extra "9.0.1"
-    globby "11.0.1"
-    unixify "1.0.0"
-
-"@graphql-tools/load@6.0.15", "@graphql-tools/load@^6.0.0":
+"@graphql-tools/load@^6.0.0":
   version "6.0.15"
   resolved "https://registry.yarnpkg.com/@graphql-tools/load/-/load-6.0.15.tgz#f2012b8938b3a535dbafefbb719997684028f30f"
   integrity sha512-STH3ZjbViRqDyCw+f7PZrnDs6yhP7m2l4x5lJBMyMeLaLwuO1z+WhgtqYZNpCYlQY2jNSLXWCa0nWmpYvdLnlA==
@@ -1851,23 +1781,6 @@
     "@graphql-tools/utils" "6.0.15"
     tslib "~2.0.0"
 
-"@graphql-tools/mock@6.0.15":
-  version "6.0.15"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/mock/-/mock-6.0.15.tgz#253a0d82ab9411fbfc8409c577f9fe3c72f6854e"
-  integrity sha512-WzQoSjIQsxwid78JJd2gz8Uv+POWdCAtShkKvUpTaR/m5V6vLBUWBL9LQS7zDxn9DWoesCWvmR/Yz4ZUzZOydw==
-  dependencies:
-    "@graphql-tools/schema" "6.0.15"
-    "@graphql-tools/utils" "6.0.15"
-    tslib "~2.0.0"
-
-"@graphql-tools/module-loader@6.0.15":
-  version "6.0.15"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/module-loader/-/module-loader-6.0.15.tgz#2c408dc73018a595d1300dfed83a1db520777685"
-  integrity sha512-GJh1qRcSMLr37d44RXEy7MDdgpr2ShHL1sfMixDF9jY5Tb7LUm6Bh4mJ3d3OvjPI5yqjp+pTRlc9SZ98zVK2vA==
-  dependencies:
-    "@graphql-tools/utils" "6.0.15"
-    tslib "~2.0.0"
-
 "@graphql-tools/prisma-loader@^6.0.0":
   version "6.0.7"
   resolved "https://registry.yarnpkg.com/@graphql-tools/prisma-loader/-/prisma-loader-6.0.7.tgz#2605d1102e3a6e276093ddaa8eabeec4af7cbb16"
@@ -1887,14 +1800,6 @@
     "@graphql-tools/utils" "6.0.15"
     relay-compiler "10.0.0"
 
-"@graphql-tools/resolvers-composition@6.0.15":
-  version "6.0.15"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/resolvers-composition/-/resolvers-composition-6.0.15.tgz#8d1228c3598b595099ba7be1ba66c3d827dbc7f1"
-  integrity sha512-JQWA+Acw4QVz3eiHqEEtHunTksmVj6gRFelfHAZ7jB50Ig6GJ76AsycZqOq2aDW3IC6ygKXQlCgxzgZVQBwMqg==
-  dependencies:
-    "@graphql-tools/utils" "6.0.15"
-    lodash "4.17.19"
-
 "@graphql-tools/schema@6.0.15":
   version "6.0.15"
   resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-6.0.15.tgz#b016f9f36820342982887a291baa7e7d11b039ae"
@@ -1911,34 +1816,6 @@
     "@graphql-tools/utils" "6.0.7"
     tslib "~2.0.0"
 
-"@graphql-tools/stitch@6.0.15":
-  version "6.0.15"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/stitch/-/stitch-6.0.15.tgz#aa0c7718d970bea2586930fd05eced178f3e4d68"
-  integrity sha512-ooqPaDiBGLBtGlf0aEDHTCBofTjTUjuh/j5B7PwRFT4Tt6kzNpCcp3uAvbfQ+zjv/aTZNHK80CBKqI+vdTTZWA==
-  dependencies:
-    "@graphql-tools/batch-delegate" "6.0.15"
-    "@graphql-tools/delegate" "6.0.15"
-    "@graphql-tools/merge" "6.0.15"
-    "@graphql-tools/schema" "6.0.15"
-    "@graphql-tools/utils" "6.0.15"
-    "@graphql-tools/wrap" "6.0.15"
-    tslib "~2.0.0"
-
-"@graphql-tools/url-loader@6.0.15", "@graphql-tools/url-loader@^6.0.0":
-  version "6.0.15"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/url-loader/-/url-loader-6.0.15.tgz#3ad621ed75c03fbc0ea08d2560f379a053c4035f"
-  integrity sha512-/iGuK7J9yCECYMYQJqKNWnz4ytPHppkxh4YS5Ud9QPDNl488e+eInyNbkdiWcFGyZ4KHqEnXSDdRFg3mFNrMnw==
-  dependencies:
-    "@graphql-tools/delegate" "6.0.15"
-    "@graphql-tools/utils" "6.0.15"
-    "@graphql-tools/wrap" "6.0.15"
-    "@types/websocket" "1.0.1"
-    cross-fetch "3.0.5"
-    subscriptions-transport-ws "0.9.17"
-    tslib "~2.0.0"
-    valid-url "1.0.9"
-    websocket "1.0.31"
-
 "@graphql-tools/url-loader@6.0.7":
   version "6.0.7"
   resolved "https://registry.yarnpkg.com/@graphql-tools/url-loader/-/url-loader-6.0.7.tgz#0357e760797a72d2b471fcf55fbc79bb6442c05d"
@@ -1949,6 +1826,21 @@
     "@types/websocket" "1.0.0"
     cross-fetch "3.0.4"
     subscriptions-transport-ws "0.9.16"
+    tslib "~2.0.0"
+    valid-url "1.0.9"
+    websocket "1.0.31"
+
+"@graphql-tools/url-loader@^6.0.0":
+  version "6.0.15"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/url-loader/-/url-loader-6.0.15.tgz#3ad621ed75c03fbc0ea08d2560f379a053c4035f"
+  integrity sha512-/iGuK7J9yCECYMYQJqKNWnz4ytPHppkxh4YS5Ud9QPDNl488e+eInyNbkdiWcFGyZ4KHqEnXSDdRFg3mFNrMnw==
+  dependencies:
+    "@graphql-tools/delegate" "6.0.15"
+    "@graphql-tools/utils" "6.0.15"
+    "@graphql-tools/wrap" "6.0.15"
+    "@types/websocket" "1.0.1"
+    cross-fetch "3.0.5"
+    subscriptions-transport-ws "0.9.17"
     tslib "~2.0.0"
     valid-url "1.0.9"
     websocket "1.0.31"
@@ -3752,7 +3644,7 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@>= 8", "@types/node@>=6":
+"@types/node@*", "@types/node@>= 8":
   version "14.0.14"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.14.tgz#24a0b5959f16ac141aeb0c5b3cd7a15b7c64cbce"
   integrity sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ==
@@ -4297,14 +4189,6 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
-"@wry/context@^0.4.0":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.4.4.tgz#e50f5fa1d6cfaabf2977d1fda5ae91717f8815f8"
-  integrity sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==
-  dependencies:
-    "@types/node" ">=6"
-    tslib "^1.9.3"
-
 "@wry/context@^0.5.2":
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.5.2.tgz#f2a5d5ab9227343aa74c81e06533c1ef84598ec7"
@@ -4312,10 +4196,17 @@
   dependencies:
     tslib "^1.9.3"
 
-"@wry/equality@^0.1.2", "@wry/equality@^0.1.9":
+"@wry/equality@^0.1.2":
   version "0.1.11"
   resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.11.tgz#35cb156e4a96695aa81a9ecc4d03787bc17f1790"
   integrity sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==
+  dependencies:
+    tslib "^1.9.3"
+
+"@wry/equality@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.2.0.tgz#a312d1b6a682d0909904c2bcd355b02303104fb7"
+  integrity sha512-Y4d+WH6hs+KZJUC8YKLYGarjGekBrhslDbf/R20oV+AakHPINSitHfDRQz3EGcEWc1luXYNUvMhawWtZVWNGvQ==
   dependencies:
     tslib "^1.9.3"
 
@@ -4624,21 +4515,6 @@ anymatch@^3.0.3, anymatch@~3.1.1:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-apollo-boost@^0.4.9:
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/apollo-boost/-/apollo-boost-0.4.9.tgz#ab3ba539c2ca944e6fd156583a1b1954b17a6791"
-  integrity sha512-05y5BKcDaa8w47f8d81UVwKqrAjn8uKLv6QM9fNdldoNzQ+rnOHgFlnrySUZRz9QIT3vPftQkEz2UEASp1Mi5g==
-  dependencies:
-    apollo-cache "^1.3.5"
-    apollo-cache-inmemory "^1.6.6"
-    apollo-client "^2.6.10"
-    apollo-link "^1.0.6"
-    apollo-link-error "^1.0.3"
-    apollo-link-http "^1.3.1"
-    graphql-tag "^2.4.2"
-    ts-invariant "^0.4.0"
-    tslib "^1.10.0"
-
 apollo-cache-control@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/apollo-cache-control/-/apollo-cache-control-0.11.0.tgz#7075492d04c5424e7c6769380b503e8f75b39d61"
@@ -4646,39 +4522,6 @@ apollo-cache-control@^0.11.0:
   dependencies:
     apollo-server-env "^2.4.4"
     apollo-server-plugin-base "^0.9.0"
-
-apollo-cache-inmemory@^1.6.6:
-  version "1.6.6"
-  resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.6.tgz#56d1f2a463a6b9db32e9fa990af16d2a008206fd"
-  integrity sha512-L8pToTW/+Xru2FFAhkZ1OA9q4V4nuvfoPecBM34DecAugUZEBhI2Hmpgnzq2hTKZ60LAMrlqiASm0aqAY6F8/A==
-  dependencies:
-    apollo-cache "^1.3.5"
-    apollo-utilities "^1.3.4"
-    optimism "^0.10.0"
-    ts-invariant "^0.4.0"
-    tslib "^1.10.0"
-
-apollo-cache@1.3.5, apollo-cache@^1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.3.5.tgz#9dbebfc8dbe8fe7f97ba568a224bca2c5d81f461"
-  integrity sha512-1XoDy8kJnyWY/i/+gLTEbYLnoiVtS8y7ikBr/IfmML4Qb+CM7dEEbIUOjnY716WqmZ/UpXIxTfJsY7rMcqiCXA==
-  dependencies:
-    apollo-utilities "^1.3.4"
-    tslib "^1.10.0"
-
-apollo-client@^2.6.10:
-  version "2.6.10"
-  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.6.10.tgz#86637047b51d940c8eaa771a4ce1b02df16bea6a"
-  integrity sha512-jiPlMTN6/5CjZpJOkGeUV0mb4zxx33uXWdj/xQCfAMkuNAC3HN7CvYDyMHHEzmcQ5GV12LszWoQ/VlxET24CtA==
-  dependencies:
-    "@types/zen-observable" "^0.8.0"
-    apollo-cache "1.3.5"
-    apollo-link "^1.0.0"
-    apollo-utilities "1.3.4"
-    symbol-observable "^1.0.2"
-    ts-invariant "^0.4.0"
-    tslib "^1.10.0"
-    zen-observable "^0.8.0"
 
 apollo-datasource@^0.7.1:
   version "0.7.1"
@@ -4728,16 +4571,7 @@ apollo-graphql@^0.4.0:
     apollo-env "^0.6.5"
     lodash.sortby "^4.7.0"
 
-apollo-link-error@^1.0.3:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/apollo-link-error/-/apollo-link-error-1.1.13.tgz#c1a1bb876ffe380802c8df0506a32c33aad284cd"
-  integrity sha512-jAZOOahJU6bwSqb2ZyskEK1XdgUY9nkmeclCrW7Gddh1uasHVqmoYc4CKdb0/H0Y1J9lvaXKle2Wsw/Zx1AyUg==
-  dependencies:
-    apollo-link "^1.2.14"
-    apollo-link-http-common "^0.2.16"
-    tslib "^1.9.3"
-
-apollo-link-http-common@^0.2.14, apollo-link-http-common@^0.2.16:
+apollo-link-http-common@^0.2.14:
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz#756749dafc732792c8ca0923f9a40564b7c59ecc"
   integrity sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==
@@ -4746,16 +4580,7 @@ apollo-link-http-common@^0.2.14, apollo-link-http-common@^0.2.16:
     ts-invariant "^0.4.0"
     tslib "^1.9.3"
 
-apollo-link-http@^1.3.1:
-  version "1.5.17"
-  resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.5.17.tgz#499e9f1711bf694497f02c51af12d82de5d8d8ba"
-  integrity sha512-uWcqAotbwDEU/9+Dm9e1/clO7hTB2kQ/94JYcGouBVLjoKmTeJTUPQKcJGpPwUjZcSqgYicbFqQSoJIW0yrFvg==
-  dependencies:
-    apollo-link "^1.2.14"
-    apollo-link-http-common "^0.2.16"
-    tslib "^1.9.3"
-
-apollo-link@1.2.14, apollo-link@^1.0.0, apollo-link@^1.0.6, apollo-link@^1.2.12, apollo-link@^1.2.14:
+apollo-link@^1.2.12, apollo-link@^1.2.14:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.14.tgz#3feda4b47f9ebba7f4160bef8b977ba725b684d9"
   integrity sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==
@@ -4861,15 +4686,6 @@ apollo-tracing@^0.11.0:
     apollo-server-env "^2.4.4"
     apollo-server-plugin-base "^0.9.0"
 
-apollo-upload-client@14.0.1:
-  version "14.0.1"
-  resolved "https://registry.yarnpkg.com/apollo-upload-client/-/apollo-upload-client-14.0.1.tgz#62ca85c4e45d48c2e73cabcdd7cc639492dacb4b"
-  integrity sha512-2Ebh5LQukHpGNebAWRdf9i3t91mJbZAyEG7WVrw9Mx3bxKIQ+4iYmBz3XV+pK8lqs8332i4k3D46hGdXDc5/gg==
-  dependencies:
-    "@apollo/client" "^3.0.2"
-    "@babel/runtime" "^7.10.5"
-    extract-files "^8.1.0"
-
 apollo-upload-client@^13.0.0:
   version "13.0.0"
   resolved "https://registry.yarnpkg.com/apollo-upload-client/-/apollo-upload-client-13.0.0.tgz#146d1ddd85d711fcac8ca97a72d3ca6787f2b71b"
@@ -4880,7 +4696,7 @@ apollo-upload-client@^13.0.0:
     apollo-link-http-common "^0.2.14"
     extract-files "^8.0.0"
 
-apollo-utilities@1.3.4, apollo-utilities@^1.0.1, apollo-utilities@^1.3.0, apollo-utilities@^1.3.4:
+apollo-utilities@^1.0.1, apollo-utilities@^1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.3.4.tgz#6129e438e8be201b6c55b0f13ce49d2c7175c9cf"
   integrity sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==
@@ -6740,6 +6556,15 @@ clone-deep@^0.2.4:
     lazy-cache "^1.0.3"
     shallow-clone "^0.1.2"
 
+clone-deep@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-4.0.1.tgz#c19fd9bdbbf85942b4fd979c84dcf7d5f07c2387"
+  integrity sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==
+  dependencies:
+    is-plain-object "^2.0.4"
+    kind-of "^6.0.2"
+    shallow-clone "^3.0.0"
+
 clone-response@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
@@ -7229,6 +7054,17 @@ cosmiconfig@6.0.0, cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
+cosmiconfig@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.0.tgz#ef9b44d773959cae63ddecd122de23853b60f8d3"
+  integrity sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==
+  dependencies:
+    "@types/parse-json" "^4.0.0"
+    import-fresh "^3.2.1"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+    yaml "^1.10.0"
+
 cosmiconfig@^5.0.0, cosmiconfig@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
@@ -7672,11 +7508,6 @@ data-urls@^2.0.0:
     abab "^2.0.3"
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
-
-dataloader@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.0.0.tgz#41eaf123db115987e21ca93c005cd7753c55fe6f"
-  integrity sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==
 
 date-fns@2.15.0, date-fns@^2.0.1:
   version "2.15.0"
@@ -9250,7 +9081,7 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extract-files@^8.0.0, extract-files@^8.1.0:
+extract-files@^8.0.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-8.1.0.tgz#46a0690d0fe77411a2e3804852adeaa65cd59288"
   integrity sha512-PTGtfthZK79WUMk+avLmwx3NGdU8+iVFXC2NMGxKsn0MnihOG2lvumj+AZo8CTwTrwjXDgZ5tztbRlEdRjBonQ==
@@ -9708,15 +9539,6 @@ fork-ts-checker-webpack-plugin@1.5.0:
     tapable "^1.0.0"
     worker-rpc "^0.1.0"
 
-form-data@3.0.0, form-data@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
-  integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
-
 form-data@^2.3.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
@@ -9724,6 +9546,15 @@ form-data@^2.3.1:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
+form-data@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
+  integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
 form-data@~2.3.2:
@@ -10319,7 +10150,12 @@ graphql-subscriptions@^1.0.0:
   dependencies:
     iterall "^1.2.1"
 
-graphql-tag@2.10.4, graphql-tag@^2.10.4, graphql-tag@^2.4.2, graphql-tag@^2.9.2:
+graphql-tag@2.11.0, graphql-tag@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.11.0.tgz#1deb53a01c46a7eb401d6cb59dec86fa1cccbffd"
+  integrity sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA==
+
+graphql-tag@^2.9.2:
   version "2.10.4"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.4.tgz#2f301a98219be8b178a6453bb7e33b79b66d8f83"
   integrity sha512-O7vG5BT3w6Sotc26ybcvLKNTdfr4GfsIVMD+LdYqXCeJIYPRyp8BIsDOUtxw7S1PYvRw5vH3278J2EDezR6mfA==
@@ -10337,34 +10173,6 @@ graphql-tools@5.0.0:
     node-fetch "^2.6.0"
     tslib "^1.11.1"
     uuid "^7.0.3"
-
-graphql-tools@6.0.15:
-  version "6.0.15"
-  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-6.0.15.tgz#502d26203487dca452ca51888180104bb3c345ff"
-  integrity sha512-1UpMZGyNCzZ3TfgFGA/9iGM2Xii5rLh1eyQEAEx32eU/H9fiZJFXQlgtGmQlc1HWxHr0/pkV6XgehKn6DnpP1g==
-  dependencies:
-    "@graphql-tools/batch-delegate" "6.0.15"
-    "@graphql-tools/code-file-loader" "6.0.15"
-    "@graphql-tools/delegate" "6.0.15"
-    "@graphql-tools/git-loader" "6.0.15"
-    "@graphql-tools/github-loader" "6.0.15"
-    "@graphql-tools/graphql-file-loader" "6.0.15"
-    "@graphql-tools/graphql-tag-pluck" "6.0.15"
-    "@graphql-tools/import" "6.0.15"
-    "@graphql-tools/json-file-loader" "6.0.15"
-    "@graphql-tools/links" "6.0.15"
-    "@graphql-tools/load" "6.0.15"
-    "@graphql-tools/load-files" "6.0.15"
-    "@graphql-tools/merge" "6.0.15"
-    "@graphql-tools/mock" "6.0.15"
-    "@graphql-tools/module-loader" "6.0.15"
-    "@graphql-tools/relay-operation-optimizer" "6.0.15"
-    "@graphql-tools/resolvers-composition" "6.0.15"
-    "@graphql-tools/schema" "6.0.15"
-    "@graphql-tools/stitch" "6.0.15"
-    "@graphql-tools/url-loader" "6.0.15"
-    "@graphql-tools/utils" "6.0.15"
-    "@graphql-tools/wrap" "6.0.15"
 
 graphql-tools@^4.0.0:
   version "4.0.8"
@@ -11058,7 +10866,7 @@ import-fresh@^2.0.0:
     caller-path "^2.0.0"
     resolve-from "^3.0.0"
 
-import-fresh@^3.0.0, import-fresh@^3.1.0:
+import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
   integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
@@ -13924,7 +13732,7 @@ lodash@4.17.15:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-lodash@4.17.19, lodash@^4.0.1, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.3.0, lodash@~4.17.15:
+lodash@^4.0.1, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.3.0, lodash@~4.17.15:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
@@ -14680,11 +14488,6 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.0, mkdir
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
-
-mock-apollo-client@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/mock-apollo-client/-/mock-apollo-client-0.4.0.tgz#556a6090b1816dbf07e51093b652aca84aee979e"
-  integrity sha512-cHznpkX8uUClkWWJMpgdDWzEgjacM85xt69S9gPLrssM8Vahas0QmEJkFUycrRQyBkaqxvRe58Bg3a5pOvj2zA==
 
 modify-values@^1.0.0:
   version "1.0.1"
@@ -15583,13 +15386,6 @@ opn@^5.5.0:
   integrity sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==
   dependencies:
     is-wsl "^1.1.0"
-
-optimism@^0.10.0:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.10.3.tgz#163268fdc741dea2fb50f300bedda80356445fd7"
-  integrity sha512-9A5pqGoQk49H6Vhjb9kPgAeeECfUDF6aIICbMDL23kDLStBn1MWk3YvcZ4xWF9CsSf6XEgvRLkXy4xof/56vVw==
-  dependencies:
-    "@wry/context" "^0.4.0"
 
 optimism@^0.12.1:
   version "0.12.1"
@@ -17257,17 +17053,6 @@ re-resizable@^6.1.1:
   dependencies:
     fast-memoize "^2.5.1"
 
-react-apollo@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-3.1.5.tgz#36692d393c47e7ccc37f0a885c7cc5a8b4961c91"
-  integrity sha512-xOxMqxORps+WHrUYbjVHPliviomefOpu5Sh35oO3osuOyPTxvrljdfTLGCggMhcXBsDljtS5Oy4g+ijWg3D4JQ==
-  dependencies:
-    "@apollo/react-common" "^3.1.4"
-    "@apollo/react-components" "^3.1.5"
-    "@apollo/react-hoc" "^3.1.5"
-    "@apollo/react-hooks" "^3.1.5"
-    "@apollo/react-ssr" "^3.1.5"
-
 react-clientside-effect@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz#6212fb0e07b204e714581dd51992603d1accc837"
@@ -18769,6 +18554,13 @@ shallow-clone@^0.1.2:
     lazy-cache "^0.2.3"
     mixin-object "^2.0.1"
 
+shallow-clone@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-3.0.1.tgz#8f2981ad92531f55035b01fb230769a40e02efa3"
+  integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
+  dependencies:
+    kind-of "^6.0.2"
+
 shallow-equal@^1.1.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.1.tgz#4c16abfa56043aa20d050324efa68940b0da79da"
@@ -19994,7 +19786,7 @@ svgo@^1.0.0, svgo@^1.2.2, svgo@^1.3.0:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-symbol-observable@^1.0.2, symbol-observable@^1.0.4, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
+symbol-observable@^1.0.4, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
@@ -21504,6 +21296,14 @@ webpack-log@^2.0.0:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
 
+webpack-merge@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.1.0.tgz#5a24b2d5fa0431db96862116a7b7f18c4cd7bbd4"
+  integrity sha512-NNEXYSV/ixLwICcAhlVQ8c8E8dHmOcVnubfhoFdL6Tpbq6N9ZUvotQBYPwTsyXepXmCm34KjXgdC4PCQwJBp/w==
+  dependencies:
+    clone-deep "^4.0.1"
+    wildcard "^2.0.0"
+
 webpack-merge@^4.2.1, webpack-merge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.2.2.tgz#a27c52ea783d1398afd2087f547d7b9d2f43634d"
@@ -21713,6 +21513,11 @@ widest-line@^3.1.0:
   dependencies:
     string-width "^4.0.0"
 
+wildcard@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.0.tgz#a77d20e5200c6faaac979e4b3aadc7b3dd7f8fec"
+  integrity sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==
+
 windows-release@^3.1.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/windows-release/-/windows-release-3.3.1.tgz#cb4e80385f8550f709727287bf71035e209c4ace"
@@ -21919,7 +21724,7 @@ yaml-ast-parser@^0.0.40:
   resolved "https://registry.yarnpkg.com/yaml-ast-parser/-/yaml-ast-parser-0.0.40.tgz#08536d4e73d322b1c9ce207ab8dd70e04d20ae6e"
   integrity sha1-CFNtTnPTIrHJziB6uN1w4E0grm4=
 
-yaml@^1.7.2:
+yaml@^1.10.0, yaml@^1.7.2:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==


### PR DESCRIPTION
For the most part, this is a mechanical conversion of import paths.

Interesting bits:

- `ssr` is now toggled off across all widgets, so they don't run on sku static renders in case their parent component is not excepted by some `ClientOnly` implementation.
- `mock-apollo-client` does not support Apollo Client 3, so we roll our own client mock by pulling down the SEEK API schema and serving it up via `makeExecutableSchema`.