### PR TITLE
chore: trigger a new release of wingman-be to update broken package.json main file link

### DIFF
--- a/.changeset/twelve-kiwis-stare.md
+++ b/.changeset/twelve-kiwis-stare.md
@@ -1,0 +1,5 @@
+---
+'wingman-be': patch
+---
+
+Release updated package.json with correct main file path


### PR DESCRIPTION
The update to skuba 3.7.3 https://github.com/seek-oss/wingman/pull/75/ updated the main file reference from `"lib/index.ts"` to `"lib/index.js"` but was never released
