### PR TITLE
Unnest graphQL input component

### DIFF
--- a/.changeset/late-beans-dream.md
+++ b/.changeset/late-beans-dream.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': patch
+---
+
+Unnest GraphQL input component

--- a/fe/lib/components/Questionnaire/components/FormBuilderQueryInput.tsx
+++ b/fe/lib/components/Questionnaire/components/FormBuilderQueryInput.tsx
@@ -43,30 +43,24 @@ export const FormBuilderQueryInput = ({
   };
 
   return (
-    <ContentBlock>
-      <Stack space="gutter">
-        <Card>
-          <Stack space="gutter">
-            <Textarea
-              label="GraphQL Input"
-              id={id}
-              lineLimit={10}
-              value={input}
-              onChange={(e) => {
-                setInput(e.currentTarget.value);
-              }}
-            />
-            {showError && (
-              <Alert tone="caution">
-                <Text>{queryInputError}</Text>
-              </Alert>
-            )}
-            <Actions>
-              <Button onClick={() => checkValidQuery()}>Save</Button>
-            </Actions>
-          </Stack>
-        </Card>
-      </Stack>
-    </ContentBlock>
+    <Stack space="gutter">
+      <Textarea
+        label="GraphQL Input"
+        id={id}
+        lineLimit={10}
+        value={input}
+        onChange={e => {
+          setInput(e.currentTarget.value);
+        }}
+      />
+      {showError && (
+        <Alert tone="caution">
+          <Text>{queryInputError}</Text>
+        </Alert>
+      )}
+      <Actions>
+        <Button onClick={() => checkValidQuery()}>Save</Button>
+      </Actions>
+    </Stack>
   );
 };

--- a/fe/lib/components/Questionnaire/components/FormBuilderQueryInput.tsx
+++ b/fe/lib/components/Questionnaire/components/FormBuilderQueryInput.tsx
@@ -2,8 +2,6 @@ import {
   Actions,
   Alert,
   Button,
-  Card,
-  ContentBlock,
   Stack,
   Text,
   Textarea,
@@ -49,7 +47,7 @@ export const FormBuilderQueryInput = ({
         id={id}
         lineLimit={10}
         value={input}
-        onChange={e => {
+        onChange={(e) => {
           setInput(e.currentTarget.value);
         }}
       />


### PR DESCRIPTION
Removes unnecessary layers of braid so the consuming app can have a better layout