### PR TITLE
Align Privacy Consent render with candidate

### DIFF
--- a/.changeset/itchy-garlics-smash.md
+++ b/.changeset/itchy-garlics-smash.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': minor
+---
+
+Align Privacy Consent render with candidate

--- a/fe/lib/components/Questionnaire/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/fe/lib/components/Questionnaire/QuestionnaireForm/QuestionnaireForm.tsx
@@ -78,11 +78,7 @@ const renderQuestion = (
 };
 
 const renderPrivacyConsent = (component: PrivacyConsent) => (
-  <PrivacyConsentRenderer
-    key={component.value}
-    privacy={component}
-    title="Privacy consent"
-  />
+  <PrivacyConsentRenderer key={component.value} privacy={component} />
 );
 
 export const QuestionnaireForm = (props: RenderSchemaProps) => {

--- a/fe/lib/components/Questionnaire/QuestionnaireForm/components/PrivacyConsent.tsx
+++ b/fe/lib/components/Questionnaire/QuestionnaireForm/components/PrivacyConsent.tsx
@@ -1,10 +1,10 @@
 import {
   Card,
   Checkbox,
+  IconNewWindow,
   Stack,
   Text,
   TextLink,
-  IconNewWindow,
 } from 'braid-design-system';
 import React, { useState } from 'react';
 
@@ -29,7 +29,7 @@ const PrivacyConsentRenderer = ({ privacy }: PrivacyConsentRendererProps) => {
         />
         <Text>
           <TextLink hitArea="large" href={privacy.privacyPolicyUrl.url}>
-            Link to Employer's Privacy Policy <IconNewWindow />
+            Link to Employer&apos;s Privacy Policy <IconNewWindow />
           </TextLink>
         </Text>
       </Stack>

--- a/fe/lib/components/Questionnaire/QuestionnaireForm/components/PrivacyConsent.tsx
+++ b/fe/lib/components/Questionnaire/QuestionnaireForm/components/PrivacyConsent.tsx
@@ -1,36 +1,37 @@
-import { Card, Checkbox, Stack, Text, TextLink } from 'braid-design-system';
+import {
+  Card,
+  Checkbox,
+  Stack,
+  Text,
+  TextLink,
+  IconLink,
+} from 'braid-design-system';
 import React, { useState } from 'react';
 
 import { PrivacyConsent } from '../../questionTypes';
 
 interface PrivacyConsentRendererProps {
   privacy: PrivacyConsent;
-  title: string;
 }
 
-const PrivacyConsentRenderer = ({
-  privacy,
-  title,
-}: PrivacyConsentRendererProps) => {
+const PrivacyConsentRenderer = ({ privacy }: PrivacyConsentRendererProps) => {
   const [checked, setChecked] = useState(false);
   const handleClick = () => setChecked(!checked);
 
   return (
     <Card>
       <Stack space="medium">
-        <Text size="large">{title}</Text>
-        <Text>
-          {privacy.descriptionHtml || 'Do you agree to the privacy policy?'}{' '}
-          <TextLink hitArea="large" href={privacy.privacyPolicyUrl.url}>
-            Privacy policy
-          </TextLink>
-        </Text>
         <Checkbox
           id="privacyConsentCheckbox"
-          label="I have read and accept the privacy policy"
+          label="I agree to this employer's Privacy Policy"
           onChange={handleClick}
           checked={checked}
         />
+        <Text>
+          <TextLink hitArea="large" href={privacy.privacyPolicyUrl.url}>
+            Link to Employer's Privacy Policy <IconLink />
+          </TextLink>
+        </Text>
       </Stack>
     </Card>
   );

--- a/fe/lib/components/Questionnaire/QuestionnaireForm/components/PrivacyConsent.tsx
+++ b/fe/lib/components/Questionnaire/QuestionnaireForm/components/PrivacyConsent.tsx
@@ -4,7 +4,7 @@ import {
   Stack,
   Text,
   TextLink,
-  IconLink,
+  IconNewWindow,
 } from 'braid-design-system';
 import React, { useState } from 'react';
 
@@ -29,7 +29,7 @@ const PrivacyConsentRenderer = ({ privacy }: PrivacyConsentRendererProps) => {
         />
         <Text>
           <TextLink hitArea="large" href={privacy.privacyPolicyUrl.url}>
-            Link to Employer's Privacy Policy <IconLink />
+            Link to Employer's Privacy Policy <IconNewWindow />
           </TextLink>
         </Text>
       </Stack>


### PR DESCRIPTION
This aligns with how the consent is rendered on the candidate site, including ignoring `descriptionHtml`