### PR TITLE
Remove hirer ID from the questionnaire builder

### DIFF
--- a/.changeset/thick-bugs-hide.md
+++ b/.changeset/thick-bugs-hide.md
@@ -1,0 +1,7 @@
+---
+'wingman-fe': minor
+---
+
+Remove hirer ID from questionnaire builder
+
+Consumers must now supply a `hirerId` prop to `<QuestionnaireBuilder/>`

--- a/.changeset/thick-bugs-hide.md
+++ b/.changeset/thick-bugs-hide.md
@@ -4,4 +4,5 @@
 
 Remove hirer ID from questionnaire builder
 
-Consumers must now supply a `hirerId` prop to `<QuestionnaireBuilder/>`
+- Consumers must now supply a `hirerId` prop to `<QuestionnaireBuilder/>`
+- `graphqlInput` is now takes an array of components

--- a/fe/lib/components/Questionnaire/QuestionnaireBuilder/QuestionnaireBuilder.tsx
+++ b/fe/lib/components/Questionnaire/QuestionnaireBuilder/QuestionnaireBuilder.tsx
@@ -16,14 +16,14 @@ import {
   QuestionnaireCreateInput,
   convertComponentsToMutationVariables,
 } from '../components/GraphqlQueryRenderer/GraphqlQueryRenderer';
-import { mapMutationVariableToFormComponent } from '../mapping';
-import { FormComponent, MutationVariableInput } from '../questionTypes';
+import { mapGraphqlToFormComponent } from '../mapping';
+import { FormComponent, GraphqlComponentInput } from '../questionTypes';
 
 import { FormBuilder } from './FormBuilder/FormBuilder';
 
 interface QuestionnaireBuilderProps {
   hirerId: string;
-  graphqlInput?: MutationVariableInput;
+  graphqlInput?: GraphqlComponentInput[];
   onChange?: (mutationVariables: QuestionnaireCreateInput) => void;
 }
 
@@ -36,7 +36,7 @@ export const QuestionnaireBuilder = ({
 
   useEffect(() => {
     if (graphqlInput) {
-      setFormBuilderState(mapMutationVariableToFormComponent(graphqlInput));
+      setFormBuilderState(mapGraphqlToFormComponent(graphqlInput));
     }
   }, [graphqlInput]);
 

--- a/fe/lib/components/Questionnaire/QuestionnaireBuilder/QuestionnaireBuilder.tsx
+++ b/fe/lib/components/Questionnaire/QuestionnaireBuilder/QuestionnaireBuilder.tsx
@@ -7,7 +7,6 @@ import {
   ContentBlock,
   Heading,
   Stack,
-  TextField,
 } from 'braid-design-system';
 import React, { useEffect, useState } from 'react';
 
@@ -23,23 +22,21 @@ import { FormComponent, MutationVariableInput } from '../questionTypes';
 import { FormBuilder } from './FormBuilder/FormBuilder';
 
 interface QuestionnaireBuilderProps {
+  hirerId: string;
   graphqlInput?: MutationVariableInput;
   onChange?: (mutationVariables: QuestionnaireCreateInput) => void;
 }
 
 export const QuestionnaireBuilder = ({
+  hirerId,
   graphqlInput,
   onChange,
 }: QuestionnaireBuilderProps) => {
   const [formBuilderState, setFormBuilderState] = useState<FormComponent[]>([]);
-  const [hirerId, setHirerId] = useState(
-    graphqlInput?.input.applicationQuestionnaire.hirerId ?? '',
-  );
 
   useEffect(() => {
     if (graphqlInput) {
       setFormBuilderState(mapMutationVariableToFormComponent(graphqlInput));
-      setHirerId(graphqlInput.input.applicationQuestionnaire.hirerId);
     }
   }, [graphqlInput]);
 
@@ -71,16 +68,6 @@ export const QuestionnaireBuilder = ({
         <Card>
           <Stack space="large">
             <Heading level="3">GraphQL Output</Heading>
-
-            {typeof hirerId === 'undefined' && (
-              <TextField
-                id="hirerId"
-                label="Hirer OID"
-                placeholder="seekAnzPublicTest:organization:seek:93WyyF1h"
-                value={hirerId}
-                onChange={({ currentTarget: { value } }) => setHirerId(value)}
-              />
-            )}
 
             <GraphqlQueryRenderer
               components={formBuilderState}

--- a/fe/lib/components/Questionnaire/app.stories.tsx
+++ b/fe/lib/components/Questionnaire/app.stories.tsx
@@ -7,7 +7,9 @@ import { storiesOf } from 'sku/@storybook/react';
 import { QuestionnaireBuilder } from './QuestionnaireBuilder/QuestionnaireBuilder';
 
 storiesOf('QuestionnaireBuilder', module)
-  .add('Builder', () => <QuestionnaireBuilder />)
+  .add('Builder', () => (
+    <QuestionnaireBuilder hirerId="seekAnzPublicTest:organization:seek:93WyyF1h" />
+  ))
   .addDecorator((story) => (
     <BraidLoadableProvider themeName="apac">
       <Box paddingX="gutter" paddingY="large">

--- a/fe/lib/components/Questionnaire/components/GraphqlQueryRenderer/GraphqlQueryRenderer.tsx
+++ b/fe/lib/components/Questionnaire/components/GraphqlQueryRenderer/GraphqlQueryRenderer.tsx
@@ -85,7 +85,7 @@ export const convertComponentsToMutationVariables = (
 };
 
 const renderVariablesPane = (components: FormComponent[], hirerId: string) => {
-  if (components.length > 0 && hirerId) {
+  if (components.length > 0) {
     const { variables } = convertComponentsToMutationVariables(
       components,
       hirerId,
@@ -102,20 +102,7 @@ const renderVariablesPane = (components: FormComponent[], hirerId: string) => {
     );
   }
 
-  if (hirerId && components.length === 0) {
-    return <Text>You need to add some questions first</Text>;
-  }
-
-  if (!hirerId && components.length > 0) {
-    return <Text>You need to add your hirer ID first</Text>;
-  }
-
-  return (
-    <Text>
-      You need to add your hirer ID, and then add some questions to see any
-      output.
-    </Text>
-  );
+  return <Text>You need to add some questions first</Text>;
 };
 
 interface GraphqlQueryRendererProps {

--- a/fe/lib/components/Questionnaire/mapping.ts
+++ b/fe/lib/components/Questionnaire/mapping.ts
@@ -6,7 +6,7 @@ import {
 
 import {
   FormComponent,
-  MutationVariableInput,
+  GraphqlComponentInput,
   PrivacyConsent,
   Question,
 } from './questionTypes';
@@ -44,10 +44,10 @@ export const mapApplicationQuestionnaireToFormComponent = (
       : mapQuestion(component as ApplicationQuestion),
   );
 
-export const mapMutationVariableToFormComponent = (
-  graphqlInput: MutationVariableInput,
+export const mapGraphqlToFormComponent = (
+  graphqlInput: GraphqlComponentInput[],
 ): FormComponent[] =>
-  graphqlInput.input.applicationQuestionnaire.components.map((component) =>
+  graphqlInput.map((component) =>
     component.componentTypeCode === 'PrivacyConsent'
       ? component.privacyConsent
       : component.question,

--- a/fe/lib/components/Questionnaire/questionTypes.ts
+++ b/fe/lib/components/Questionnaire/questionTypes.ts
@@ -93,7 +93,7 @@ const SelectionQuestion = BaseQuestion.And(
   }),
 );
 
-const GraphqlInput = RTRecord({
+export const GraphqlComponentInput = RTRecord({
   componentTypeCode: Literal('PrivacyConsent'),
   privacyConsent: PrivacyConsent,
 }).Or(
@@ -103,11 +103,13 @@ const GraphqlInput = RTRecord({
   }),
 );
 
+export type GraphqlComponentInput = Static<typeof GraphqlComponentInput>;
+
 const QuestionnaireMutationVariableInput = RTRecord({
   input: RTRecord({
     applicationQuestionnaire: RTRecord({
       hirerId: String,
-      components: Array(GraphqlInput),
+      components: Array(GraphqlComponentInput),
     }),
   }),
 });


### PR DESCRIPTION
This is currently broken unless a mutation is provided. Instead, this depends on our consumers supplying their own ID. This can either be provided from their session state or from an explicit input.