### PR TITLE
fix: job category suggest

### DIFF
--- a/.changeset/forty-ads-love.md
+++ b/.changeset/forty-ads-love.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': patch
+---
+
+fix(JobCategorySuggest): set current value of managed radio group

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -31,9 +31,7 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
     { choices, onSelect, showConfidence = false, ...restProps },
     forwardedRef,
   ) => {
-    const [selectedJobCategory, setSelectedJobCategory] = useState<
-      number
-    >();
+    const [selectedJobCategory, setSelectedJobCategory] = useState<number>();
 
     const handleChoiceSelect = (event: React.FormEvent<HTMLInputElement>) => {
       const index = Number(event.currentTarget.value);

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -32,7 +32,7 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
     forwardedRef,
   ) => {
     const [selectedJobCategory, setSelectedJobCategory] = useState<
-      JobCategory
+      number
     >();
 
     const handleChoiceSelect = (event: React.FormEvent<HTMLInputElement>) => {
@@ -40,7 +40,7 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
 
       const choice = choices[index];
 
-      setSelectedJobCategory(choice.jobCategory);
+      setSelectedJobCategory(index);
 
       if (onSelect) {
         onSelect(choice);
@@ -56,7 +56,7 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
         <RadioGroup
           id="job-category-suggest-select"
           onChange={handleChoiceSelect}
-          value={selectedJobCategory?.id.value ?? ''}
+          value={selectedJobCategory ?? ''}
           {...restProps}
         >
           {choices.map((choice, index) => {


### PR DESCRIPTION
With #239 we changed the radio group value to be index based, as a result we need to update the managed radio group with the selected index not the SEEK ID.

- This changes the current useState used for job category to be purely index (int) based and not store the JobCategory choice. Within the `onSelect` passed in function we still send back the full jobCategory to the parent. 