### PR TITLE
refactor(JobCategorySuggest): Switch to JobCategory ID for value of RadioItem

### DIFF
--- a/.changeset/late-kids-trade.md
+++ b/.changeset/late-kids-trade.md
@@ -1,0 +1,5 @@
+---
+'wingman-be': patch
+---
+
+refactor(JobCategorySuggest): switch to JobCategory ID for radio group

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -31,17 +31,21 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
     { choices, onSelect, showConfidence = false, ...restProps },
     forwardedRef,
   ) => {
-    const [selectedJobCategory, setSelectedJobCategory] = useState<number>();
+    const [selectedJobCategory, setSelectedJobCategory] = useState<
+      JobCategory
+    >();
 
     const handleChoiceSelect = (event: React.FormEvent<HTMLInputElement>) => {
-      const index = Number(event.currentTarget.value);
+      const choiceId = event.currentTarget.value;
 
-      const choice = choices[index];
+      const jobCategorySuggest = choices.find(
+        (choice) => choice.jobCategory.id.value === choiceId,
+      );
 
-      setSelectedJobCategory(index);
+      setSelectedJobCategory(jobCategorySuggest?.jobCategory);
 
-      if (onSelect) {
-        onSelect(choice);
+      if (onSelect && jobCategorySuggest) {
+        onSelect(jobCategorySuggest);
       }
     };
 
@@ -54,10 +58,10 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
         <RadioGroup
           id="job-category-suggest-select"
           onChange={handleChoiceSelect}
-          value={selectedJobCategory ?? ''}
+          value={selectedJobCategory?.id.value ?? ''}
           {...restProps}
         >
-          {choices.map((choice, index) => {
+          {choices.map((choice) => {
             const { jobCategory, confidence } = choice;
             const { id } = jobCategory;
             return (
@@ -65,7 +69,7 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
                 key={id.value}
                 label={getJobCategoryName(jobCategory)}
                 ref={forwardedRef}
-                value={index}
+                value={id.value}
               >
                 {showConfidence && (
                   <Text tone="secondary" size="small">


### PR DESCRIPTION
Moves back to a SEEK ID for the value of radio group items:

Some form libraries such as [react-hook-form](https://react-hook-form.com/) use the value of the underlying radio button via a `ref` to get and set its form state. 

Switching it back to the ID of the JobCategory means we can use this value in parent components without a callback.