### PR TITLE
JobCategorySuggest: Use ID as RadioItem value

### DIFF
--- a/.changeset/famous-rats-rest.md
+++ b/.changeset/famous-rats-rest.md
@@ -1,0 +1,7 @@
+---
+'wingman-fe': patch
+---
+
+JobCategorySuggest: Use ID as RadioItem value
+
+This releases #243.


### PR DESCRIPTION
This was accidentally released under the backend package.