### PR TITLE
Fix SpecifiedPersonForm event handling

### DIFF
--- a/.changeset/slimy-seas-provide.md
+++ b/.changeset/slimy-seas-provide.md
@@ -1,0 +1,5 @@
+---
+"wingman-fe": patch
+---
+
+Fix SpecifiedPersonForm event handling

--- a/fe/lib/components/Person/SpecifiedPersonForm.tsx
+++ b/fe/lib/components/Person/SpecifiedPersonForm.tsx
@@ -48,16 +48,18 @@ const mapFormDataToMutationInput = (
 export const SpecifiedPersonForm = ({ onCreate }: Props) => {
   const { handleSubmit, control, errors } = useForm<SubmitData>();
 
-  return (
-    <form
-      onSubmit={(event) => {
-        event.preventDefault();
+  const onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    // prevent any outer forms from receiving the event too
+    event.stopPropagation();
 
-        handleSubmit((formData) =>
-          onCreate(mapFormDataToMutationInput(formData)),
-        );
-      }}
-    >
+    return handleSubmit((values) =>
+      onCreate(mapFormDataToMutationInput(values)),
+    )(event);
+  };
+
+  return (
+    <form onSubmit={onSubmit}>
       <Stack space="small">
         <Controller
           render={(formProps) => (


### PR DESCRIPTION
The consumers callback wasn't firing, but the parent form submission was 😓 

Uses https://github.com/react-hook-form/react-hook-form/issues/1005 

I'm on the fence as to whether this component should be refactored to just not use `useForm`