### PR TITLE
Forward JobCategorySuggest name properly

### DIFF
--- a/.changeset/ten-ants-complain.md
+++ b/.changeset/ten-ants-complain.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': patch
+---
+
+**JobCategorySuggest:** Forward `name` prop

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
@@ -82,6 +82,7 @@ export const JobCategorySuggest = forwardRef<HTMLInputElement, Props>(
           suggestData?.jobCategorySuggestions && (
             <JobCategorySuggestChoices
               choices={suggestData.jobCategorySuggestions}
+              name={name}
               ref={forwardedRef}
               onSelect={onSelect}
               showConfidence={showConfidence}

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -15,6 +15,7 @@ import { flattenResourceByKey } from '../../utils';
 
 interface Props {
   choices: JobCategorySuggestionChoice[];
+  name?: string;
   onSelect?: (jobCategorySuggestionChoice: JobCategorySuggestionChoice) => void;
   showConfidence?: boolean;
   tone?: ComponentProps<typeof RadioGroup>['tone'];
@@ -28,7 +29,7 @@ const getJobCategoryName = (jobCategory: JobCategory): string =>
 
 const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
   (
-    { choices, onSelect, showConfidence = false, ...restProps },
+    { choices, name, onSelect, showConfidence = false, ...restProps },
     forwardedRef,
   ) => {
     const [selectedJobCategory, setSelectedJobCategory] = useState<
@@ -57,6 +58,7 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
 
         <RadioGroup
           id="job-category-suggest-select"
+          name={name}
           onChange={handleChoiceSelect}
           value={selectedJobCategory?.id.value ?? ''}
           {...restProps}


### PR DESCRIPTION
This was causing `react-hook-form` consumer usage to incorrectly choose the hardcoded `id` rather than the supplied `name` as the field name.