### PR TITLE
Fix frontend build

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,3 +28,7 @@ jobs:
 
       - name: Test
         run: yarn test
+
+      # sku lint does not dry run the build
+      - name: Build fe
+        run: yarn fe build

--- a/fe/example/src/pages/Positions/Questionnaires.tsx
+++ b/fe/example/src/pages/Positions/Questionnaires.tsx
@@ -8,7 +8,7 @@ import {
 } from 'braid-design-system';
 import React, { useState } from 'react';
 
-import { QuestionnaireForm } from '../../../../lib/components/Questionnaire';
+import { QuestionnaireForm } from '../../../../lib/components/Questionnaire/QuestionnaireForm/QuestionnaireForm';
 import { Header } from '../../components/Header';
 import type { Questionnaire } from '../../data/questionnaires';
 import { QuestionnaireSelect } from '../../widgets/QuestionnaireSelect';

--- a/fe/lib/components/Questionnaire/index.ts
+++ b/fe/lib/components/Questionnaire/index.ts
@@ -1,7 +1,3 @@
-export { QuestionnaireBuilder } from './QuestionnaireBuilder/QuestionnaireBuilder';
-
-export { FormBuilder } from './QuestionnaireBuilder/FormBuilder/FormBuilder';
-export { QuestionnaireForm } from './QuestionnaireForm/QuestionnaireForm';
 export { GraphqlQueryRenderer } from './components/GraphqlQueryRenderer/GraphqlQueryRenderer';
 export type { QuestionnaireCreateInput } from './components/GraphqlQueryRenderer/GraphqlQueryRenderer';
 


### PR DESCRIPTION
Some tooling change in `sku build` really hates the indirection of an export-only file. This removes those unused re-exports to reduce the chance of it happening again, and runs `sku build` on branches so we catch the issue earlier in future.