### PR TITLE
Remove redundant classnames usage

### DIFF
--- a/fe/lib/components/private/RedactableText/RedactableText.tsx
+++ b/fe/lib/components/private/RedactableText/RedactableText.tsx
@@ -1,5 +1,4 @@
 import { Box, Text } from 'braid-design-system';
-import classNames from 'classnames';
 import React, { ComponentProps } from 'react';
 import { useStyles } from 'sku/react-treat';
 
@@ -13,12 +12,7 @@ export const RedactableText = ({ children, redact, ...textProps }: Props) => {
   const styles = useStyles(styleDefs);
   return (
     <Text {...textProps}>
-      <Box
-        className={classNames({
-          [styles.redact]: redact,
-        })}
-        component="span"
-      >
+      <Box className={{ [styles.redact]: redact }} component="span">
         {children}
       </Box>
     </Text>


### PR DESCRIPTION
This is some internal mock code that doesn't require a release.