### PR TITLE
Limit code scanning to specific branches

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,6 +7,7 @@ name: 'CodeQL'
 
 on:
   push:
+    branches: [beta, main, master]
   pull_request:
   schedule:
     - cron: '0 22 * * 0'


### PR DESCRIPTION
Otherwise this fails on Dependabot PRs:

https://github.com/seek-oss/datadog-custom-metrics/pull/80/checks?check_run_id=2382838577#step:3:54