### PR TITLE
Clean up job category GraphQL queries

### DIFF
--- a/.changeset/rare-hotels-destroy.md
+++ b/.changeset/rare-hotels-destroy.md
@@ -1,0 +1,7 @@
+---
+'wingman-fe': minor
+---
+
+**JobCategorySelect, JobCategorySuggest:** Clean up job category GraphQL queries
+
+

--- a/codegen.yml
+++ b/codegen.yml
@@ -2,9 +2,7 @@ generates:
   ./fe/lib/types/seek.graphql.ts:
     schema: ${SEEK_SCHEMA_PATH:https://graphql.seek.com/graphql}
     documents:
-      - fe/lib/components/JobCategorySelect/queries.ts
-      - fe/lib/components/JobCategorySuggest/queries.ts
-      - fe/lib/components/LocationSuggest/queries.ts
+      - fe/lib/components/**/queries.ts
     plugins:
       - typescript
       - typescript-operations

--- a/codegen.yml
+++ b/codegen.yml
@@ -2,6 +2,8 @@ generates:
   ./fe/lib/types/seek.graphql.ts:
     schema: ${SEEK_SCHEMA_PATH:https://graphql.seek.com/graphql}
     documents:
+      - fe/lib/components/JobCategorySelect/queries.ts
+      - fe/lib/components/JobCategorySuggest/queries.ts
       - fe/lib/components/LocationSuggest/queries.ts
     plugins:
       - typescript

--- a/fe/lib/components/JobCategorySelect/JobCategorySelect.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelect.tsx
@@ -8,7 +8,10 @@ import {
 } from 'braid-design-system';
 import React, { ComponentPropsWithRef, forwardRef, useState } from 'react';
 
-import type { JobCategory } from '../../types/seek.graphql';
+import type {
+  JobCategoriesQuery,
+  JobCategoryAttributesFragment,
+} from '../../types/seek.graphql';
 
 import JobCategorySelectInput from './JobCategorySelectInput';
 import { JOB_CATEGORIES } from './queries';
@@ -17,7 +20,7 @@ interface FieldProps extends ComponentPropsWithRef<typeof Dropdown> {}
 
 interface Props extends Omit<FieldProps, 'value' | 'onChange' | 'children'> {
   client?: ApolloClient<unknown>;
-  onSelect?: (jobCategory: JobCategory) => void;
+  onSelect?: (jobCategory: JobCategoryAttributesFragment) => void;
   schemeId: string;
 }
 
@@ -41,7 +44,7 @@ export const JobCategorySelect = forwardRef<HTMLInputElement, Props>(
       data: categoriesData,
       loading: categoriesLoading,
       error: categoriesError,
-    } = useQuery(JOB_CATEGORIES, {
+    } = useQuery<JobCategoriesQuery>(JOB_CATEGORIES, {
       ...(client && { client }),
       fetchPolicy: 'no-cache',
       ssr: false,
@@ -52,7 +55,9 @@ export const JobCategorySelect = forwardRef<HTMLInputElement, Props>(
 
     const [selectedJobCategoryId, setSelectedJobCategoryId] = useState('');
 
-    const handleJobCategoriesSelect = (selectedJobCategory: JobCategory) => {
+    const handleJobCategoriesSelect = (
+      selectedJobCategory: JobCategoryAttributesFragment,
+    ) => {
       if (onSelect) {
         onSelect(selectedJobCategory);
       }

--- a/fe/lib/components/JobCategorySelect/queries.ts
+++ b/fe/lib/components/JobCategorySelect/queries.ts
@@ -8,28 +8,17 @@ const JOB_CATEGORY_ATTRIBUTES = gql`
     name
   }
 `;
-
-const NESTED_JOB_CATEGORY_ATTRIBUTES = gql`
-  fragment nestedJobCategoryAttributes on JobCategory {
-    ...jobCategoryAttributes
-    parent {
-      ...jobCategoryAttributes
-    }
-    children {
+export const JOB_CATEGORIES = gql`
+  query JobCategories($schemeId: String!) {
+    jobCategories(schemeId: $schemeId) {
       ...jobCategoryAttributes
       parent {
+        ...jobCategoryAttributes
+      }
+      children {
         ...jobCategoryAttributes
       }
     }
   }
   ${JOB_CATEGORY_ATTRIBUTES}
-`;
-
-export const JOB_CATEGORIES = gql`
-  query($schemeId: String!) {
-    jobCategories(schemeId: $schemeId) {
-      ...nestedJobCategoryAttributes
-    }
-  }
-  ${NESTED_JOB_CATEGORY_ATTRIBUTES}
 `;

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
@@ -10,19 +10,22 @@ import React, { ComponentPropsWithRef, forwardRef, useEffect } from 'react';
 import { useDebounce } from 'use-debounce';
 
 import type {
-  JobCategorySuggestionChoice,
+  JobCategorySuggestQuery,
+  JobCategorySuggestionChoiceAttributesFragment,
   JobCategorySuggestionPositionProfileInput,
 } from '../../types/seek.graphql';
 
 import JobCategorySuggestChoices from './JobCategorySuggestChoices';
-import { JOB_CATEGORY_SUGGESTION } from './queries';
+import { JOB_CATEGORY_SUGGEST } from './queries';
 
 interface RadioProps extends ComponentPropsWithRef<typeof RadioGroup> {}
 
 interface Props extends Partial<Omit<RadioProps, 'id'>> {
   client?: ApolloClient<unknown>;
   debounceDelay?: number;
-  onSelect?: (jobCategorySuggestionChoice: JobCategorySuggestionChoice) => void;
+  onSelect?: (
+    jobCategorySuggestionChoice: JobCategorySuggestionChoiceAttributesFragment,
+  ) => void;
   positionProfile: JobCategorySuggestionPositionProfileInput;
   schemeId: string;
   showConfidence?: boolean;
@@ -50,7 +53,7 @@ export const JobCategorySuggest = forwardRef<HTMLInputElement, Props>(
     const [
       getCategorySuggestion,
       { data: suggestData, error: suggestError, loading: suggestLoading },
-    ] = useLazyQuery(JOB_CATEGORY_SUGGESTION, {
+    ] = useLazyQuery<JobCategorySuggestQuery>(JOB_CATEGORY_SUGGEST, {
       client,
       fetchPolicy: 'no-cache',
       ssr: false,

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -9,14 +9,16 @@ import React, { ComponentProps, forwardRef, useState } from 'react';
 
 import type {
   JobCategory,
-  JobCategorySuggestionChoice,
+  JobCategorySuggestionChoiceAttributesFragment,
 } from '../../types/seek.graphql';
 import { flattenResourceByKey } from '../../utils';
 
 interface Props {
-  choices: JobCategorySuggestionChoice[];
+  choices: JobCategorySuggestionChoiceAttributesFragment[];
   name?: string;
-  onSelect?: (jobCategorySuggestionChoice: JobCategorySuggestionChoice) => void;
+  onSelect?: (
+    jobCategorySuggestionChoice: JobCategorySuggestionChoiceAttributesFragment,
+  ) => void;
   showConfidence?: boolean;
   tone?: ComponentProps<typeof RadioGroup>['tone'];
 }

--- a/fe/lib/components/JobCategorySuggest/queries.ts
+++ b/fe/lib/components/JobCategorySuggest/queries.ts
@@ -9,24 +9,25 @@ const JOB_CATEGORY_ATTRIBUTES = gql`
   }
 `;
 
-const NESTED_JOB_CATEGORY_ATTRIBUTES = gql`
-  fragment nestedJobCategoryAttributes on JobCategory {
-    ...jobCategoryAttributes
-    parent {
-      ...jobCategoryAttributes
-    }
-    children {
+const JOB_CATEGORY_SUGGESTION_CHOICE_ATTRIBUTES = gql`
+  fragment jobCategorySuggestionChoiceAttributes on JobCategorySuggestionChoice {
+    jobCategory {
       ...jobCategoryAttributes
       parent {
         ...jobCategoryAttributes
       }
+      children {
+        ...jobCategoryAttributes
+      }
     }
+    confidence
   }
+
   ${JOB_CATEGORY_ATTRIBUTES}
 `;
 
-export const JOB_CATEGORY_SUGGESTION = gql`
-  query(
+export const JOB_CATEGORY_SUGGEST = gql`
+  query JobCategorySuggest(
     $positionProfile: JobCategorySuggestionPositionProfileInput!
     $schemeId: String!
     $first: Int
@@ -36,11 +37,9 @@ export const JOB_CATEGORY_SUGGESTION = gql`
       schemeId: $schemeId
       first: $first
     ) {
-      jobCategory {
-        ...nestedJobCategoryAttributes
-      }
-      confidence
+      ...jobCategorySuggestionChoiceAttributes
     }
   }
-  ${NESTED_JOB_CATEGORY_ATTRIBUTES}
+
+  ${JOB_CATEGORY_SUGGESTION_CHOICE_ATTRIBUTES}
 `;

--- a/fe/lib/types/seek.graphql.ts
+++ b/fe/lib/types/seek.graphql.ts
@@ -111,11 +111,19 @@ export interface AddressInput {
   countrySubDivisions: Array<AddressComponentInput>;
   /** The city or suburb of the address. */
   city?: Maybe<Scalars['String']>;
-  /** The postal code of the address. */
+  /**
+   * The postal code of the address.
+   *
+   * This field has a maximum length of 50 bytes in UTF-8 encoding.
+   */
   postalCode?: Maybe<Scalars['String']>;
   /** The geographical coordinates of the address. */
   geoLocation?: Maybe<GeoLocationInput>;
-  /** The formatted representation of the whole address for display purposes. */
+  /**
+   * The formatted representation of the whole address for display purposes.
+   *
+   * This field has a maximum length of 1,000 bytes in UTF-8 encoding.
+   */
   formattedAddress?: Maybe<Scalars['String']>;
 }
 
@@ -211,6 +219,8 @@ export interface ApplicationMethodInput {
   applicationUri?: Maybe<WebUrlInput>;
   /**
    * The email address to direct candidate applications to.
+   *
+   * This field has a maximum length of 100 bytes in UTF-8 encoding.
    *
    * This is deprecated. Do not use this field. This has been replaced by Application Export.
    */
@@ -791,7 +801,7 @@ export interface CandidateProcessAction {
   code: Scalars['String'];
   /** The free-form description of the action. */
   description?: Maybe<Scalars['String']>;
-  /** A short human-readable name of the workflow process. */
+  /** A short human-readable name for the workflow step. */
   name?: Maybe<Scalars['String']>;
   /** A deep link to the action. */
   seekUrl?: Maybe<WebUrl>;
@@ -833,6 +843,8 @@ export interface CandidateProcessActionInput {
    * A deep link to the action.
    *
    * This is required for a profile action of an uploaded candidate.
+   *
+   * The `url` field has a maximum length of 1,000 bytes in UTF-8 encoding.
    */
   seekUrl?: Maybe<WebUrlInput>;
 }
@@ -1381,7 +1393,7 @@ export interface CreatePositionOpeningPositionOpeningInput {
    *
    * The metadata is not used by SEEK and won't be seen by hirers or candidates.
    *
-   * This field has a maximum length of 1000 characters.
+   * This field has a maximum length of 1,000 bytes in UTF-8 encoding.
    */
   seekPartnerMetadata?: Maybe<Scalars['String']>;
   /**
@@ -1465,14 +1477,24 @@ export interface CreateUnpostedPositionProfileForOpeningInput {
 export interface CreateUnpostedPositionProfileForOpeningPayload {
   __typename?: 'CreateUnpostedPositionProfileForOpeningPayload';
   /** Attributes of the newly created unposted position profile. */
-  positionProfile: PositionProfile;
+  positionProfile: UnpostedPositionProfile;
 }
 
 /** An unposted profile of a position opening to create. */
 export interface CreateUnpostedPositionProfileForOpeningPositionProfileInput {
   /** The identifier for the `PositionOpening` that this position profile belongs to. */
   positionOpeningId: Scalars['String'];
-  /** A short phrase describing the position as it would be listed on a business card or in a company directory. */
+  /**
+   * A human-readable name given to the profile.
+   *
+   * This in addition to the `positionTitle` can help identify the profile to an end user.
+   */
+  profileName?: Maybe<Scalars['String']>;
+  /**
+   * A short phrase describing the position as it would be listed on a business card or in a company directory.
+   *
+   * This field has a maximum length of 80 bytes in UTF-8 encoding.
+   */
   positionTitle: Scalars['String'];
   /**
    * An array of identifiers for the `HiringOrganization`s that have the position.
@@ -1481,12 +1503,18 @@ export interface CreateUnpostedPositionProfileForOpeningPositionProfileInput {
    * this should contain exactly one element that matches the `postingRequester` on the position opening.
    */
   positionOrganizations: Array<Scalars['String']>;
-  /** An optional hirer-provided opaque job reference. */
+  /**
+   * An optional hirer-provided opaque job reference.
+   *
+   * This field has a maximum length of 50 bytes in UTF-8 encoding.
+   */
   seekHirerJobReference?: Maybe<Scalars['String']>;
   /**
    * An optional opaque billing reference.
    *
    * SEEK does not use this field on unposted position profiles.
+   *
+   * This field has a maximum length of 50 bytes in UTF-8 encoding.
    */
   seekBillingReference?: Maybe<Scalars['String']>;
   /**
@@ -1523,7 +1551,7 @@ export interface CreateUnpostedPositionProfileForOpeningPositionProfileInput {
    *
    * The metadata is not used by SEEK and won't be seen by hirers or candidates.
    *
-   * This field has a maximum length of 1000 characters.
+   * This field has a maximum length of 1,000 bytes in UTF-8 encoding.
    */
   seekPartnerMetadata?: Maybe<Scalars['String']>;
 }
@@ -1673,7 +1701,7 @@ export interface DeleteUnpostedPositionProfileInput {
 export interface DeleteUnpostedPositionProfilePayload {
   __typename?: 'DeleteUnpostedPositionProfilePayload';
   /** The details of the deleted unposted position profile. */
-  positionProfile: PositionProfile;
+  positionProfile: UnpostedPositionProfile;
 }
 
 /** The details of the unposted position profile to be deleted. */
@@ -2164,13 +2192,20 @@ export interface Mutation {
   /**
    * Updates an existing webhook subscription's delivery configuration.
    *
-   * This modifies fields related to the URL, payload & signature of an existing webhook subscription.
+   * This modifies fields related to the URL and payload of an existing webhook subscription.
    * Changes may take up to half an hour to take effect.
    *
    * The fields that determine which events are to be delivered are immutable.
    * A new webhook subscription should be created for such cases.
    */
   updateWebhookSubscriptionDeliveryConfiguration?: Maybe<UpdateWebhookSubscriptionDeliveryConfigurationPayload>;
+  /**
+   * Updates an existing webhook subscription's signing configuration.
+   *
+   * This modifies fields related to the signature of an existing webhook subscription.
+   * Changes may take up to half an hour to take effect.
+   */
+  updateWebhookSubscriptionSigningConfiguration?: Maybe<UpdateWebhookSubscriptionSigningConfigurationPayload>;
   /** Deletes an existing webhook subscription. */
   deleteWebhookSubscription?: Maybe<DeleteWebhookSubscriptionPayload>;
   /**
@@ -2395,6 +2430,15 @@ export interface MutationUpdateWebhookSubscriptionDeliveryConfigurationArgs {
  *
  * This acts as the public, top-level API from which all mutation queries must start.
  */
+export interface MutationUpdateWebhookSubscriptionSigningConfigurationArgs {
+  input: UpdateWebhookSubscriptionSigningConfigurationInput;
+}
+
+/**
+ * The schema's entry-point for mutations.
+ *
+ * This acts as the public, top-level API from which all mutation queries must start.
+ */
 export interface MutationDeleteWebhookSubscriptionArgs {
   input: DeleteWebhookSubscriptionInput;
 }
@@ -2531,10 +2575,23 @@ export interface PositionFormattedDescriptionInput {
    *
    * Scheme requirements:
    *
-   * - The `seekAnz` scheme requires `AdvertisementDetails` and `SearchSummary` to be included and non-empty.
+   * - The `seekAnz` scheme requires `AdvertisementDetails` and `SearchSummary` to be included.
+   */
+  descriptionId: Scalars['String'];
+  /**
+   * The HTML content of the description.
+   *
+   * The maximum length differs by `descriptionId`:
+   *
+   *   - `AdvertisementDetails` has a maximum length of 20,000 bytes in UTF-8 encoding.
+   *   - `SearchBulletPoint` has a maximum length of 80 bytes in UTF-8 encoding.
+   *   - `SearchSummary` has a maximum length of 150 bytes in UTF-8 encoding.
+   *
+   * Scheme requirements:
    *
    * - The `seekAnz` scheme supports the following HTML tags in `AdvertisementDetails`:
-   *   - `a`
+   *
+   *   - `a` (Available on a per hirer basis. Hirer must contact SEEK to enable.)
    *   - `br`
    *   - `div`
    *   - `em`
@@ -2547,8 +2604,6 @@ export interface PositionFormattedDescriptionInput {
    *
    *   Other descriptions will have all HTML tags stripped.
    */
-  descriptionId: Scalars['String'];
-  /** The HTML content of the description. */
   content: Scalars['String'];
 }
 
@@ -2599,7 +2654,7 @@ export interface PositionOpening {
    *
    * The metadata is not used by SEEK and won't be seen by hirers or candidates.
    *
-   * This field has a maximum length of 1000 characters.
+   * This field has a maximum length of 1,000 bytes in UTF-8 encoding.
    */
   seekPartnerMetadata?: Maybe<Scalars['String']>;
   /**
@@ -2764,16 +2819,65 @@ export interface PositionProfile {
    *
    * The metadata is not used by SEEK and won't be seen by hirers or candidates.
    *
-   * This field has a maximum length of 1000 characters.
+   * This field has a maximum length of 1,000 bytes in UTF-8 encoding.
    */
   seekPartnerMetadata?: Maybe<Scalars['String']>;
 }
 
-/**
- * The event signaling that a `PositionProfile` has been posted.
- *
- * Corresponding events for the `updatePostedPositionProfile` and `closePostedPositionProfile` mutations are not currently available.
- */
+/** The event signaling that a posted `PositionProfile` has been closed. */
+export interface PositionProfileClosedEvent extends Event {
+  __typename?: 'PositionProfileClosedEvent';
+  /** The identifier for the `Event`. */
+  id: ObjectIdentifier;
+  /**
+   * The data source for the event.
+   *
+   * The following schemes are supported for this event type:
+   *
+   * - `seekAnz`
+   */
+  schemeId: Scalars['String'];
+  /** The type of event, i.e. `PositionProfileClosed`. */
+  typeCode: Scalars['String'];
+  /**
+   * The date & time the `PositionProfile` was closed.
+   *
+   * `PositionProfile`s are closed automatically when they reach their `PostingInstruction`'s `end` date.
+   * They can also be closed early using the `closePostedPositionProfile` mutation.
+   *
+   * This field has weak ordering guarantees, so it should not be used as a pagination argument.
+   */
+  createDateTime: Scalars['DateTime'];
+  /** The identifier for the `PositionProfile` that was closed. */
+  positionProfileId: Scalars['String'];
+  /**
+   * The `PositionProfile` that was closed.
+   *
+   * This may return null if the `PositionProfile` has been closed for an extended period of time.
+   */
+  positionProfile?: Maybe<PostedPositionProfile>;
+  /**
+   * A page of webhook attempts for the current event matching the specified criteria.
+   *
+   * A maximum of 100 webhook attempts can be returned in a single page.
+   * Additional webhook attempts can be queried using a pagination cursor.
+   *
+   * The result list is returned in ascending creation date & time order.
+   * It starts from the earliest known attempt if no pagination arguments are provided.
+   */
+  webhookAttempts: WebhookAttemptsConnection;
+}
+
+/** The event signaling that a posted `PositionProfile` has been closed. */
+export interface PositionProfileClosedEventWebhookAttemptsArgs {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  filter?: Maybe<WebhookAttemptsFilterInput>;
+}
+
+/** The event signaling that a `PositionProfile` has been posted. */
 export interface PositionProfilePostedEvent extends Event {
   __typename?: 'PositionProfilePostedEvent';
   /** The identifier for the `Event`. */
@@ -2801,7 +2905,7 @@ export interface PositionProfilePostedEvent extends Event {
    *
    * This may return null if the `PositionProfile` has been closed for an extended period of time.
    */
-  positionProfile?: Maybe<PositionProfile>;
+  positionProfile?: Maybe<PostedPositionProfile>;
   /**
    * A page of webhook attempts for the current event matching the specified criteria.
    *
@@ -2814,11 +2918,7 @@ export interface PositionProfilePostedEvent extends Event {
   webhookAttempts: WebhookAttemptsConnection;
 }
 
-/**
- * The event signaling that a `PositionProfile` has been posted.
- *
- * Corresponding events for the `updatePostedPositionProfile` and `closePostedPositionProfile` mutations are not currently available.
- */
+/** The event signaling that a `PositionProfile` has been posted. */
 export interface PositionProfilePostedEventWebhookAttemptsArgs {
   after?: Maybe<Scalars['String']>;
   before?: Maybe<Scalars['String']>;
@@ -2905,7 +3005,11 @@ export interface PostPositionProfileForOpeningPayloadSuccess {
 export interface PostPositionProfileForOpeningPositionProfileInput {
   /** The identifier for the `PositionOpening` that this position profile belongs to. */
   positionOpeningId: Scalars['String'];
-  /** A short phrase describing the position as it would be listed on a business card or in a company directory. */
+  /**
+   * A short phrase describing the position as it would be listed on a business card or in a company directory.
+   *
+   * This field has a maximum length of 80 bytes in UTF-8 encoding.
+   */
   positionTitle: Scalars['String'];
   /**
    * An array of identifiers for the `HiringOrganization`s that have the position.
@@ -2915,12 +3019,18 @@ export interface PostPositionProfileForOpeningPositionProfileInput {
    * - The `seekAnz` scheme requires exactly one element.
    */
   positionOrganizations: Array<Scalars['String']>;
-  /** An optional hirer-provided opaque job reference. */
+  /**
+   * An optional hirer-provided opaque job reference.
+   *
+   * This field has a maximum length of 50 bytes in UTF-8 encoding.
+   */
   seekHirerJobReference?: Maybe<Scalars['String']>;
   /**
    * An optional opaque billing reference.
    *
    * This appears on the invoice when SEEK bills the hirer for the job ad.
+   *
+   * This field has a maximum length of 50 bytes in UTF-8 encoding.
    */
   seekBillingReference?: Maybe<Scalars['String']>;
   /** An array of formatted position profile descriptions. */
@@ -2993,7 +3103,7 @@ export interface PostPositionProfileForOpeningPositionProfileInput {
    *
    * The metadata is not used by SEEK and won't be seen by hirers or candidates.
    *
-   * This field has a maximum length of 1000 characters.
+   * This field has a maximum length of 1,000 bytes in UTF-8 encoding.
    */
   seekPartnerMetadata?: Maybe<Scalars['String']>;
 }
@@ -3022,7 +3132,11 @@ export interface PostPositionPositionOpeningPayload {
 
 /** The details of the position profile to be created. */
 export interface PostPositionPositionProfileInput {
-  /** A short phrase describing the position as it would be listed on a business card or in a company directory. */
+  /**
+   * A short phrase describing the position as it would be listed on a business card or in a company directory.
+   *
+   * This field has a maximum length of 80 bytes in UTF-8 encoding.
+   */
   positionTitle: Scalars['String'];
   /**
    * An array of identifiers for the `HiringOrganization`s that have the position.
@@ -3035,15 +3149,15 @@ export interface PostPositionPositionProfileInput {
   /**
    * An optional hirer-provided opaque job reference.
    *
-   * Scheme requirements:
-   *
-   * - The `seekAnz` scheme requires this field to have a maximum length of 50 characters.
+   * This field has a maximum length of 50 bytes in UTF-8 encoding.
    */
   seekHirerJobReference?: Maybe<Scalars['String']>;
   /**
    * An optional opaque billing reference.
    *
    * This appears on the invoice when SEEK bills the hirer for the job ad.
+   *
+   * This field has a maximum length of 50 bytes in UTF-8 encoding.
    */
   seekBillingReference?: Maybe<Scalars['String']>;
   /** An array of formatted position profile descriptions. */
@@ -3116,7 +3230,7 @@ export interface PostPositionPositionProfileInput {
    *
    * The metadata is not used by SEEK and won't be seen by hirers or candidates.
    *
-   * This field has a maximum length of 1000 characters.
+   * This field has a maximum length of 1,000 bytes in UTF-8 encoding.
    */
   seekPartnerMetadata?: Maybe<Scalars['String']>;
 }
@@ -3214,7 +3328,7 @@ export interface PostedPositionProfile extends PositionProfile {
    *
    * The metadata is not used by SEEK and won't be seen by hirers or candidates.
    *
-   * This field has a maximum length of 1000 characters.
+   * This field has a maximum length of 1,000 bytes in UTF-8 encoding.
    */
   seekPartnerMetadata?: Maybe<Scalars['String']>;
 }
@@ -3440,16 +3554,6 @@ export interface Query {
    */
   events: EventsConnection;
   /**
-   * A page of webhook attempts matching the specified criteria generated by a selected subscription.
-   *
-   * A maximum of 100 webhook attempts can be returned in a single page.
-   * Additional webhook attempts can be queried using a pagination cursor.
-   *
-   * The result list is returned in ascending creation date & time order.
-   * It starts from the earliest known attempt if no pagination arguments are provided.
-   */
-  webhookAttemptsForSubscription: WebhookAttemptsConnection;
-  /**
    * A page of webhook attempts matching the specified criteria generated by a selected event.
    *
    * A maximum of 100 webhook attempts can be returned in a single page.
@@ -3482,7 +3586,7 @@ export interface Query {
    * The result list is returned in ascending creation date & time order.
    * It starts from the earliest known request if no pagination arguments are provided.
    */
-  webhookRequestsForSubscription: WebhookRequestConnection;
+  webhookRequestsForSubscription: WebhookRequestsConnection;
   /** The webhook request for the given `requestId`. */
   webhookRequest?: Maybe<WebhookRequest>;
 }
@@ -3715,20 +3819,6 @@ export interface QueryEventsArgs {
  *
  * This acts as the public, top-level API from which all queries must start.
  */
-export interface QueryWebhookAttemptsForSubscriptionArgs {
-  after?: Maybe<Scalars['String']>;
-  before?: Maybe<Scalars['String']>;
-  first?: Maybe<Scalars['Int']>;
-  last?: Maybe<Scalars['Int']>;
-  filter?: Maybe<WebhookAttemptsFilterInput>;
-  subscriptionId: Scalars['String'];
-}
-
-/**
- * The schema's entry-point for queries.
- *
- * This acts as the public, top-level API from which all queries must start.
- */
 export interface QueryWebhookAttemptsForEventArgs {
   after?: Maybe<Scalars['String']>;
   before?: Maybe<Scalars['String']>;
@@ -3820,8 +3910,12 @@ export interface RemunerationAmountInput {
    *
    * For the `seekAnz` scheme, a single currency is accepted in each location:
    *
-   * - `NZD` is used by New Zealand (`seekAnz:location:seek:2b9U8B8Es`) and its children
-   * - `GBP` is used by the UK & Ireland (`seekAnz:location:seek:2beMJFcmV`) and their children
+   * - `NZD` is used by locations in New Zealand.
+   *   These are `Location`s that have a `countryCode` of `NZ`.
+   *
+   * - `GBP` is used by locations in the UK & Ireland.
+   *   These are `Location`s that have a `countryCode` of `GB` or `IE`.
+   *
    * - `AUD` is used by all other locations
    */
   currency: Scalars['String'];
@@ -4200,7 +4294,7 @@ export interface SeekVideoInput {
    *
    * Scheme requirements:
    *
-   *  - The `seekAnz` scheme requires URLs to be YouTube embed URLs less than 255 characters e.g. `https://www.youtube.com/embed/aAgePQvHBQM`.
+   *  - The `seekAnz` scheme requires URLs to be YouTube embed URLs, e.g. `https://www.youtube.com/embed/aAgePQvHBQM`.
    */
   url: Scalars['String'];
   /**
@@ -4258,6 +4352,12 @@ export interface UnpostedPositionProfile extends PositionProfile {
   __typename?: 'UnpostedPositionProfile';
   /** The identifier for the `PositionProfile`. */
   profileId: ObjectIdentifier;
+  /**
+   * A human-readable name given to the profile.
+   *
+   * This in addition to the `positionTitle` can help identify the profile to an end user.
+   */
+  profileName?: Maybe<Scalars['String']>;
   /** The `PositionOpening` that this profile was created under. */
   positionOpening: PositionOpening;
   /** The type of position profile, i.e. `UnpostedPositionProfile`. */
@@ -4327,7 +4427,7 @@ export interface UnpostedPositionProfile extends PositionProfile {
    *
    * The metadata is not used by SEEK and won't be seen by hirers or candidates.
    *
-   * This field has a maximum length of 1000 characters.
+   * This field has a maximum length of 1,000 bytes in UTF-8 encoding.
    */
   seekPartnerMetadata?: Maybe<Scalars['String']>;
 }
@@ -4456,7 +4556,11 @@ export interface UpdatePostedPositionProfilePayload {
 export interface UpdatePostedPositionProfilePositionProfileInput {
   /** The identifier for the posted `PositionProfile` to update. */
   profileId: Scalars['String'];
-  /** A short phrase describing the position as it would be listed on a business card or in a company directory. */
+  /**
+   * A short phrase describing the position as it would be listed on a business card or in a company directory.
+   *
+   * This field has a maximum length of 80 bytes in UTF-8 encoding.
+   */
   positionTitle: Scalars['String'];
   /**
    * An array of identifiers for the `HiringOrganization`s that have the position.
@@ -4466,12 +4570,18 @@ export interface UpdatePostedPositionProfilePositionProfileInput {
    * - The `seekAnz` scheme requires exactly one element.
    */
   positionOrganizations: Array<Scalars['String']>;
-  /** An optional hirer-provided opaque job reference. */
+  /**
+   * An optional hirer-provided opaque job reference.
+   *
+   * This field has a maximum length of 50 bytes in UTF-8 encoding.
+   */
   seekHirerJobReference?: Maybe<Scalars['String']>;
   /**
    * An optional opaque billing reference.
    *
    * This appears on the invoice when SEEK bills the hirer for the job ad.
+   *
+   * This field has a maximum length of 50 bytes in UTF-8 encoding.
    */
   seekBillingReference?: Maybe<Scalars['String']>;
   /** An array of formatted position profile descriptions. */
@@ -4548,7 +4658,7 @@ export interface UpdatePostedPositionProfilePositionProfileInput {
    *
    * The metadata is not used by SEEK and won't be seen by hirers or candidates.
    *
-   * This field has a maximum length of 1000 characters.
+   * This field has a maximum length of 1,000 bytes in UTF-8 encoding.
    */
   seekPartnerMetadata?: Maybe<Scalars['String']>;
 }
@@ -4613,17 +4723,39 @@ export interface UpdateUnpostedPositionProfileInput {
 export interface UpdateUnpostedPositionProfilePayload {
   __typename?: 'UpdateUnpostedPositionProfilePayload';
   /** Attributes of the updated unposted position profile. */
-  positionProfile: PositionProfile;
+  positionProfile: UnpostedPositionProfile;
 }
 
 /** An unposted profile of a position opening to update. */
 export interface UpdateUnpostedPositionProfilePositionProfileInput {
   /** The identifier for the unposted `PositionProfile` to update. */
   profileId: Scalars['String'];
-  /** A short phrase describing the position as it would be listed on a business card or in a company directory. */
+  /**
+   * A human-readable name given to the profile.
+   *
+   * This in addition to the `positionTitle` can help identify the profile to an end user.
+   */
+  profileName?: Maybe<Scalars['String']>;
+  /**
+   * A short phrase describing the position as it would be listed on a business card or in a company directory.
+   *
+   * This field has a maximum length of 80 bytes in UTF-8 encoding.
+   */
   positionTitle: Scalars['String'];
-  /** An optional hirer-provided opaque job reference. */
+  /**
+   * An optional hirer-provided opaque job reference.
+   *
+   * This field has a maximum length of 50 bytes in UTF-8 encoding.
+   */
   seekHirerJobReference?: Maybe<Scalars['String']>;
+  /**
+   * An optional opaque billing reference.
+   *
+   * SEEK does not use this field on unposted position profiles.
+   *
+   * This field has a maximum length of 50 bytes in UTF-8 encoding.
+   */
+  seekBillingReference?: Maybe<Scalars['String']>;
   /**
    * An array of formatted position profile descriptions.
    *
@@ -4658,7 +4790,7 @@ export interface UpdateUnpostedPositionProfilePositionProfileInput {
    *
    * The metadata is not used by SEEK and won't be seen by hirers or candidates.
    *
-   * This field has a maximum length of 1000 characters.
+   * This field has a maximum length of 1,000 bytes in UTF-8 encoding.
    */
   seekPartnerMetadata?: Maybe<Scalars['String']>;
 }
@@ -4844,6 +4976,25 @@ export interface UpdateWebhookSubscriptionDeliveryConfigurationSubscriptionInput
    * This number must be between 1 and 10 inclusive. Defaults to 10.
    */
   maxEventsPerAttempt?: Maybe<Scalars['Int']>;
+}
+
+/** The input parameter for the `updateWebhookSubscriptionSigningConfiguration` mutation. */
+export interface UpdateWebhookSubscriptionSigningConfigurationInput {
+  /** The details of the webhook subscription to be updated. */
+  webhookSubscription: UpdateWebhookSubscriptionSigningConfigurationSubscriptionInput;
+}
+
+/** The output parameter for the `updateWebhookSubscriptionSigningConfiguration` mutation. */
+export interface UpdateWebhookSubscriptionSigningConfigurationPayload {
+  __typename?: 'UpdateWebhookSubscriptionSigningConfigurationPayload';
+  /** The details of the updated webhook subscription. */
+  webhookSubscription: WebhookSubscription;
+}
+
+/** The details of the webhook subscription signing configuration to be updated. */
+export interface UpdateWebhookSubscriptionSigningConfigurationSubscriptionInput {
+  /** The identifier for the `WebhookSubscription`. */
+  id: Scalars['String'];
   /**
    * The algorithm for signing webhooks.
    *
@@ -5136,19 +5287,6 @@ export interface WebhookRequest {
   attempts: Array<WebhookAttempt>;
 }
 
-/** A page of webhook requests. */
-export interface WebhookRequestConnection {
-  __typename?: 'WebhookRequestConnection';
-  /**
-   * The page of webhook requests and their corresponding cursors.
-   *
-   * This is always a non-empty list.
-   */
-  edges: Array<WebhookRequestEdge>;
-  /** The pagination metadata for this page of webhook requests. */
-  pageInfo: PageInfo;
-}
-
 /** A webhook request in a paginated list. */
 export interface WebhookRequestEdge {
   __typename?: 'WebhookRequestEdge';
@@ -5172,14 +5310,14 @@ export interface WebhookRequestFilterInput {
    * The creation date & time that resulting webhook requests must succeed.
    *
    * This can be used to initiate the retrieval of paginated results.
-   * Subsequent queries should use the opaque cursors returned from `WebhookRequestConnection`.
+   * Subsequent queries should use the opaque cursors returned from `WebhookRequestsConnection`.
    */
   afterDateTime?: Maybe<Scalars['DateTime']>;
   /**
    * The creation date & time that resulting webhook requests must precede.
    *
    * This can be used to initiate the retrieval of paginated results.
-   * Subsequent queries should use the opaque cursors returned from `WebhookRequestConnection`.
+   * Subsequent queries should use the opaque cursors returned from `WebhookRequestsConnection`.
    */
   beforeDateTime?: Maybe<Scalars['DateTime']>;
   /**
@@ -5190,6 +5328,19 @@ export interface WebhookRequestFilterInput {
    * If this is not provided then requests of all types will be returned.
    */
   descriptionCodes?: Maybe<Array<Scalars['String']>>;
+}
+
+/** A page of webhook requests. */
+export interface WebhookRequestsConnection {
+  __typename?: 'WebhookRequestsConnection';
+  /**
+   * The page of webhook requests and their corresponding cursors.
+   *
+   * This is always a non-empty list.
+   */
+  edges: Array<WebhookRequestEdge>;
+  /** The pagination metadata for this page of webhook requests. */
+  pageInfo: PageInfo;
 }
 
 /**
@@ -5221,6 +5372,15 @@ export interface WebhookSubscription {
    * A non-null `hirerId` indicates that this subscription is filtered to a single hirer.
    */
   hirerId?: Maybe<ObjectIdentifier>;
+  /**
+   * The optional hirer associated with this webhook subscription.
+   *
+   * This will only be accessible if there is an active relationship between the partner and hirer.
+   *
+   * By default webhook subscriptions will send events from all hirers the partner has access to.
+   * A non-null `hirer` field indicates that this subscription is filtered to a single hirer.
+   */
+  hirer?: Maybe<HiringOrganization>;
   /** The subscriber-owned URL where events are sent to. */
   url: Scalars['String'];
   /**
@@ -5252,15 +5412,15 @@ export interface WebhookSubscription {
   /** The date & time the webhook subscription was last updated. */
   updateDateTime: Scalars['DateTime'];
   /**
-   * A page of webhook attempts for the current subscription matching the specified criteria.
+   * A page of webhook requests for the subscription matching the specified criteria.
    *
-   * A maximum of 100 webhook attempts can be returned in a single page.
-   * Additional webhook attempts can be queried using a pagination cursor.
+   * A maximum of 100 webhook requests can be returned in a single page.
+   * Additional webhook requests can be queried using a pagination cursor.
    *
    * The result list is returned in ascending creation date & time order.
-   * It starts from the earliest known attempt if no pagination arguments are provided.
+   * It starts from the earliest known request if no pagination arguments are provided.
    */
-  webhookAttempts: WebhookAttemptsConnection;
+  webhookRequests: WebhookRequestsConnection;
   /**
    * A page of replays for the current webhook subscription matching the specified criteria.
    *
@@ -5278,12 +5438,12 @@ export interface WebhookSubscription {
  *
  * Events are delivered in batches with a HTTP POST request to the specified subscription URL.
  */
-export interface WebhookSubscriptionWebhookAttemptsArgs {
+export interface WebhookSubscriptionWebhookRequestsArgs {
   after?: Maybe<Scalars['String']>;
   before?: Maybe<Scalars['String']>;
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
-  filter?: Maybe<WebhookAttemptsFilterInput>;
+  filter?: Maybe<WebhookRequestFilterInput>;
 }
 
 /**
@@ -5373,8 +5533,7 @@ export interface WebhookSubscriptionReplaysConnection {
    * - The property `hasPreviousPage` will always be false when paginating by `first`
    * - The property `hasNextPage` will always be false when paginating by `last`
    *
-   * To discern whether a next/previous page exists in these conditions, an additional request will need to be made
-   * to retrieve the next/previous page.
+   * To discern whether a next/previous page exists in these conditions, an additional request will need to be made to retrieve the next/previous page.
    */
   pageInfo: PageInfo;
 }
@@ -5443,6 +5602,56 @@ export interface WebhookSubscriptionsFilterInput {
    */
   hirerIds?: Maybe<Array<Scalars['String']>>;
 }
+
+export type JobCategoryAttributesFragment = {
+  __typename?: 'JobCategory';
+} & Pick<JobCategory, 'name'> & {
+    id: { __typename?: 'ObjectIdentifier' } & Pick<ObjectIdentifier, 'value'>;
+  };
+
+export type JobCategoriesQueryVariables = Exact<{
+  schemeId: Scalars['String'];
+}>;
+
+export type JobCategoriesQuery = { __typename?: 'Query' } & {
+  jobCategories: Array<
+    { __typename?: 'JobCategory' } & {
+      parent?: Maybe<
+        { __typename?: 'JobCategory' } & JobCategoryAttributesFragment
+      >;
+      children?: Maybe<
+        Array<{ __typename?: 'JobCategory' } & JobCategoryAttributesFragment>
+      >;
+    } & JobCategoryAttributesFragment
+  >;
+};
+
+export type JobCategorySuggestionChoiceAttributesFragment = {
+  __typename?: 'JobCategorySuggestionChoice';
+} & Pick<JobCategorySuggestionChoice, 'confidence'> & {
+    jobCategory: { __typename?: 'JobCategory' } & {
+      parent?: Maybe<
+        { __typename?: 'JobCategory' } & JobCategoryAttributesFragment
+      >;
+      children?: Maybe<
+        Array<{ __typename?: 'JobCategory' } & JobCategoryAttributesFragment>
+      >;
+    } & JobCategoryAttributesFragment;
+  };
+
+export type JobCategorySuggestQueryVariables = Exact<{
+  positionProfile: JobCategorySuggestionPositionProfileInput;
+  schemeId: Scalars['String'];
+  first?: Maybe<Scalars['Int']>;
+}>;
+
+export type JobCategorySuggestQuery = { __typename?: 'Query' } & {
+  jobCategorySuggestions: Array<
+    {
+      __typename?: 'JobCategorySuggestionChoice';
+    } & JobCategorySuggestionChoiceAttributesFragment
+  >;
+};
 
 export type LocationAttributesFragment = { __typename?: 'Location' } & Pick<
   Location,

--- a/fe/lib/types/seekFragmentTypes.ts
+++ b/fe/lib/types/seekFragmentTypes.ts
@@ -24,6 +24,7 @@ const result: PossibleTypesResultData = {
     Event: [
       'CandidateApplicationCreatedEvent',
       'CandidateProfilePurchasedEvent',
+      'PositionProfileClosedEvent',
       'PositionProfilePostedEvent',
     ],
     PositionProfile: ['PostedPositionProfile', 'UnpostedPositionProfile'],

--- a/fe/lib/types/seekSchema.graphql
+++ b/fe/lib/types/seekSchema.graphql
@@ -1,5 +1,8 @@
-schema { query: Query
-mutation: Mutation }
+schema {
+  query: Query
+  mutation: Mutation
+}
+
 """A physical address."""
 type Address {
   """The street line address."""
@@ -27,6 +30,7 @@ type Address {
   """The formatted representation of the whole address for display purposes."""
   formattedAddress: String
 }
+
 """An individual component of a physical address."""
 type AddressComponent {
   """
@@ -41,6 +45,7 @@ type AddressComponent {
   """The actual component value."""
   value: String!
 }
+
 """An individual component of a physical address."""
 input AddressComponentInput {
   """
@@ -55,6 +60,7 @@ input AddressComponentInput {
   """The actual component value."""
   value: String!
 }
+
 """A physical address."""
 input AddressInput {
   """The street line address."""
@@ -79,13 +85,22 @@ input AddressInput {
   countrySubDivisions: [AddressComponentInput!]!
   """The city or suburb of the address."""
   city: String
-  """The postal code of the address."""
+  """
+  The postal code of the address.
+  
+  This field has a maximum length of 50 bytes in UTF-8 encoding.
+  """
   postalCode: String
   """The geographical coordinates of the address."""
   geoLocation: GeoLocationInput
-  """The formatted representation of the whole address for display purposes."""
+  """
+  The formatted representation of the whole address for display purposes.
+  
+  This field has a maximum length of 1,000 bytes in UTF-8 encoding.
+  """
   formattedAddress: String
 }
+
 """
 Advertisement branding details and images.
 
@@ -103,6 +118,7 @@ type AdvertisementBranding {
   """The organization that has the advertisement branding."""
   hirer: HiringOrganization!
 }
+
 """An advertisement branding in a paginated list."""
 type AdvertisementBrandingEdge {
   """
@@ -114,6 +130,7 @@ type AdvertisementBrandingEdge {
   """The actual advertisement branding."""
   node: AdvertisementBranding!
 }
+
 """A visual representation of advertisement branding."""
 type AdvertisementBrandingImage {
   """
@@ -133,6 +150,7 @@ type AdvertisementBrandingImage {
   """
   url: String!
 }
+
 """A page of advertisement brandings for a hirer."""
 type AdvertisementBrandingsConnection {
   """
@@ -144,6 +162,7 @@ type AdvertisementBrandingsConnection {
   """The pagination metadata for this page of advertisement brandings."""
   pageInfo: PageInfo!
 }
+
 """A method of applying to a position."""
 type ApplicationMethod {
   """
@@ -155,6 +174,7 @@ type ApplicationMethod {
   """The email address that candidate applications are directed to."""
   applicationEmail: Email @deprecated(reason: "This has been replaced by Application Export")
 }
+
 """A method of applying to a position."""
 input ApplicationMethodInput {
   """
@@ -166,10 +186,13 @@ input ApplicationMethodInput {
   """
   The email address to direct candidate applications to.
   
+  This field has a maximum length of 100 bytes in UTF-8 encoding.
+  
   This is deprecated. Do not use this field. This has been replaced by Application Export.
   """
   applicationEmail: EmailInput
 }
+
 """
 A privacy policy consent component of an `ApplicationQuestionnaire`.
 
@@ -203,6 +226,7 @@ type ApplicationPrivacyConsent implements ApplicationQuestionnaireComponent {
   """
   descriptionHtml: String
 }
+
 """
 A privacy policy consent component of an `ApplicationQuestionnaire`.
 
@@ -234,6 +258,7 @@ input ApplicationPrivacyConsentInput {
   """
   descriptionHtml: String
 }
+
 """A candidate's response to a privacy policy consent component in the questionnaire."""
 type ApplicationPrivacyConsentResponse implements ApplicationQuestionnaireComponentResponse {
   """The privacy consent component this is responding to."""
@@ -247,6 +272,7 @@ type ApplicationPrivacyConsentResponse implements ApplicationQuestionnaireCompon
   """This indicates whether or not the candidate agrees to the provided privacy policy."""
   consentGivenIndicator: Boolean!
 }
+
 """
 A question component of an `ApplicationQuestionnaire`.
 
@@ -290,6 +316,7 @@ type ApplicationQuestion implements ApplicationQuestionnaireComponent {
   """
   responseChoice: [ApplicationQuestionChoice!]
 }
+
 """A single answer to a question in the questionnaire."""
 type ApplicationQuestionAnswer {
   """
@@ -301,6 +328,7 @@ type ApplicationQuestionAnswer {
   """The text value of the selected answer."""
   answer: String!
 }
+
 """A possible response to an `ApplicationQuestion`."""
 type ApplicationQuestionChoice {
   """The identifier for the `ApplicationQuestionChoice`."""
@@ -320,6 +348,7 @@ type ApplicationQuestionChoice {
   """
   preferredIndicator: Boolean!
 }
+
 """A possible response to an `ApplicationQuestion`."""
 input ApplicationQuestionChoiceInput {
   """Text of the choice displayed to the candidate."""
@@ -338,6 +367,7 @@ input ApplicationQuestionChoiceInput {
   """
   preferredIndicator: Boolean!
 }
+
 """
 A question component of an `ApplicationQuestionnaire`.
 
@@ -380,6 +410,7 @@ input ApplicationQuestionInput {
   """
   responseChoice: [ApplicationQuestionChoiceInput!]
 }
+
 """A candidate's response to a question in the questionnaire."""
 type ApplicationQuestionResponse implements ApplicationQuestionnaireComponentResponse {
   """The question this is responding to."""
@@ -408,6 +439,7 @@ type ApplicationQuestionResponse implements ApplicationQuestionnaireComponentRes
   """
   score: Float
 }
+
 """
 A set of questions presented to a candidate during an application.
 
@@ -419,6 +451,7 @@ type ApplicationQuestionnaire {
   """The array of components in the order they are presented to the candidate."""
   components: [ApplicationQuestionnaireComponent!]!
 }
+
 """
 A component of an application questionnaire.
 
@@ -444,6 +477,7 @@ interface ApplicationQuestionnaireComponent {
   """
   value: String
 }
+
 """A component of the questionnaire to be created."""
 input ApplicationQuestionnaireComponentInput {
   """
@@ -468,6 +502,7 @@ input ApplicationQuestionnaireComponentInput {
   """
   privacyConsent: ApplicationPrivacyConsentInput
 }
+
 """
 A response to a component in a questionnaire.
 
@@ -487,6 +522,7 @@ interface ApplicationQuestionnaireComponentResponse {
   """
   componentTypeCode: String!
 }
+
 """A completed candidate submission for an `ApplicationQuestionnaire`."""
 type ApplicationQuestionnaireSubmission {
   """The set of questions presented to the candidate during the application."""
@@ -502,6 +538,7 @@ type ApplicationQuestionnaireSubmission {
   """
   score: Float
 }
+
 """The details of a position that a candidate is associated with."""
 type AssociatedPositionOpening {
   """
@@ -533,6 +570,7 @@ type AssociatedPositionOpening {
   """
   candidateAppliedIndicator: Boolean
 }
+
 """A profile attachment stored at an external URL."""
 type Attachment {
   """
@@ -569,6 +607,7 @@ type Attachment {
   """The role of the attachment within a profile."""
   seekRole: SeekAttachmentRole @deprecated(reason: "Use seekRoleCode")
 }
+
 """
 A person who applied for a position at a company.
 
@@ -602,6 +641,7 @@ type Candidate {
   """
   profiles: [CandidateProfile!]!
 }
+
 """
 The event signaling that a candidate has applied for a `PositionOpening`.
 
@@ -686,6 +726,7 @@ type CandidateApplicationCreatedEvent implements Event {
     filter: WebhookAttemptsFilterInput
   ): WebhookAttemptsConnection!
 }
+
 """Information about a person not specific to a candidate profile."""
 type CandidatePerson {
   """The person's name."""
@@ -693,6 +734,7 @@ type CandidatePerson {
   """Methods of communication with the person."""
   communication: Communication!
 }
+
 """Information about a person not specific to a candidate profile."""
 input CandidatePersonInput {
   """The person's name."""
@@ -700,6 +742,7 @@ input CandidatePersonInput {
   """Methods of communication with the person."""
   communication: CommunicationInput!
 }
+
 """An action that can be executed as part of a workflow process."""
 type CandidateProcessAction {
   """
@@ -722,11 +765,12 @@ type CandidateProcessAction {
   code: String!
   """The free-form description of the action."""
   description: String
-  """A short human-readable name of the workflow process."""
+  """A short human-readable name for the workflow step."""
   name: String
   """A deep link to the action."""
   seekUrl: WebUrl
 }
+
 """An action that can be executed as part of a workflow process."""
 input CandidateProcessActionInput {
   """
@@ -763,9 +807,12 @@ input CandidateProcessActionInput {
   A deep link to the action.
   
   This is required for a profile action of an uploaded candidate.
+  
+  The `url` field has a maximum length of 1,000 bytes in UTF-8 encoding.
   """
   seekUrl: WebUrlInput
 }
+
 """A single item in a `CandidateProfile`'s workflow process history."""
 type CandidateProcessHistoryItem {
   """The identifier for the `CandidateProcessHistoryItem`."""
@@ -805,6 +852,7 @@ type CandidateProcessHistoryItem {
   """The parties that executed the action."""
   primaryParties: [CandidateProcessParty!]!
 }
+
 """A page of candidate process history items."""
 type CandidateProcessHistoryItemConnection {
   """
@@ -816,6 +864,7 @@ type CandidateProcessHistoryItemConnection {
   """The pagination metadata for this page of candidate process history items."""
   pageInfo: PageInfo!
 }
+
 """A candidate process history item in a paginated list."""
 type CandidateProcessHistoryItemEdge {
   """
@@ -827,6 +876,7 @@ type CandidateProcessHistoryItemEdge {
   """The actual candidate process history item."""
   node: CandidateProcessHistoryItem!
 }
+
 """A single item in a `CandidateProfile`'s workflow process history."""
 input CandidateProcessHistoryItemInput {
   """The date & time the action was executed."""
@@ -868,11 +918,13 @@ input CandidateProcessHistoryItemInput {
   """
   primaryParties: [CandidateProcessPartyInput!]!
 }
+
 """A position profile associated with a workflow process."""
 input CandidateProcessHistoryItem_PositionProfileInput {
   """The identifier for the `PositionProfile`."""
   profileId: String!
 }
+
 """
 A party that contributes to a workflow process.
 
@@ -884,6 +936,7 @@ type CandidateProcessParty {
   """The organization that is contributing to the workflow process."""
   organization: Organization
 }
+
 """
 A party that contributes to a workflow process.
 
@@ -895,6 +948,7 @@ input CandidateProcessPartyInput {
   """The organization that is contributing to the workflow process."""
   organization: OrganizationInput
 }
+
 """A status of a workflow process."""
 type CandidateProcessStatus {
   """
@@ -915,6 +969,7 @@ type CandidateProcessStatus {
   """
   code: String!
 }
+
 """A status of a workflow process."""
 input CandidateProcessStatusInput {
   """
@@ -935,6 +990,7 @@ input CandidateProcessStatusInput {
   """
   code: String!
 }
+
 """Structured information about a candidate in relation to a particular position."""
 type CandidateProfile {
   """
@@ -997,6 +1053,7 @@ type CandidateProfile {
   """The completed candidate submission for the position profile's questionnaire."""
   seekQuestionnaireSubmission: ApplicationQuestionnaireSubmission
 }
+
 """The event signaling that a `CandidateProfile` has been purchased."""
 type CandidateProfilePurchasedEvent implements Event {
   """The identifier for the `Event`."""
@@ -1064,6 +1121,7 @@ type CandidateProfilePurchasedEvent implements Event {
     filter: WebhookAttemptsFilterInput
   ): WebhookAttemptsConnection!
 }
+
 """A source from which the candidate was obtained from."""
 type CandidateSource {
   """Free text description of the source."""
@@ -1079,6 +1137,7 @@ type CandidateSource {
   """
   type: String!
 }
+
 """A certification or license held by the candidate."""
 type Certification {
   """The free text name of the certification."""
@@ -1113,26 +1172,31 @@ type Certification {
   """
   descriptions: [String!]!
 }
+
 """The input parameter for the `closePostedPositionProfile` mutation."""
 input ClosePostedPositionProfileInput {
   """The details of the position profile to be closed."""
   positionProfile: ClosePostedPositionProfile_PositionProfileInput!
 }
+
 """The output of the `closePostedPositionProfile` mutation."""
 type ClosePostedPositionProfilePayload {
   """Attributes of the closed position profile."""
   positionProfile: ClosePostedPositionProfile_PositionProfilePayload!
 }
+
 """The details of the position profile to be closed."""
 input ClosePostedPositionProfile_PositionProfileInput {
   """The identifier for the posted `PositionProfile` to be closed."""
   profileId: String!
 }
+
 """Attributes of the closed position profile."""
 type ClosePostedPositionProfile_PositionProfilePayload {
   """The identifier for the closed `PositionProfile`."""
   profileId: ObjectIdentifier!
 }
+
 """Communication channels for a person."""
 type Communication {
   """
@@ -1154,6 +1218,7 @@ type Communication {
   """
   address: [Address!]!
 }
+
 """Communication channels for a person."""
 input CommunicationInput {
   """
@@ -1181,16 +1246,19 @@ input CommunicationInput {
   """
   address: [AddressInput!]
 }
+
 """The input parameter for the `createApplicationQuestionnaire` mutation."""
 input CreateApplicationQuestionnaireInput {
   """The details of the questionnaire to be created."""
   applicationQuestionnaire: CreateApplicationQuestionnaire_ApplicationQuestionnaireInput!
 }
+
 """The output parameter for the `createApplicationQuestionnaire` mutation."""
 type CreateApplicationQuestionnairePayload {
   """The details of the created questionnaire."""
   applicationQuestionnaire: ApplicationQuestionnaire!
 }
+
 """The details of the questionnaire to be created."""
 input CreateApplicationQuestionnaire_ApplicationQuestionnaireInput {
   """
@@ -1202,6 +1270,7 @@ input CreateApplicationQuestionnaire_ApplicationQuestionnaireInput {
   """The array of components in the order they are presented to the candidate."""
   components: [ApplicationQuestionnaireComponentInput!]!
 }
+
 """The input parameter for the `createCandidateProcessHistoryItem` mutation."""
 input CreateCandidateProcessHistoryItemInput {
   """The details of the `CandidateProfile` that the `CandidateProcessHistoryItem` belongs to."""
@@ -1209,8 +1278,10 @@ input CreateCandidateProcessHistoryItemInput {
   """The details of the `CandidateProcessHistoryItem` to be added to the `CandidateProfile`."""
   candidateProcessHistoryItem: CreateCandidateProcessHistoryItem_CandidateProcessHistoryItemInput!
 }
+
 """The output parameter for the `createCandidateProcessHistoryItem` mutation."""
 union CreateCandidateProcessHistoryItemPayload = CreateCandidateProcessHistoryItemPayload_Conflict | CreateCandidateProcessHistoryItemPayload_Success
+
 """The conflict result for the `createCandidateProcessHistoryItem` mutation."""
 type CreateCandidateProcessHistoryItemPayload_Conflict {
   """The details of the conflicting `CandidateProcessHistoryItem`."""
@@ -1218,6 +1289,7 @@ type CreateCandidateProcessHistoryItemPayload_Conflict {
   """The `CandidateProfile` that the `CandidateProcessHistoryItem` belongs to."""
   candidateProfile: CandidateProfile!
 }
+
 """The success result for the `createCandidateProcessHistoryItem` mutation."""
 type CreateCandidateProcessHistoryItemPayload_Success {
   """The details of the `CandidateProcessHistoryItem` created."""
@@ -1225,6 +1297,7 @@ type CreateCandidateProcessHistoryItemPayload_Success {
   """The `CandidateProfile` that the `CandidateProcessHistoryItem` belongs to."""
   candidateProfile: CandidateProfile!
 }
+
 """The candidate process history to create."""
 input CreateCandidateProcessHistoryItem_CandidateProcessHistoryItemInput {
   """
@@ -1268,21 +1341,25 @@ input CreateCandidateProcessHistoryItem_CandidateProcessHistoryItemInput {
   """The parties that executed the action."""
   primaryParties: [CandidateProcessPartyInput!]!
 }
+
 """The candidate profile that the process history item belongs to."""
 input CreateCandidateProcessHistoryItem_CandidateProfileInput {
   """The identifier for the `CandidateProfile` that the `CandidateProcessHistoryItem` relates to."""
   profileId: String!
 }
+
 """The input parameter for the `createPositionOpening` mutation."""
 input CreatePositionOpeningInput {
   """The details of the position opening to be created."""
   positionOpening: CreatePositionOpening_PositionOpeningInput!
 }
+
 """The output parameter for the `createPositionOpening` mutation."""
 type CreatePositionOpeningPayload {
   """The details of the created position opening."""
   positionOpening: PositionOpening!
 }
+
 """The details of the position opening to be created."""
 input CreatePositionOpening_PositionOpeningInput {
   """The party that owns the position opening."""
@@ -1292,7 +1369,7 @@ input CreatePositionOpening_PositionOpeningInput {
   
   The metadata is not used by SEEK and won't be seen by hirers or candidates.
   
-  This field has a maximum length of 1000 characters.
+  This field has a maximum length of 1,000 bytes in UTF-8 encoding.
   """
   seekPartnerMetadata: String
   """
@@ -1308,6 +1385,7 @@ input CreatePositionOpening_PositionOpeningInput {
   """
   statusCode: String
 }
+
 """A collection of information about where and how to post a job ad."""
 input CreatePostingInstructionInput {
   """
@@ -1364,21 +1442,34 @@ input CreatePostingInstructionInput {
   """
   brandingId: String
 }
+
 """The input parameter for the `createUnpostedPositionProfileForOpening` mutation."""
 input CreateUnpostedPositionProfileForOpeningInput {
   """An unposted profile of a position opening to create."""
   positionProfile: CreateUnpostedPositionProfileForOpeningPositionProfileInput!
 }
+
 """The output parameter for the `createUnpostedPositionProfileForOpening` mutation."""
 type CreateUnpostedPositionProfileForOpeningPayload {
   """Attributes of the newly created unposted position profile."""
-  positionProfile: PositionProfile!
+  positionProfile: UnpostedPositionProfile!
 }
+
 """An unposted profile of a position opening to create."""
 input CreateUnpostedPositionProfileForOpeningPositionProfileInput {
   """The identifier for the `PositionOpening` that this position profile belongs to."""
   positionOpeningId: String!
-  """A short phrase describing the position as it would be listed on a business card or in a company directory."""
+  """
+  A human-readable name given to the profile.
+  
+  This in addition to the `positionTitle` can help identify the profile to an end user.
+  """
+  profileName: String
+  """
+  A short phrase describing the position as it would be listed on a business card or in a company directory.
+  
+  This field has a maximum length of 80 bytes in UTF-8 encoding.
+  """
   positionTitle: String!
   """
   An array of identifiers for the `HiringOrganization`s that have the position.
@@ -1387,12 +1478,18 @@ input CreateUnpostedPositionProfileForOpeningPositionProfileInput {
   this should contain exactly one element that matches the `postingRequester` on the position opening.
   """
   positionOrganizations: [String!]!
-  """An optional hirer-provided opaque job reference."""
+  """
+  An optional hirer-provided opaque job reference.
+  
+  This field has a maximum length of 50 bytes in UTF-8 encoding.
+  """
   seekHirerJobReference: String
   """
   An optional opaque billing reference.
   
   SEEK does not use this field on unposted position profiles.
+  
+  This field has a maximum length of 50 bytes in UTF-8 encoding.
   """
   seekBillingReference: String
   """
@@ -1429,27 +1526,32 @@ input CreateUnpostedPositionProfileForOpeningPositionProfileInput {
   
   The metadata is not used by SEEK and won't be seen by hirers or candidates.
   
-  This field has a maximum length of 1000 characters.
+  This field has a maximum length of 1,000 bytes in UTF-8 encoding.
   """
   seekPartnerMetadata: String
 }
+
 """The input parameter for the `createWebhookSubscription` mutation."""
 input CreateWebhookSubscriptionInput {
   """The details of the webhook subscription to be created."""
   webhookSubscription: CreateWebhookSubscription_SubscriptionInput!
 }
+
 """The output parameter for the `createWebhookSubscription` mutation."""
 union CreateWebhookSubscriptionPayload = CreateWebhookSubscriptionPayload_Conflict | CreateWebhookSubscriptionPayload_Success
+
 """The conflict result for the `createWebhookSubscription` mutation."""
 type CreateWebhookSubscriptionPayload_Conflict {
   """The details of the conflicting webhook subscription."""
   conflictingWebhookSubscription: WebhookSubscription!
 }
+
 """The success result for the `createWebhookSubscription` mutation."""
 type CreateWebhookSubscriptionPayload_Success {
   """The details of the created webhook subscription."""
   webhookSubscription: WebhookSubscription!
 }
+
 """The details of the webhook subscription to be created."""
 input CreateWebhookSubscription_SubscriptionInput {
   """
@@ -1504,6 +1606,7 @@ input CreateWebhookSubscription_SubscriptionInput {
   """
   secret: String
 }
+
 """
 A monetary amount expressed as an integer in a specified minor currency unit.
 
@@ -1519,60 +1622,73 @@ type CurrencyMinorUnit {
   """The three-letter ISO 4217 currency code, in uppercase."""
   currency: String!
 }
+
 """A date string, such as 2007-12-03, compliant with the `full-date` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar."""
 scalar Date
+
 """A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar."""
 scalar DateTime
+
 """The input parameter for the `deleteCandidateProcessHistoryItem` mutation."""
 input DeleteCandidateProcessHistoryItemInput {
   """The details of the  `CandidateProcessHistoryItem` to be deleted."""
   candidateProcessHistoryItem: DeleteCandidateProcessHistoryItem_CandidateProcessHistoryItemInput!
 }
+
 """The output parameter for the `deleteCandidateProcessHistoryItem` mutation."""
 type DeleteCandidateProcessHistoryItemPayload {
   """The details of the `CandidateProcessHistoryItem` that was deleted."""
   candidateProcessHistoryItem: CandidateProcessHistoryItem!
 }
+
 """The details of the `CandidateProcessHistoryItem` to be deleted."""
 input DeleteCandidateProcessHistoryItem_CandidateProcessHistoryItemInput {
   """The identifier for the `CandidateProcessHistoryItem` to be deleted."""
   id: String!
 }
+
 """The input parameter for the `deletePositionOpening` mutation."""
 input DeletePositionOpeningInput {
   """The details of the position opening to be deleted."""
   positionOpening: DeletePositionOpening_PositionOpeningInput!
 }
+
 """The output parameter for the `deletePositionOpening` mutation."""
 type DeletePositionOpeningPayload {
   """The details of the deleted position opening."""
   positionOpening: PositionOpening!
 }
+
 """The details of the position opening to be deleted."""
 input DeletePositionOpening_PositionOpeningInput {
   """The identifier for the `PositionOpening` to be deleted."""
   documentId: String!
 }
+
 """The input parameter for the `deleteUnpostedPositionProfile` mutation."""
 input DeleteUnpostedPositionProfileInput {
   """The details of the unposted position profile to be deleted."""
   positionProfile: DeleteUnpostedPositionProfile_PositionProfileInput!
 }
+
 """The output parameter for the `deleteUnpostedPositionProfile` mutation."""
 type DeleteUnpostedPositionProfilePayload {
   """The details of the deleted unposted position profile."""
-  positionProfile: PositionProfile!
+  positionProfile: UnpostedPositionProfile!
 }
+
 """The details of the unposted position profile to be deleted."""
 input DeleteUnpostedPositionProfile_PositionProfileInput {
   """The identifier for the unposted `PositionProfile`."""
   profileId: String!
 }
+
 """The input parameter for the `deleteUploadedCandidate` mutation."""
 input DeleteUploadedCandidateInput {
   """The details of the uploaded `Candidate` to be deleted."""
   candidate: DeleteUploadedCandidate_CandidateInput!
 }
+
 """The output parameter for the `deleteUploadedCandidate` mutation."""
 type DeleteUploadedCandidatePayload {
   """
@@ -1582,26 +1698,31 @@ type DeleteUploadedCandidatePayload {
   """
   candidate: Candidate!
 }
+
 """The details of the uploaded candidate to be deleted."""
 input DeleteUploadedCandidate_CandidateInput {
   """The identifier for the uploaded `Candidate` to be deleted."""
   documentId: String!
 }
+
 """The input parameter for the `deleteWebhookSubscription` mutation."""
 input DeleteWebhookSubscriptionInput {
   """The details of the webhook subscription to be deleted."""
   webhookSubscription: DeleteWebhookSubscription_SubscriptionInput!
 }
+
 """The output parameter for the `deleteWebhookSubscription` mutation."""
 type DeleteWebhookSubscriptionPayload {
   """The details of the deleted webhook subscription."""
   webhookSubscription: WebhookSubscription!
 }
+
 """The details of the webhook subscription to be deleted."""
 input DeleteWebhookSubscription_SubscriptionInput {
   """The identifier for the `WebhookSubscription`."""
   id: String!
 }
+
 """Instructions on how a candidate should be distributed."""
 type DistributionGuidelines {
   """
@@ -1614,6 +1735,7 @@ type DistributionGuidelines {
   """
   seekProductCodes: [String!]!
 }
+
 """Instructions on how a candidate should be distributed."""
 input DistributionGuidelinesInput {
   """
@@ -1625,6 +1747,7 @@ input DistributionGuidelinesInput {
   """
   seekProductCodes: [String!]!
 }
+
 """The details documenting a person's attendance at an educational institution."""
 type EducationAttendance {
   """The institution the person attended."""
@@ -1638,6 +1761,7 @@ type EducationAttendance {
   """
   descriptions: [String!]!
 }
+
 """The details of a student's degree."""
 type EducationDegree {
   """The name of the degree."""
@@ -1659,6 +1783,7 @@ type EducationDegree {
   """
   date: HistoryDate
 }
+
 """A time period for which an associated object is effective."""
 type EffectiveTimePeriod {
   """
@@ -1669,16 +1794,19 @@ type EffectiveTimePeriod {
   """
   validTo: HistoryDate
 }
+
 """An email address."""
 type Email {
   """The email address."""
   address: String!
 }
+
 """An email address."""
 input EmailInput {
   """The email address."""
   address: String!
 }
+
 """The details of a person's employment, work, or relevant experience."""
 type EmployerHistory {
   """The specific organization to which the person held positions."""
@@ -1686,6 +1814,7 @@ type EmployerHistory {
   """The set of positions that the person held."""
   positionHistories: [PositionHistory!]!
 }
+
 """
 A signal that an action has been performed on the SEEK platform that may be of interest to an integration partner.
 
@@ -1762,6 +1891,7 @@ interface Event {
     filter: WebhookAttemptsFilterInput
   ): WebhookAttemptsConnection!
 }
+
 """An event in a stream."""
 type EventEdge {
   """
@@ -1779,6 +1909,7 @@ type EventEdge {
   """
   streamDateTime: DateTime!
 }
+
 """A page of events from a stream."""
 type EventsConnection {
   """
@@ -1790,6 +1921,7 @@ type EventsConnection {
   """The pagination metadata for this page of events."""
   pageInfo: PageInfo!
 }
+
 """
 The criteria to filter events by.
 
@@ -1832,6 +1964,7 @@ input EventsFilterInput {
   """
   subscriptionId: String
 }
+
 """A geographical coordinate."""
 type GeoLocation {
   """The latitude of the geographical location."""
@@ -1839,6 +1972,7 @@ type GeoLocation {
   """The longitude of the geographical location."""
   longitude: Float!
 }
+
 """A geographical coordinate."""
 input GeoLocationInput {
   """The latitude of the geographical location."""
@@ -1846,6 +1980,7 @@ input GeoLocationInput {
   """The longitude of the geographical location."""
   longitude: Float!
 }
+
 """An organization hiring for an open position."""
 type HiringOrganization {
   """The identifier for the `HiringOrganization`."""
@@ -1860,6 +1995,7 @@ type HiringOrganization {
   """
   seekAnzAdvertiserId: Int
 }
+
 """
 A date string compliant with the ISO 8601 "year", "year and month" or "complete date" formats.
 
@@ -1868,6 +2004,7 @@ For example, `"2020"`, `"2020-05"` and `"2020-05-27"` are all valid for `History
 This is used for dates in a candidate's position & employment histories where the precise month or day may not have been provided.
 """
 scalar HistoryDate
+
 """The category of a job's occupation."""
 type JobCategory {
   """The identifier for the `JobCategory`."""
@@ -1888,6 +2025,7 @@ type JobCategory {
   """Name of the job category."""
   name: String!
 }
+
 """A job category with information of the suggested choice."""
 type JobCategorySuggestionChoice {
   """The job category information of the suggestion choice."""
@@ -1899,6 +2037,7 @@ type JobCategorySuggestionChoice {
   """
   confidence: Float!
 }
+
 """The input parameter for the `jobCategorySuggestions` query."""
 input JobCategorySuggestionPositionProfileInput {
   """The position title."""
@@ -1919,6 +2058,7 @@ input JobCategorySuggestionPositionProfileInput {
   """
   positionFormattedDescriptions: [PositionFormattedDescriptionInput!]
 }
+
 """A physical address with a persistent identifier."""
 type Location {
   """The identifier for the `Location`."""
@@ -1934,11 +2074,13 @@ type Location {
   """The two-letter ISO 3166-1:2013 country code, in uppercase."""
   countryCode: String!
 }
+
 """A suggested location."""
 type LocationSuggestion {
   """Location information of the choice."""
   location: Location!
 }
+
 """
 The schema's entry-point for mutations.
 
@@ -2026,13 +2168,20 @@ type Mutation {
   """
   Updates an existing webhook subscription's delivery configuration.
   
-  This modifies fields related to the URL, payload & signature of an existing webhook subscription.
+  This modifies fields related to the URL and payload of an existing webhook subscription.
   Changes may take up to half an hour to take effect.
   
   The fields that determine which events are to be delivered are immutable.
   A new webhook subscription should be created for such cases.
   """
   updateWebhookSubscriptionDeliveryConfiguration(input: UpdateWebhookSubscriptionDeliveryConfigurationInput!): UpdateWebhookSubscriptionDeliveryConfigurationPayload
+  """
+  Updates an existing webhook subscription's signing configuration.
+  
+  This modifies fields related to the signature of an existing webhook subscription.
+  Changes may take up to half an hour to take effect.
+  """
+  updateWebhookSubscriptionSigningConfiguration(input: UpdateWebhookSubscriptionSigningConfigurationInput!): UpdateWebhookSubscriptionSigningConfigurationPayload
   """Deletes an existing webhook subscription."""
   deleteWebhookSubscription(input: DeleteWebhookSubscriptionInput!): DeleteWebhookSubscriptionPayload
   """
@@ -2044,21 +2193,25 @@ type Mutation {
   """
   replayWebhookSubscription(input: ReplayWebhookSubscriptionInput!): ReplayWebhookSubscriptionPayload
 }
+
 """An opaque identifier for GraphQL objects."""
 type ObjectIdentifier {
   """The identifier itself."""
   value: String!
 }
+
 """Basic information to identify and reference a specific organization."""
 type Organization {
   """The human readable name of the organization."""
   name: String!
 }
+
 """Basic information to identify and reference a specific organization."""
 input OrganizationInput {
   """The human readable name of the organization."""
   name: String!
 }
+
 """
 Pagination metadata for a result list.
 
@@ -2076,11 +2229,13 @@ type PageInfo {
   """An opaque string cursor for retrieving the next page of results."""
   endCursor: String
 }
+
 """A skill or competency asserted by the candidate."""
 type PersonCompetency {
   """The human readable name of the competency."""
   competencyName: String!
 }
+
 """The name of a person including a breakdown of name components."""
 type PersonName {
   """The formatted name of a person, as it would be written out together."""
@@ -2090,6 +2245,7 @@ type PersonName {
   """The family name (or surname) of a person, if provided."""
   family: String
 }
+
 """The name of a person associated with an object."""
 input PersonNameInput {
   """The formatted name of a person, as it would be written out together."""
@@ -2099,16 +2255,19 @@ input PersonNameInput {
   """The optional family name (or surname) of a person."""
   family: String
 }
+
 """The phone number of a person."""
 type Phone {
   """The phone number represented as a human readable string."""
   formattedNumber: String!
 }
+
 """The phone number of a person."""
 input PhoneInput {
   """The phone number represented as a human readable string."""
   formattedNumber: String!
 }
+
 """A formatted description of the position profile."""
 type PositionFormattedDescription {
   """The description type."""
@@ -2116,6 +2275,7 @@ type PositionFormattedDescription {
   """The HTML content of the description."""
   content: String!
 }
+
 """
 A description type identifier.
 
@@ -2134,6 +2294,7 @@ type PositionFormattedDescriptionIdentifier {
   """
   value: String!
 }
+
 """A formatted description of the position profile."""
 input PositionFormattedDescriptionInput {
   """
@@ -2148,10 +2309,23 @@ input PositionFormattedDescriptionInput {
   
   Scheme requirements:
   
-  - The `seekAnz` scheme requires `AdvertisementDetails` and `SearchSummary` to be included and non-empty.
+  - The `seekAnz` scheme requires `AdvertisementDetails` and `SearchSummary` to be included.
+  """
+  descriptionId: String!
+  """
+  The HTML content of the description.
+  
+  The maximum length differs by `descriptionId`:
+  
+    - `AdvertisementDetails` has a maximum length of 20,000 bytes in UTF-8 encoding.
+    - `SearchBulletPoint` has a maximum length of 80 bytes in UTF-8 encoding.
+    - `SearchSummary` has a maximum length of 150 bytes in UTF-8 encoding.
+  
+  Scheme requirements:
   
   - The `seekAnz` scheme supports the following HTML tags in `AdvertisementDetails`:
-    - `a`
+  
+    - `a` (Available on a per hirer basis. Hirer must contact SEEK to enable.)
     - `br`
     - `div`
     - `em`
@@ -2164,10 +2338,9 @@ input PositionFormattedDescriptionInput {
   
     Other descriptions will have all HTML tags stripped.
   """
-  descriptionId: String!
-  """The HTML content of the description."""
   content: String!
 }
+
 """The details about a person's tenure within the position."""
 type PositionHistory {
   """
@@ -2189,6 +2362,7 @@ type PositionHistory {
   """An array of descriptions of the person's responsibilities, skills and achievements in the position."""
   descriptions: [String!]!
 }
+
 """
 A job requisition or position opening within an organization.
 
@@ -2212,7 +2386,7 @@ type PositionOpening {
   
   The metadata is not used by SEEK and won't be seen by hirers or candidates.
   
-  This field has a maximum length of 1000 characters.
+  This field has a maximum length of 1,000 bytes in UTF-8 encoding.
   """
   seekPartnerMetadata: String
   """
@@ -2228,6 +2402,7 @@ type PositionOpening {
   """
   positionProfiles: [PositionProfile!]!
 }
+
 """A page of position openings."""
 type PositionOpeningConnection {
   """
@@ -2239,6 +2414,7 @@ type PositionOpeningConnection {
   """The pagination metadata for this page of position openings."""
   pageInfo: PageInfo!
 }
+
 """A position opening in a paginated list."""
 type PositionOpeningEdge {
   """
@@ -2250,6 +2426,7 @@ type PositionOpeningEdge {
   """The actual position opening."""
   node: PositionOpening!
 }
+
 """
 The criteria to filter position openings by.
 
@@ -2267,6 +2444,7 @@ input PositionOpeningsFilterInput {
   """
   statusCode: String
 }
+
 """A candidate's preferences in an ideal position."""
 type PositionPreference {
   """
@@ -2276,6 +2454,7 @@ type PositionPreference {
   """
   locations: [PreferredLocation!]!
 }
+
 """A candidate's preferences in an ideal position."""
 input PositionPreferenceInput {
   """
@@ -2287,6 +2466,7 @@ input PositionPreferenceInput {
   """
   locations: [PreferredLocationInput!]!
 }
+
 """
 A profile of a position opening.
 
@@ -2368,16 +2548,13 @@ interface PositionProfile {
   
   The metadata is not used by SEEK and won't be seen by hirers or candidates.
   
-  This field has a maximum length of 1000 characters.
+  This field has a maximum length of 1,000 bytes in UTF-8 encoding.
   """
   seekPartnerMetadata: String
 }
-"""
-The event signaling that a `PositionProfile` has been posted.
 
-Corresponding events for the `updatePostedPositionProfile` and `closePostedPositionProfile` mutations are not currently available.
-"""
-type PositionProfilePostedEvent implements Event {
+"""The event signaling that a posted `PositionProfile` has been closed."""
+type PositionProfileClosedEvent implements Event {
   """The identifier for the `Event`."""
   id: ObjectIdentifier!
   """
@@ -2388,22 +2565,25 @@ type PositionProfilePostedEvent implements Event {
   - `seekAnz`
   """
   schemeId: String!
-  """The type of event, i.e. `PositionProfilePosted`."""
+  """The type of event, i.e. `PositionProfileClosed`."""
   typeCode: String!
   """
-  The date & time the `PositionProfile` was considered as successfully posted inside of SEEK's internal systems.
+  The date & time the `PositionProfile` was closed.
+  
+  `PositionProfile`s are closed automatically when they reach their `PostingInstruction`'s `end` date.
+  They can also be closed early using the `closePostedPositionProfile` mutation.
   
   This field has weak ordering guarantees, so it should not be used as a pagination argument.
   """
   createDateTime: DateTime!
-  """The identifier for the `PositionProfile` that was posted."""
+  """The identifier for the `PositionProfile` that was closed."""
   positionProfileId: String!
   """
-  The `PositionProfile` that was posted.
+  The `PositionProfile` that was closed.
   
   This may return null if the `PositionProfile` has been closed for an extended period of time.
   """
-  positionProfile: PositionProfile
+  positionProfile: PostedPositionProfile
   """
   A page of webhook attempts for the current event matching the specified criteria.
   
@@ -2447,6 +2627,79 @@ type PositionProfilePostedEvent implements Event {
     filter: WebhookAttemptsFilterInput
   ): WebhookAttemptsConnection!
 }
+
+"""The event signaling that a `PositionProfile` has been posted."""
+type PositionProfilePostedEvent implements Event {
+  """The identifier for the `Event`."""
+  id: ObjectIdentifier!
+  """
+  The data source for the event.
+  
+  The following schemes are supported for this event type:
+  
+  - `seekAnz`
+  """
+  schemeId: String!
+  """The type of event, i.e. `PositionProfilePosted`."""
+  typeCode: String!
+  """
+  The date & time the `PositionProfile` was considered as successfully posted inside of SEEK's internal systems.
+  
+  This field has weak ordering guarantees, so it should not be used as a pagination argument.
+  """
+  createDateTime: DateTime!
+  """The identifier for the `PositionProfile` that was posted."""
+  positionProfileId: String!
+  """
+  The `PositionProfile` that was posted.
+  
+  This may return null if the `PositionProfile` has been closed for an extended period of time.
+  """
+  positionProfile: PostedPositionProfile
+  """
+  A page of webhook attempts for the current event matching the specified criteria.
+  
+  A maximum of 100 webhook attempts can be returned in a single page.
+  Additional webhook attempts can be queried using a pagination cursor.
+  
+  The result list is returned in ascending creation date & time order.
+  It starts from the earliest known attempt if no pagination arguments are provided.
+  """
+  webhookAttempts(
+    """
+    An opaque cursor to the earlier bounding webhook attempt.
+    
+    Resulting webhook attempts will _succeed_ this cursor.
+    """
+    after: String
+    """
+    An opaque cursor to the later bounding webhook attempt.
+    
+    Resulting webhook attempts will _precede_ this cursor.
+    """
+    before: String
+    """
+    The upper limit of webhook attempts to return from the start of the list.
+    
+    Defaults to 10 if neither `first` nor `last` are specified.
+    Excess webhook attempts will be trimmed from the end of the list.
+    
+    `first` and `last` cannot be specified in the same query.
+    """
+    first: Int
+    """
+    The upper limit of webhook attempts to return from the end of the list.
+    
+    Excess webhook attempts will be trimmed from the start of the list.
+    
+    `first` and `last` cannot be specified in the same query.
+    """
+    last: Int
+    """The additional `WebhookAttempt`-specific criteria to filter by."""
+    filter: WebhookAttemptsFilterInput
+  ): WebhookAttemptsConnection!
+}
+
 """The information required to post a job ad for a newly created position."""
 input PostPositionInput {
   """The details of the position opening to be created."""
@@ -2454,8 +2707,10 @@ input PostPositionInput {
   """A profile of a position opening."""
   positionProfile: PostPosition_PositionProfileInput!
 }
+
 """The output parameter for the `postPosition` mutation."""
 union PostPositionPayload = PostPositionPayload_Success | PostPositionPayload_Conflict
+
 """
 The conflict result for the `postPosition` mutation.
 
@@ -2468,6 +2723,7 @@ type PostPositionPayload_Conflict {
   """Attributes of the conflicting position profile."""
   conflictingPositionProfile: PostPosition_PositionProfilePayload!
 }
+
 """The success result for the `postPosition` mutation."""
 type PostPositionPayload_Success {
   """Attributes of the newly created position opening."""
@@ -2475,6 +2731,7 @@ type PostPositionPayload_Success {
   """Attributes of the newly created position profile."""
   positionProfile: PostPosition_PositionProfilePayload!
 }
+
 """The input parameter for the `postPositionProfileForOpening` mutation."""
 input PostPositionProfileForOpeningInput {
   """
@@ -2484,8 +2741,10 @@ input PostPositionProfileForOpeningInput {
   """
   positionProfile: PostPositionProfileForOpeningPositionProfileInput!
 }
+
 """The output parameter for the `postPositionProfileForOpening` mutation."""
 union PostPositionProfileForOpeningPayload = PostPositionProfileForOpeningPayload_Success | PostPositionProfileForOpeningPayload_Conflict
+
 """
 The conflict result for the `postPositionProfileForOpening` mutation.
 
@@ -2496,11 +2755,13 @@ type PostPositionProfileForOpeningPayload_Conflict {
   """Attributes of the conflicting position profile."""
   conflictingPositionProfile: PostPositionProfileForOpening_PositionProfilePayload!
 }
+
 """The success result for the `postPositionProfileForOpening` mutation."""
 type PostPositionProfileForOpeningPayload_Success {
   """Attributes of the newly created position profile."""
   positionProfile: PostPositionProfileForOpening_PositionProfilePayload!
 }
+
 """
 A profile for posting a job ad against an existing position opening.
 
@@ -2509,7 +2770,11 @@ This contains information of how a position opening is presented on a given chan
 input PostPositionProfileForOpeningPositionProfileInput {
   """The identifier for the `PositionOpening` that this position profile belongs to."""
   positionOpeningId: String!
-  """A short phrase describing the position as it would be listed on a business card or in a company directory."""
+  """
+  A short phrase describing the position as it would be listed on a business card or in a company directory.
+  
+  This field has a maximum length of 80 bytes in UTF-8 encoding.
+  """
   positionTitle: String!
   """
   An array of identifiers for the `HiringOrganization`s that have the position.
@@ -2519,12 +2784,18 @@ input PostPositionProfileForOpeningPositionProfileInput {
   - The `seekAnz` scheme requires exactly one element.
   """
   positionOrganizations: [String!]!
-  """An optional hirer-provided opaque job reference."""
+  """
+  An optional hirer-provided opaque job reference.
+  
+  This field has a maximum length of 50 bytes in UTF-8 encoding.
+  """
   seekHirerJobReference: String
   """
   An optional opaque billing reference.
   
   This appears on the invoice when SEEK bills the hirer for the job ad.
+  
+  This field has a maximum length of 50 bytes in UTF-8 encoding.
   """
   seekBillingReference: String
   """An array of formatted position profile descriptions."""
@@ -2597,15 +2868,17 @@ input PostPositionProfileForOpeningPositionProfileInput {
   
   The metadata is not used by SEEK and won't be seen by hirers or candidates.
   
-  This field has a maximum length of 1000 characters.
+  This field has a maximum length of 1,000 bytes in UTF-8 encoding.
   """
   seekPartnerMetadata: String
 }
+
 """Attributes of the position profile."""
 type PostPositionProfileForOpening_PositionProfilePayload {
   """The identifier for the `PositionProfile`."""
   profileId: ObjectIdentifier!
 }
+
 """Attributes of the position opening."""
 type PostPosition_PositionOpeningPayload {
   """
@@ -2619,9 +2892,14 @@ type PostPosition_PositionOpeningPayload {
   """
   documentId: ObjectIdentifier!
 }
+
 """The details of the position profile to be created."""
 input PostPosition_PositionProfileInput {
-  """A short phrase describing the position as it would be listed on a business card or in a company directory."""
+  """
+  A short phrase describing the position as it would be listed on a business card or in a company directory.
+  
+  This field has a maximum length of 80 bytes in UTF-8 encoding.
+  """
   positionTitle: String!
   """
   An array of identifiers for the `HiringOrganization`s that have the position.
@@ -2634,15 +2912,15 @@ input PostPosition_PositionProfileInput {
   """
   An optional hirer-provided opaque job reference.
   
-  Scheme requirements:
-  
-  - The `seekAnz` scheme requires this field to have a maximum length of 50 characters.
+  This field has a maximum length of 50 bytes in UTF-8 encoding.
   """
   seekHirerJobReference: String
   """
   An optional opaque billing reference.
   
   This appears on the invoice when SEEK bills the hirer for the job ad.
+  
+  This field has a maximum length of 50 bytes in UTF-8 encoding.
   """
   seekBillingReference: String
   """An array of formatted position profile descriptions."""
@@ -2715,10 +2993,11 @@ input PostPosition_PositionProfileInput {
   
   The metadata is not used by SEEK and won't be seen by hirers or candidates.
   
-  This field has a maximum length of 1000 characters.
+  This field has a maximum length of 1,000 bytes in UTF-8 encoding.
   """
   seekPartnerMetadata: String
 }
+
 """Attributes of the position profile."""
 type PostPosition_PositionProfilePayload {
   """
@@ -2732,6 +3011,7 @@ type PostPosition_PositionProfilePayload {
   """
   profileId: ObjectIdentifier!
 }
+
 """
 A profile of a position opening.
 
@@ -2809,10 +3089,11 @@ type PostedPositionProfile implements PositionProfile {
   
   The metadata is not used by SEEK and won't be seen by hirers or candidates.
   
-  This field has a maximum length of 1000 characters.
+  This field has a maximum length of 1,000 bytes in UTF-8 encoding.
   """
   seekPartnerMetadata: String
 }
+
 """A collection of information about where and how to post a job ad."""
 type PostingInstruction {
   """The start date of the posting."""
@@ -2848,6 +3129,7 @@ type PostingInstruction {
   """The branding applied to the posted job ad."""
   branding: AdvertisementBranding
 }
+
 """The party that owns the position opening."""
 type PostingRequester {
   """
@@ -2877,6 +3159,7 @@ type PostingRequester {
   """Specific contact people for the position opening at the party."""
   personContacts: [SpecifiedPerson!]!
 }
+
 """The party that owns the position opening."""
 input PostingRequesterInput {
   """The identifier for the `HiringOrganization` that owns the position opening."""
@@ -2897,16 +3180,19 @@ input PostingRequesterInput {
   """
   personContacts: [SpecifiedPersonInput!]!
 }
+
 """A candidate's preferences in the location of a position."""
 type PreferredLocation {
   """The address that represents the preferred location."""
   referenceLocation: Address
 }
+
 """A candidate's preferences in the location of a position."""
 input PreferredLocationInput {
   """The address that represents the preferred location."""
   referenceLocation: AddressInput
 }
+
 """
 The schema's entry-point for queries.
 
@@ -3254,50 +3540,6 @@ type Query {
     schemeId: String!
   ): EventsConnection!
   """
-  A page of webhook attempts matching the specified criteria generated by a selected subscription.
-  
-  A maximum of 100 webhook attempts can be returned in a single page.
-  Additional webhook attempts can be queried using a pagination cursor.
-  
-  The result list is returned in ascending creation date & time order.
-  It starts from the earliest known attempt if no pagination arguments are provided.
-  """
-  webhookAttemptsForSubscription(
-    """
-    An opaque cursor to the earlier bounding webhook attempt.
-    
-    Resulting webhook attempts will _succeed_ this cursor.
-    """
-    after: String
-    """
-    An opaque cursor to the later bounding webhook attempt.
-    
-    Resulting webhook attempts will _precede_ this cursor.
-    """
-    before: String
-    """
-    The upper limit of webhook attempts to return from the start of the list.
-    
-    Defaults to 10 if neither `first` nor `last` are specified.
-    Excess webhook attempts will be trimmed from the end of the list.
-    
-    `first` and `last` cannot be specified in the same query.
-    """
-    first: Int
-    """
-    The upper limit of webhook attempts to return from the end of the list.
-    
-    Excess webhook attempts will be trimmed from the start of the list.
-    
-    `first` and `last` cannot be specified in the same query.
-    """
-    last: Int
-    """The additional `WebhookAttempt`-specific criteria to filter by."""
-    filter: WebhookAttemptsFilterInput
-    """The identifier for the `WebhookSubscription` that generated the attempts."""
-    subscriptionId: String!
-  ): WebhookAttemptsConnection!
-  """
   A page of webhook attempts matching the specified criteria generated by a selected event.
   
   A maximum of 100 webhook attempts can be returned in a single page.
@@ -3443,7 +3685,7 @@ type Query {
     filter: WebhookRequestFilterInput
     """The identifier for the `WebhookSubscription` that generated the requests."""
     subscriptionId: String!
-  ): WebhookRequestConnection!
+  ): WebhookRequestsConnection!
   """The webhook request for the given `requestId`."""
   webhookRequest(
     """
@@ -3462,6 +3704,7 @@ type Query {
     requestId: String!
   ): WebhookRequest
 }
+
 """A monetary amount of remuneration in a specified currency."""
 type RemunerationAmount {
   """
@@ -3473,6 +3716,7 @@ type RemunerationAmount {
   """The three-letter ISO 4217 currency code, in uppercase."""
   currency: String!
 }
+
 """A monetary amount of remuneration in a specified currency."""
 input RemunerationAmountInput {
   """
@@ -3486,12 +3730,17 @@ input RemunerationAmountInput {
   
   For the `seekAnz` scheme, a single currency is accepted in each location:
   
-  - `NZD` is used by New Zealand (`seekAnz:location:seek:2b9U8B8Es`) and its children
-  - `GBP` is used by the UK & Ireland (`seekAnz:location:seek:2beMJFcmV`) and their children
+  - `NZD` is used by locations in New Zealand.
+    These are `Location`s that have a `countryCode` of `NZ`.
+  
+  - `GBP` is used by locations in the UK & Ireland.
+    These are `Location`s that have a `countryCode` of `GB` or `IE`.
+  
   - `AUD` is used by all other locations
   """
   currency: String!
 }
+
 """The salary or compensation for a position."""
 type RemunerationPackage {
   """
@@ -3520,6 +3769,7 @@ type RemunerationPackage {
   """
   descriptions: [String!]!
 }
+
 """The salary or compensation for a position."""
 input RemunerationPackageInput {
   """
@@ -3554,6 +3804,7 @@ input RemunerationPackageInput {
   """
   descriptions: [String!]!
 }
+
 """A salary or compensation range for a position."""
 type RemunerationRange {
   """The minimum amount an organization is willing to pay for a position."""
@@ -3574,6 +3825,7 @@ type RemunerationRange {
   """
   intervalCode: String!
 }
+
 """A salary or compensation range for a position."""
 input RemunerationRangeInput {
   """The minimum amount an organization is willing to pay for a position."""
@@ -3598,6 +3850,7 @@ input RemunerationRangeInput {
   """
   intervalCode: String!
 }
+
 """The input parameter for the `replayWebhookSubscription` mutation."""
 input ReplayWebhookSubscriptionInput {
   """The details of the webhook subscription to be replayed."""
@@ -3605,11 +3858,13 @@ input ReplayWebhookSubscriptionInput {
   """The additional fields to filter which events are to be replayed."""
   filter: ReplayWebhookSubscription_FilterInput
 }
+
 """The output parameter for the `replayWebhookSubscription` mutation."""
 type ReplayWebhookSubscriptionPayload {
   """The details of the webhook subscription to have its messages redelivered."""
   webhookSubscription: WebhookSubscription!
 }
+
 """The criteria used to decide which events will be replayed."""
 input ReplayWebhookSubscription_FilterInput {
   """
@@ -3631,11 +3886,13 @@ input ReplayWebhookSubscription_FilterInput {
   """
   createdBeforeDateTime: DateTime
 }
+
 """The details of the webhook subscription to be replayed."""
 input ReplayWebhookSubscription_SubscriptionInput {
   """The identifier for the `WebhookSubscription`."""
   id: String!
 }
+
 """The details of an available ad product."""
 type SeekAnzAdProduct {
   """
@@ -3663,6 +3920,7 @@ type SeekAnzAdProduct {
   """Features this product supports."""
   features: SeekAnzAdProductFeatures!
 }
+
 """
 The input parameter for a draft advertisement.
 
@@ -3688,6 +3946,7 @@ input SeekAnzAdProductAdvertisementDraftInput {
   """The identifier for the position's `Location`."""
   positionLocationId: String
 }
+
 """The input parameter for the `seekAnzHirerAdvertisementModificationProductsAlt` query."""
 input SeekAnzAdProductAdvertisementInput {
   """
@@ -3711,6 +3970,7 @@ input SeekAnzAdProductAdvertisementInput {
   """The identifier for the position's `Location`."""
   positionLocationId: String!
 }
+
 """The details of the outstanding payment."""
 type SeekAnzAdProductCheckoutEstimate {
   """The amount left to be paid."""
@@ -3720,6 +3980,7 @@ type SeekAnzAdProductCheckoutEstimate {
   """Contract component of the checkout estimate."""
   contractConsumption: SeekAnzAdProductContractConsumption
 }
+
 """The details of changes to the hirer's contract consumption."""
 type SeekAnzAdProductContractConsumption {
   """Summary of contract consumption."""
@@ -3735,6 +3996,7 @@ type SeekAnzAdProductContractConsumption {
   """
   typeCode: String!
 }
+
 """The indicators of supported ad product features."""
 type SeekAnzAdProductFeatures {
   """
@@ -3750,6 +4012,7 @@ type SeekAnzAdProductFeatures {
   """
   searchBulletPointsIndicator: Boolean!
 }
+
 """A message shown to the hirer for the current ad product."""
 type SeekAnzAdProductMessage {
   """
@@ -3783,6 +4046,7 @@ type SeekAnzAdProductMessage {
   """The content of the message."""
   content: String!
 }
+
 """The price for an ad product."""
 type SeekAnzAdProductPrice {
   """The product price without tax."""
@@ -3794,6 +4058,7 @@ type SeekAnzAdProductPrice {
   """Whether taxes will be added when purchased."""
   taxedIndicator: Boolean!
 }
+
 """The role of an attachment within a profile."""
 enum SeekAttachmentRole {
   """A resume or CV."""
@@ -3803,16 +4068,19 @@ enum SeekAttachmentRole {
   """A document supporting a position-specific selection criteria."""
   SELECTION_CRITERIA
 }
+
 """The source system for the process history item."""
 type SeekProcessHistoryItemSource {
   """Free text description of the source."""
   name: String!
 }
+
 """The source system for the process history item."""
 input SeekProcessHistoryItemSourceInput {
   """Free text description of the source."""
   name: String!
 }
+
 """A collection of information about the video to display alongside advertisement details."""
 type SeekVideo {
   """The URL of the video."""
@@ -3827,6 +4095,7 @@ type SeekVideo {
   """
   seekAnzPositionCode: String
 }
+
 """A collection of information about the video to display alongside advertisement details."""
 input SeekVideoInput {
   """
@@ -3834,7 +4103,7 @@ input SeekVideoInput {
   
   Scheme requirements:
   
-   - The `seekAnz` scheme requires URLs to be YouTube embed URLs less than 255 characters e.g. `https://www.youtube.com/embed/aAgePQvHBQM`.
+   - The `seekAnz` scheme requires URLs to be YouTube embed URLs, e.g. `https://www.youtube.com/embed/aAgePQvHBQM`.
   """
   url: String!
   """
@@ -3847,6 +4116,7 @@ input SeekVideoInput {
   """
   seekAnzPositionCode: String
 }
+
 """A reference to a person associated with an object."""
 type SpecifiedPerson {
   """The person's name."""
@@ -3863,6 +4133,7 @@ type SpecifiedPerson {
   """
   roleCode: String
 }
+
 """A reference to a person associated with an object."""
 input SpecifiedPersonInput {
   """The person's name."""
@@ -3879,6 +4150,7 @@ input SpecifiedPersonInput {
   """
   roleCode: String
 }
+
 """
 A profile of a position opening.
 
@@ -3887,6 +4159,12 @@ This contains information of how a position opening is presented as an internal 
 type UnpostedPositionProfile implements PositionProfile {
   """The identifier for the `PositionProfile`."""
   profileId: ObjectIdentifier!
+  """
+  A human-readable name given to the profile.
+  
+  This in addition to the `positionTitle` can help identify the profile to an end user.
+  """
+  profileName: String
   """The `PositionOpening` that this profile was created under."""
   positionOpening: PositionOpening!
   """The type of position profile, i.e. `UnpostedPositionProfile`."""
@@ -3956,20 +4234,23 @@ type UnpostedPositionProfile implements PositionProfile {
   
   The metadata is not used by SEEK and won't be seen by hirers or candidates.
   
-  This field has a maximum length of 1000 characters.
+  This field has a maximum length of 1,000 bytes in UTF-8 encoding.
   """
   seekPartnerMetadata: String
 }
+
 """The input parameter for the `updateCandidateProcessHistoryItem` mutation."""
 input UpdateCandidateProcessHistoryItemInput {
   """The details of the  `CandidateProcessHistoryItem` to be updated."""
   candidateProcessHistoryItem: UpdateCandidateProcessHistoryItem_CandidateProcessHistoryItemInput!
 }
+
 """The output parameter for the `updateCandidateProcessHistoryItem` mutation."""
 type UpdateCandidateProcessHistoryItemPayload {
   """The details of the `CandidateProcessHistoryItem` that was updated."""
   candidateProcessHistoryItem: CandidateProcessHistoryItem!
 }
+
 """The details of the `CandidateProcessHistoryItem` to be updated."""
 input UpdateCandidateProcessHistoryItem_CandidateProcessHistoryItemInput {
   """The identifier for the `CandidateProcessHistoryItem` to be updated."""
@@ -4008,16 +4289,19 @@ input UpdateCandidateProcessHistoryItem_CandidateProcessHistoryItemInput {
   """The parties that executed the action."""
   primaryParties: [CandidateProcessPartyInput!]!
 }
+
 """The input parameter for the `updatePositionOpeningPersonContacts` mutation."""
 input UpdatePositionOpeningPersonContactsInput {
   """The details of the position opening to be updated."""
   positionOpening: UpdatePositionOpeningPersonContactsPositionOpeningInput!
 }
+
 """The output parameter for the `updatePositionOpeningPersonContacts` mutation."""
 type UpdatePositionOpeningPersonContactsPayload {
   """The details of the updated position opening."""
   positionOpening: PositionOpening!
 }
+
 """The details of the position opening to be updated."""
 input UpdatePositionOpeningPersonContactsPositionOpeningInput {
   """The identifier for the `PositionOpening` to be updated."""
@@ -4030,16 +4314,19 @@ input UpdatePositionOpeningPersonContactsPositionOpeningInput {
   """
   personContacts: [SpecifiedPersonInput!]!
 }
+
 """The input parameter for the `updatePositionOpeningStatus` mutation."""
 input UpdatePositionOpeningStatusInput {
   """The details of the position opening to be updated."""
   positionOpening: UpdatePositionOpeningStatusPositionOpeningInput!
 }
+
 """The output parameter for the `updatePositionOpeningStatus` mutation."""
 type UpdatePositionOpeningStatusPayload {
   """The details of the updated position opening."""
   positionOpening: PositionOpening!
 }
+
 """The details of the position opening to have its status updated."""
 input UpdatePositionOpeningStatusPositionOpeningInput {
   """The identifier for the `PositionOpening` to be updated."""
@@ -4055,21 +4342,28 @@ input UpdatePositionOpeningStatusPositionOpeningInput {
   """
   statusCode: String!
 }
+
 """The input parameter for the `updatePostedPositionProfile` mutation."""
 input UpdatePostedPositionProfileInput {
   """The values to replace on a posted position profile."""
   positionProfile: UpdatePostedPositionProfile_PositionProfileInput!
 }
+
 """The output of the `updatePostedPositionProfile` mutation."""
 type UpdatePostedPositionProfilePayload {
   """Attributes of the updated position profile."""
   positionProfile: UpdatePostedPositionProfile_PositionProfilePayload!
 }
+
 """The values to replace on a posted position profile."""
 input UpdatePostedPositionProfile_PositionProfileInput {
   """The identifier for the posted `PositionProfile` to update."""
   profileId: String!
-  """A short phrase describing the position as it would be listed on a business card or in a company directory."""
+  """
+  A short phrase describing the position as it would be listed on a business card or in a company directory.
+  
+  This field has a maximum length of 80 bytes in UTF-8 encoding.
+  """
   positionTitle: String!
   """
   An array of identifiers for the `HiringOrganization`s that have the position.
@@ -4079,12 +4373,18 @@ input UpdatePostedPositionProfile_PositionProfileInput {
   - The `seekAnz` scheme requires exactly one element.
   """
   positionOrganizations: [String!]!
-  """An optional hirer-provided opaque job reference."""
+  """
+  An optional hirer-provided opaque job reference.
+  
+  This field has a maximum length of 50 bytes in UTF-8 encoding.
+  """
   seekHirerJobReference: String
   """
   An optional opaque billing reference.
   
   This appears on the invoice when SEEK bills the hirer for the job ad.
+  
+  This field has a maximum length of 50 bytes in UTF-8 encoding.
   """
   seekBillingReference: String
   """An array of formatted position profile descriptions."""
@@ -4161,15 +4461,17 @@ input UpdatePostedPositionProfile_PositionProfileInput {
   
   The metadata is not used by SEEK and won't be seen by hirers or candidates.
   
-  This field has a maximum length of 1000 characters.
+  This field has a maximum length of 1,000 bytes in UTF-8 encoding.
   """
   seekPartnerMetadata: String
 }
+
 """Attributes of the updated position profile."""
 type UpdatePostedPositionProfile_PositionProfilePayload {
   """The identifier for the updated `PositionProfile`."""
   profileId: ObjectIdentifier!
 }
+
 """A collection of information about where and how to post a job ad."""
 input UpdatePostingInstructionInput {
   """
@@ -4212,24 +4514,49 @@ input UpdatePostingInstructionInput {
   """
   brandingId: String
 }
+
 """The input parameter for the `updateUnpostedPositionProfile` mutation."""
 input UpdateUnpostedPositionProfileInput {
   """An unposted profile of a position opening to update."""
   positionProfile: UpdateUnpostedPositionProfile_PositionProfileInput!
 }
+
 """The output parameter for the `updateUnpostedPositionProfile` mutation."""
 type UpdateUnpostedPositionProfilePayload {
   """Attributes of the updated unposted position profile."""
-  positionProfile: PositionProfile!
+  positionProfile: UnpostedPositionProfile!
 }
+
 """An unposted profile of a position opening to update."""
 input UpdateUnpostedPositionProfile_PositionProfileInput {
   """The identifier for the unposted `PositionProfile` to update."""
   profileId: String!
-  """A short phrase describing the position as it would be listed on a business card or in a company directory."""
+  """
+  A human-readable name given to the profile.
+  
+  This in addition to the `positionTitle` can help identify the profile to an end user.
+  """
+  profileName: String
+  """
+  A short phrase describing the position as it would be listed on a business card or in a company directory.
+  
+  This field has a maximum length of 80 bytes in UTF-8 encoding.
+  """
   positionTitle: String!
-  """An optional hirer-provided opaque job reference."""
+  """
+  An optional hirer-provided opaque job reference.
+  
+  This field has a maximum length of 50 bytes in UTF-8 encoding.
+  """
   seekHirerJobReference: String
+  """
+  An optional opaque billing reference.
+  
+  SEEK does not use this field on unposted position profiles.
+  
+  This field has a maximum length of 50 bytes in UTF-8 encoding.
+  """
+  seekBillingReference: String
   """
   An array of formatted position profile descriptions.
   
@@ -4264,27 +4591,32 @@ input UpdateUnpostedPositionProfile_PositionProfileInput {
   
   The metadata is not used by SEEK and won't be seen by hirers or candidates.
   
-  This field has a maximum length of 1000 characters.
+  This field has a maximum length of 1,000 bytes in UTF-8 encoding.
   """
   seekPartnerMetadata: String
 }
+
 """The input parameter for the `updateUploadedCandidatePerson` mutation."""
 input UpdateUploadedCandidatePersonInput {
   """The details of the uploaded candidate to be updated."""
   candidate: UpdateUploadedCandidatePerson_CandidateInput!
 }
+
 """The output parameter for the `updateUploadedCandidatePerson` mutation."""
 union UpdateUploadedCandidatePersonPayload = UpdateUploadedCandidatePersonPayload_Conflict | UpdateUploadedCandidatePersonPayload_Success
+
 """The conflict result for the `updateUploadedCandidatePerson` mutation."""
 type UpdateUploadedCandidatePersonPayload_Conflict {
   """The details of the conflicting candidate."""
   conflictingCandidate: Candidate!
 }
+
 """The success result for the `updateUploadedCandidatePerson` mutation."""
 type UpdateUploadedCandidatePersonPayload_Success {
   """The details of the uploaded candidate that was updated."""
   candidate: Candidate!
 }
+
 """The details of the uploaded candidate to be updated."""
 input UpdateUploadedCandidatePerson_CandidateInput {
   """The identifier for the uploaded `Candidate` to be updated."""
@@ -4311,11 +4643,13 @@ input UpdateUploadedCandidatePerson_CandidateInput {
   """
   seekPrimaryEmailAddress: String!
 }
+
 """The input parameter for the `updateUploadedCandidateProfileActions` mutation."""
 input UpdateUploadedCandidateProfileActionsInput {
   """The details of the uploaded candidate profile to be updated."""
   candidateProfile: UpdateUploadedCandidateProfileActions_CandidateProfileInput!
 }
+
 """The output parameter for the `updateUploadedCandidateProfileActions` mutation."""
 type UpdateUploadedCandidateProfileActionsPayload {
   """
@@ -4325,6 +4659,7 @@ type UpdateUploadedCandidateProfileActionsPayload {
   """
   candidateProfile: CandidateProfile!
 }
+
 """The details of the uploaded candidate profile to be updated."""
 input UpdateUploadedCandidateProfileActions_CandidateProfileInput {
   """The identifier for the uploaded `CandidateProfile` to be updated."""
@@ -4340,11 +4675,13 @@ input UpdateUploadedCandidateProfileActions_CandidateProfileInput {
   """
   seekActions: [CandidateProcessActionInput!]!
 }
+
 """The input parameter for the `updateUploadedCandidateProfileDates` mutation."""
 input UpdateUploadedCandidateProfileDatesInput {
   """The details of the uploaded candidate profile to be updated."""
   candidateProfile: UpdateUploadedCandidateProfileDates_CandidateProfileInput!
 }
+
 """The output parameter for the `updateUploadedCandidateProfileDates` mutation."""
 type UpdateUploadedCandidateProfileDatesPayload {
   """
@@ -4354,6 +4691,7 @@ type UpdateUploadedCandidateProfileDatesPayload {
   """
   candidateProfile: CandidateProfile!
 }
+
 """The details of the uploaded candidate profile to be updated."""
 input UpdateUploadedCandidateProfileDates_CandidateProfileInput {
   """The identifier for the uploaded `CandidateProfile` to be updated."""
@@ -4373,11 +4711,13 @@ input UpdateUploadedCandidateProfileDates_CandidateProfileInput {
   """
   updateDateTime: DateTime!
 }
+
 """The input parameter for the `updateUploadedCandidateProfilePositionPreferences` mutation."""
 input UpdateUploadedCandidateProfilePositionPreferencesInput {
   """The details of the uploaded candidate profile to be updated."""
   candidateProfile: UpdateUploadedCandidateProfilePositionPreferences_CandidateProfileInput!
 }
+
 """The output parameter for the `updateUploadedCandidateProfilePositionPreferences` mutation."""
 type UpdateUploadedCandidateProfilePositionPreferencesPayload {
   """
@@ -4387,6 +4727,7 @@ type UpdateUploadedCandidateProfilePositionPreferencesPayload {
   """
   candidateProfile: CandidateProfile!
 }
+
 """The details of the uploaded candidate profile to be updated."""
 input UpdateUploadedCandidateProfilePositionPreferences_CandidateProfileInput {
   """The identifier for the uploaded `CandidateProfile` to be updated."""
@@ -4403,18 +4744,21 @@ input UpdateUploadedCandidateProfilePositionPreferences_CandidateProfileInput {
   """
   positionPreferences: [PositionPreferenceInput!]!
 }
+
 """The input parameter for the `updateWebhookSubscriptionDeliveryConfiguration` mutation."""
 input UpdateWebhookSubscriptionDeliveryConfigurationInput {
   """The details of the webhook subscription to be updated."""
-  webhookSubscription: UpdateWebhookSubscriptionDeliveryConfigurationSubscriptionInput!
+  webhookSubscription: UpdateWebhookSubscriptionDeliveryConfiguration_SubscriptionInput!
 }
+
 """The output parameter for the `updateWebhookSubscriptionDeliveryConfiguration` mutation."""
 type UpdateWebhookSubscriptionDeliveryConfigurationPayload {
   """The details of the updated webhook subscription."""
   webhookSubscription: WebhookSubscription!
 }
+
 """The details of the webhook subscription delivery configuration to be updated."""
-input UpdateWebhookSubscriptionDeliveryConfigurationSubscriptionInput {
+input UpdateWebhookSubscriptionDeliveryConfiguration_SubscriptionInput {
   """The identifier for the `WebhookSubscription`."""
   id: String!
   """The subscriber-owned URL where events will be sent to."""
@@ -4425,6 +4769,24 @@ input UpdateWebhookSubscriptionDeliveryConfigurationSubscriptionInput {
   This number must be between 1 and 10 inclusive. Defaults to 10.
   """
   maxEventsPerAttempt: Int
+}
+
+"""The input parameter for the `updateWebhookSubscriptionSigningConfiguration` mutation."""
+input UpdateWebhookSubscriptionSigningConfigurationInput {
+  """The details of the webhook subscription to be updated."""
+  webhookSubscription: UpdateWebhookSubscriptionSigningConfiguration_SubscriptionInput!
+}
+
+"""The output parameter for the `updateWebhookSubscriptionSigningConfiguration` mutation."""
+type UpdateWebhookSubscriptionSigningConfigurationPayload {
+  """The details of the updated webhook subscription."""
+  webhookSubscription: WebhookSubscription!
+}
+
+"""The details of the webhook subscription signing configuration to be updated."""
+input UpdateWebhookSubscriptionSigningConfiguration_SubscriptionInput {
+  """The identifier for the `WebhookSubscription`."""
+  id: String!
   """
   The algorithm for signing webhooks.
   
@@ -4449,6 +4811,7 @@ input UpdateWebhookSubscriptionDeliveryConfigurationSubscriptionInput {
   """
   secret: String
 }
+
 """The input parameter for the `uploadCandidate` mutation."""
 input UploadCandidateInput {
   """The details of the `Candidate` to be uploaded."""
@@ -4458,8 +4821,10 @@ input UploadCandidateInput {
   """The details of the `HiringOrganization` that submitted the candidate profile."""
   hiringOrganization: UploadCandidate_HiringOrganizationInput!
 }
+
 """The output parameter for the `uploadCandidate` mutation."""
 union UploadCandidatePayload = UploadCandidatePayload_Conflict | UploadCandidatePayload_Success
+
 """The conflict result for the `uploadCandidate` mutation."""
 type UploadCandidatePayload_Conflict {
   """
@@ -4471,6 +4836,7 @@ type UploadCandidatePayload_Conflict {
   """The details of the hiring organization that uploaded the candidate and their profile."""
   hiringOrganization: HiringOrganization!
 }
+
 """The success result for the `uploadCandidate` mutation."""
 type UploadCandidatePayload_Success {
   """
@@ -4482,6 +4848,7 @@ type UploadCandidatePayload_Success {
   """The details of the hiring organization that uploaded the candidate and their profile."""
   hiringOrganization: HiringOrganization!
 }
+
 """The details of the candidate to be uploaded."""
 input UploadCandidate_CandidateInput {
   """
@@ -4513,6 +4880,7 @@ input UploadCandidate_CandidateInput {
   """
   person: CandidatePersonInput!
 }
+
 """The details of the candidate profile to be uploaded."""
 input UploadCandidate_CandidateProfileInput {
   """
@@ -4557,21 +4925,25 @@ input UploadCandidate_CandidateProfileInput {
   """
   seekActions: [CandidateProcessActionInput!]!
 }
+
 """Details of the `HiringOrganization` that submitted the candidate profile."""
 input UploadCandidate_HiringOrganizationInput {
   """The identifier for the `HiringOrganization` that submitted the candidate profile."""
   id: String!
 }
+
 """An address of a human-accessible web page."""
 type WebUrl {
   """The URL of the web page."""
   url: String!
 }
+
 """An address of a human-accessible web page."""
 input WebUrlInput {
   """The URL of the web page."""
   url: String!
 }
+
 """An attempt to deliver a specific `Event` to a `WebhookSubscription`."""
 type WebhookAttempt {
   """The identifier for the `WebhookAttempt`."""
@@ -4589,6 +4961,7 @@ type WebhookAttempt {
   """The HTTP request containing the webhook attempt."""
   webhookRequest: WebhookRequest!
 }
+
 """A webhook attempt in a paginated list."""
 type WebhookAttemptEdge {
   """
@@ -4600,6 +4973,7 @@ type WebhookAttemptEdge {
   """The actual webhook attempt."""
   node: WebhookAttempt!
 }
+
 """A page of webhook attempts."""
 type WebhookAttemptsConnection {
   """
@@ -4611,6 +4985,7 @@ type WebhookAttemptsConnection {
   """The pagination metadata for this page of webhook attempts."""
   pageInfo: PageInfo!
 }
+
 """
 The criteria to filter webhook attempts by.
 
@@ -4640,6 +5015,7 @@ input WebhookAttemptsFilterInput {
   """
   descriptionCodes: [String!]
 }
+
 """
 An HTTP request to a `WebhookSubscription`.
 
@@ -4693,17 +5069,7 @@ type WebhookRequest {
   """The list of events that were attempted to be delivered in the request body."""
   attempts: [WebhookAttempt!]!
 }
-"""A page of webhook requests."""
-type WebhookRequestConnection {
-  """
-  The page of webhook requests and their corresponding cursors.
-  
-  This is always a non-empty list.
-  """
-  edges: [WebhookRequestEdge!]!
-  """The pagination metadata for this page of webhook requests."""
-  pageInfo: PageInfo!
-}
+
 """A webhook request in a paginated list."""
 type WebhookRequestEdge {
   """
@@ -4715,6 +5081,7 @@ type WebhookRequestEdge {
   """The actual webhook request."""
   node: WebhookRequest!
 }
+
 """
 The criteria to filter webhook requests by.
 
@@ -4725,14 +5092,14 @@ input WebhookRequestFilterInput {
   The creation date & time that resulting webhook requests must succeed.
   
   This can be used to initiate the retrieval of paginated results.
-  Subsequent queries should use the opaque cursors returned from `WebhookRequestConnection`.
+  Subsequent queries should use the opaque cursors returned from `WebhookRequestsConnection`.
   """
   afterDateTime: DateTime
   """
   The creation date & time that resulting webhook requests must precede.
   
   This can be used to initiate the retrieval of paginated results.
-  Subsequent queries should use the opaque cursors returned from `WebhookRequestConnection`.
+  Subsequent queries should use the opaque cursors returned from `WebhookRequestsConnection`.
   """
   beforeDateTime: DateTime
   """
@@ -4744,6 +5111,19 @@ input WebhookRequestFilterInput {
   """
   descriptionCodes: [String!]
 }
+
+"""A page of webhook requests."""
+type WebhookRequestsConnection {
+  """
+  The page of webhook requests and their corresponding cursors.
+  
+  This is always a non-empty list.
+  """
+  edges: [WebhookRequestEdge!]!
+  """The pagination metadata for this page of webhook requests."""
+  pageInfo: PageInfo!
+}
+
 """
 A subscription for a given event type and scheme to be delivered via webhook.
 
@@ -4772,6 +5152,15 @@ type WebhookSubscription {
   A non-null `hirerId` indicates that this subscription is filtered to a single hirer.
   """
   hirerId: ObjectIdentifier
+  """
+  The optional hirer associated with this webhook subscription.
+  
+  This will only be accessible if there is an active relationship between the partner and hirer.
+  
+  By default webhook subscriptions will send events from all hirers the partner has access to.
+  A non-null `hirer` field indicates that this subscription is filtered to a single hirer.
+  """
+  hirer: HiringOrganization
   """The subscriber-owned URL where events are sent to."""
   url: String!
   """
@@ -4803,47 +5192,47 @@ type WebhookSubscription {
   """The date & time the webhook subscription was last updated."""
   updateDateTime: DateTime!
   """
-  A page of webhook attempts for the current subscription matching the specified criteria.
+  A page of webhook requests for the subscription matching the specified criteria.
   
-  A maximum of 100 webhook attempts can be returned in a single page.
-  Additional webhook attempts can be queried using a pagination cursor.
+  A maximum of 100 webhook requests can be returned in a single page.
+  Additional webhook requests can be queried using a pagination cursor.
   
   The result list is returned in ascending creation date & time order.
-  It starts from the earliest known attempt if no pagination arguments are provided.
+  It starts from the earliest known request if no pagination arguments are provided.
   """
-  webhookAttempts(
+  webhookRequests(
     """
-    An opaque cursor to the earlier bounding webhook attempt.
+    An opaque cursor to the earlier bounding webhook request.
     
-    Resulting webhook attempts will _succeed_ this cursor.
+    Resulting webhook requests will _succeed_ this cursor.
     """
     after: String
     """
-    An opaque cursor to the later bounding webhook attempt.
+    An opaque cursor to the later bounding webhook request.
     
-    Resulting webhook attempts will _precede_ this cursor.
+    Resulting webhook requests will _precede_ this cursor.
     """
     before: String
     """
-    The upper limit of webhook attempts to return from the start of the list.
+    The upper limit of webhook requests to return from the start of the list.
     
     Defaults to 10 if neither `first` nor `last` are specified.
-    Excess webhook attempts will be trimmed from the end of the list.
+    Excess webhook requests will be trimmed from the end of the list.
     
     `first` and `last` cannot be specified in the same query.
     """
     first: Int
     """
-    The upper limit of webhook attempts to return from the end of the list.
+    The upper limit of webhook requests to return from the end of the list.
     
-    Excess webhook attempts will be trimmed from the start of the list.
+    Excess webhook requests will be trimmed from the start of the list.
     
     `first` and `last` cannot be specified in the same query.
     """
     last: Int
-    """The additional `WebhookAttempts`-specific criteria to filter by."""
-    filter: WebhookAttemptsFilterInput
-  ): WebhookAttemptsConnection!
+    """The additional `WebhookRequest`-specific criteria to filter by."""
+    filter: WebhookRequestFilterInput
+  ): WebhookRequestsConnection!
   """
   A page of replays for the current webhook subscription matching the specified criteria.
   
@@ -4887,6 +5276,7 @@ type WebhookSubscription {
     filter: WebhookSubscriptionReplaysFilterInput
   ): WebhookSubscriptionReplaysConnection!
 }
+
 """A webhook subscription in a paginated list."""
 type WebhookSubscriptionEdge {
   """
@@ -4898,6 +5288,7 @@ type WebhookSubscriptionEdge {
   """The actual webhook subscription."""
   node: WebhookSubscription!
 }
+
 """The state of a request to replay events for a `WebhookSubscription`."""
 type WebhookSubscriptionReplay {
   """The identifier for the `WebhookSubscriptionReplay`."""
@@ -4928,6 +5319,7 @@ type WebhookSubscriptionReplay {
   """
   statusCode: String!
 }
+
 """A webhook subscription replay in a paginated list."""
 type WebhookSubscriptionReplayEdge {
   """
@@ -4939,6 +5331,7 @@ type WebhookSubscriptionReplayEdge {
   """The actual webhook subscription replay."""
   node: WebhookSubscriptionReplay!
 }
+
 """A page of webhook subscription replays."""
 type WebhookSubscriptionReplaysConnection {
   """
@@ -4954,11 +5347,11 @@ type WebhookSubscriptionReplaysConnection {
   - The property `hasPreviousPage` will always be false when paginating by `first`
   - The property `hasNextPage` will always be false when paginating by `last`
   
-  To discern whether a next/previous page exists in these conditions, an additional request will need to be made
-  to retrieve the next/previous page.
+  To discern whether a next/previous page exists in these conditions, an additional request will need to be made to retrieve the next/previous page.
   """
   pageInfo: PageInfo!
 }
+
 """
 The criteria to filter webhook subscription replays by.
 
@@ -4974,6 +5367,7 @@ input WebhookSubscriptionReplaysFilterInput {
   """
   statusCode: String
 }
+
 """A page of webhook subscriptions."""
 type WebhookSubscriptionsConnection {
   """
@@ -4985,6 +5379,7 @@ type WebhookSubscriptionsConnection {
   """The pagination metadata for this page of subscriptions."""
   pageInfo: PageInfo!
 }
+
 """
 The criteria to filter webhook subscriptions by.
 
@@ -5020,5 +5415,7 @@ input WebhookSubscriptionsFilterInput {
   """
   hirerIds: [String!]
 }
+
 directive @complexity(value: Int!, multipliers: [String!]) on FIELD_DEFINITION
+
 directive @paginated(defaultPageSize: Int!) on FIELD_DEFINITION


### PR DESCRIPTION
- Use typed GraphQL operations

- Don't query our children's parent. This is unneeded and increases the complexity of our GraphQL operation

- Inline the `nestedJobCategoryAttributes` fragements only used in a single place

- Type our props to only include the fields we're selecting, not the entire infinite `JobCategory` object
