### PR TITLE
Provide job category node type

### DIFF
--- a/.changeset/eleven-kiwis-burn.md
+++ b/.changeset/eleven-kiwis-burn.md
@@ -1,0 +1,11 @@
+---
+'wingman-fe': minor
+---
+
+**JobCategorySelect**: Provide job category node type
+
+Job posting in ANZ requires a child category for both pricing & posting.
+
+Pass back the category node type (`parent` or `child`) so we can
+validate we have the right type of category. For example, we could block
+posting until the user has selected a `child`.

--- a/fe/lib/components/JobCategorySelect/JobCategorySelect.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelect.tsx
@@ -17,10 +17,14 @@ import JobCategorySelectInput from './JobCategorySelectInput';
 import { JOB_CATEGORIES } from './queries';
 
 interface FieldProps extends ComponentPropsWithRef<typeof Dropdown> {}
+type JobCategoryType = 'parent' | 'child';
 
 interface Props extends Omit<FieldProps, 'value' | 'onChange' | 'children'> {
   client?: ApolloClient<unknown>;
-  onSelect?: (jobCategory: JobCategoryAttributesFragment) => void;
+  onSelect?: (
+    jobCategory: JobCategoryAttributesFragment,
+    type: JobCategoryType,
+  ) => void;
   schemeId: string;
 }
 
@@ -57,9 +61,10 @@ export const JobCategorySelect = forwardRef<HTMLInputElement, Props>(
 
     const handleJobCategoriesSelect = (
       selectedJobCategory: JobCategoryAttributesFragment,
+      type: JobCategoryType,
     ) => {
       if (onSelect) {
-        onSelect(selectedJobCategory);
+        onSelect(selectedJobCategory, type);
       }
       if (selectedJobCategory?.id?.value) {
         setSelectedJobCategoryId(selectedJobCategory.id.value);

--- a/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
@@ -12,7 +12,7 @@ type AnyJobCategory = JobCategoryAttributesFragment;
 
 interface Props {
   jobCategories: AllJobCategories;
-  onSelect: (jobCategory: AnyJobCategory) => void;
+  onSelect: (jobCategory: AnyJobCategory, type: 'parent' | 'child') => void;
   tone: ComponentProps<typeof Dropdown>['tone'];
 }
 
@@ -35,7 +35,7 @@ const JobCategorySelectInput = ({
       if (parentCategory?.children) {
         setChildCategories(parentCategory.children);
         setSelectedChildCategoryId('');
-        onSelect(parentCategory);
+        onSelect(parentCategory, 'parent');
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -48,7 +48,7 @@ const JobCategorySelectInput = ({
         selectedChildCategoryId,
       );
       if (childCategory) {
-        onSelect(childCategory);
+        onSelect(childCategory, 'child');
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Job posting in ANZ requires a child category for both pricing & posting.

Pass back the category node type (`parent` or `child`) so we can validate we have the right type of category. For example, we could block posting until the user has selected a `child`.
