### PR TITLE
Remove detect error messaging on successfully location query

### DIFF
--- a/.changeset/purple-geese-notice.md
+++ b/.changeset/purple-geese-notice.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': patch
+---
+
+Remove detect error messaging on successful location query

--- a/fe/lib/components/LocationSuggest/LocationSuggest.tsx
+++ b/fe/lib/components/LocationSuggest/LocationSuggest.tsx
@@ -60,6 +60,16 @@ export const LocationSuggest = forwardRef<HTMLInputElement, Props>(
           ...(client && { client }),
           fetchPolicy: 'no-cache',
           ssr: false,
+          onCompleted: (data) => {
+            if (
+              data.locationSuggestions &&
+              data.locationSuggestions.length > 0 &&
+              Boolean(detectLocationError)
+            ) {
+              // Reset any errors on a successful location search
+              setDetectLocationError('');
+            }
+          },
         },
       );
 


### PR DESCRIPTION
**Issue:** If the "Detect" location button doesn't work (e.g. user has blocked browser behaviour), then an error will appear. This error doesn't disappear on a successful location search, which can make it confusing during its usage.

Quick video showing fix:
https://user-images.githubusercontent.com/22812702/126429104-ed3e5f16-1c77-410e-8e81-5df2ef6db560.mov

