### PR TITLE
Add Other option to job category choices

### DIFF
--- a/.changeset/fresh-mirrors-impress.md
+++ b/.changeset/fresh-mirrors-impress.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': minor
+---
+
+Add 'Other' as a suggested job category option which triggers the job category select list

--- a/fe/lib/components/JobCategorySelect/JobCategorySelect.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelect.tsx
@@ -26,6 +26,7 @@ interface Props extends Omit<FieldProps, 'value' | 'onChange' | 'children'> {
     type: JobCategoryType,
   ) => void;
   schemeId: string;
+  hideLabel?: boolean;
 }
 
 export const JobCategorySelect = forwardRef<HTMLInputElement, Props>(
@@ -39,7 +40,7 @@ export const JobCategorySelect = forwardRef<HTMLInputElement, Props>(
       name,
       reserveMessageSpace,
       tone,
-
+      hideLabel,
       ...restProps
     },
     forwardedRef,
@@ -86,6 +87,7 @@ export const JobCategorySelect = forwardRef<HTMLInputElement, Props>(
                 jobCategories={categoriesData.jobCategories}
                 onSelect={handleJobCategoriesSelect}
                 tone={tone}
+                hideLabel={hideLabel}
               />
             )
           )}

--- a/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
@@ -62,7 +62,7 @@ const JobCategorySelectInput = ({
         <Dropdown
           {...restProps}
           id="jobCategoriesSelect"
-          label={hideLabel ? "" : "Category"}
+          label={hideLabel ? undefined : 'Category'}
           onChange={(event) =>
             setSelectedParentCategoryId(event.currentTarget.value)
           }
@@ -81,7 +81,7 @@ const JobCategorySelectInput = ({
           <Dropdown
             {...restProps}
             id="subJobCategoriesSelect"
-            label={hideLabel ? "" : "Subcategory"}
+            label={hideLabel ? undefined : 'Subcategory'}
             onChange={(event) =>
               setSelectedChildCategoryId(event.currentTarget.value)
             }

--- a/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
@@ -14,11 +14,13 @@ interface Props {
   jobCategories: AllJobCategories;
   onSelect: (jobCategory: AnyJobCategory, type: 'parent' | 'child') => void;
   tone: ComponentProps<typeof Dropdown>['tone'];
+  hideLabel?: boolean;
 }
 
 const JobCategorySelectInput = ({
   jobCategories,
   onSelect,
+  hideLabel,
   ...restProps
 }: Props) => {
   const [selectedParentCategoryId, setSelectedParentCategoryId] = useState('');
@@ -60,7 +62,7 @@ const JobCategorySelectInput = ({
         <Dropdown
           {...restProps}
           id="jobCategoriesSelect"
-          label="Category"
+          label={hideLabel ? "" : "Category"}
           onChange={(event) =>
             setSelectedParentCategoryId(event.currentTarget.value)
           }
@@ -79,7 +81,7 @@ const JobCategorySelectInput = ({
           <Dropdown
             {...restProps}
             id="subJobCategoriesSelect"
-            label="Subcategory"
+            label={hideLabel ? "" : "Subcategory"}
             onChange={(event) =>
               setSelectedChildCategoryId(event.currentTarget.value)
             }

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.stories.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.stories.tsx
@@ -7,8 +7,8 @@ import { storiesOf } from 'sku/@storybook/react';
 
 import { ApolloMockProvider } from '../../testing/ApolloMockProvider';
 
-import { JobCategorySuggest } from './JobCategorySuggest';
 import { mockJobCategorySuggest } from './__fixtures__/jobCategorySuggest';
+import { JobCategorySuggest } from './JobCategorySuggest';
 import { mockJobCategories } from '../JobCategorySelect/__fixtures__/jobCategories';
 
 storiesOf('JobCategories', module)

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.stories.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.stories.tsx
@@ -9,6 +9,7 @@ import { ApolloMockProvider } from '../../testing/ApolloMockProvider';
 
 import { JobCategorySuggest } from './JobCategorySuggest';
 import { mockJobCategorySuggest } from './__fixtures__/jobCategorySuggest';
+import { mockJobCategories } from '../JobCategorySelect/__fixtures__/jobCategories';
 
 storiesOf('JobCategories', module)
   .add('Job Category Suggest', () => {
@@ -52,6 +53,7 @@ storiesOf('JobCategories', module)
       resolvers={{
         Query: {
           jobCategorySuggestions: () => mockJobCategorySuggest,
+          jobCategories: () => mockJobCategories,
         },
       }}
     >

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.stories.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.stories.tsx
@@ -45,6 +45,7 @@ storiesOf('JobCategories', module)
         schemeId="seekAnz"
         reserveMessageSpace={boolean('reserveMessageSpace', false)}
         tone={tone}
+        onSelect={() => {}}
       />
     );
   })

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.stories.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.stories.tsx
@@ -6,10 +6,10 @@ import { boolean, select } from 'sku/@storybook/addon-knobs';
 import { storiesOf } from 'sku/@storybook/react';
 
 import { ApolloMockProvider } from '../../testing/ApolloMockProvider';
-
-import { mockJobCategorySuggest } from './__fixtures__/jobCategorySuggest';
-import { JobCategorySuggest } from './JobCategorySuggest';
 import { mockJobCategories } from '../JobCategorySelect/__fixtures__/jobCategories';
+
+import { JobCategorySuggest } from './JobCategorySuggest';
+import { mockJobCategorySuggest } from './__fixtures__/jobCategorySuggest';
 
 storiesOf('JobCategories', module)
   .add('Job Category Suggest', () => {

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
@@ -94,6 +94,8 @@ export const JobCategorySuggest = forwardRef<HTMLInputElement, Props>(
               onSelect={onSelect}
               showConfidence={showConfidence}
               tone={tone}
+              client={client}
+              schemeId={schemeId}
             />
           )
         )}

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
@@ -21,13 +21,13 @@ import { JOB_CATEGORY_SUGGEST } from './queries';
 interface RadioProps extends ComponentPropsWithRef<typeof RadioGroup> {}
 
 interface Props extends Partial<Omit<RadioProps, 'id'>> {
-  client?: ApolloClient<unknown>;
-  debounceDelay?: number;
-  onSelect?: (
-    jobCategorySuggestionChoice: JobCategorySuggestionChoiceAttributesFragment,
-  ) => void;
   positionProfile: JobCategorySuggestionPositionProfileInput;
   schemeId: string;
+  onSelect: (
+    jobCategorySuggestionChoice: JobCategorySuggestionChoiceAttributesFragment,
+  ) => void;
+  client?: ApolloClient<unknown>;
+  debounceDelay?: number;
   showConfidence?: boolean;
 }
 

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -53,12 +53,6 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
       confidence: choice.confidence,
     }));
 
-    suggestions.push({
-      key: 'Other',
-      label: 'Other',
-      confidence: 0,
-    });
-
     const [selectedJobCategory, setSelectedJobCategory] = useState<string>();
 
     const handleChoiceSelect = (event: React.FormEvent<HTMLInputElement>) => {
@@ -78,7 +72,6 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
     return (
       <Stack space="small">
         <Text weight="strong">Category</Text>
-
         <RadioGroup
           {...restProps}
           name={name}
@@ -86,31 +79,45 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
           onChange={handleChoiceSelect}
           value={selectedJobCategory ?? ''}
         >
-          {suggestions.map((choice) => {
-            const { label, confidence, key } = choice;
-            return (
-              <RadioItem key={key} label={label} ref={forwardedRef} value={key}>
-                {showConfidence && (
-                  <Text tone="secondary" size="small">
-                    <Strong>Confidence score:</Strong>{' '}
-                    {`${(confidence * 100).toFixed(2)}%`}
-                  </Text>
-                )}
-              </RadioItem>
-            );
-          })}
+          <>
+            {suggestions.map((choice) => {
+              const { label, confidence, key } = choice;
+              return (
+                <RadioItem
+                  key={key}
+                  label={label}
+                  ref={forwardedRef}
+                  value={key}
+                >
+                  {showConfidence && (
+                    <Text tone="secondary" size="small">
+                      <Strong>Confidence score:</Strong>{' '}
+                      {`${(confidence * 100).toFixed(2)}%`}
+                    </Text>
+                  )}
+                </RadioItem>
+              );
+            })}
+          </>
+          <RadioItem
+            key={'Other'}
+            label={'Other'}
+            ref={forwardedRef}
+            value={'Other'}
+          >
+            {selectedJobCategory === 'Other' && (
+              <JobCategorySelect
+                client={client}
+                id="job-category-suggest-select-other"
+                onSelect={(jobCategory: JobCategoryAttributesFragment) => {
+                  onSelect({ jobCategory, confidence: 1 });
+                }}
+                schemeId={schemeId}
+                hideLabel
+              />
+            )}
+          </RadioItem>
         </RadioGroup>
-        {selectedJobCategory === 'Other' && (
-          <JobCategorySelect
-            client={client}
-            id="job-category-suggest-select-other"
-            onSelect={(jobCategory: JobCategoryAttributesFragment) => {
-              onSelect({ jobCategory, confidence: 1 });
-            }}
-            schemeId={schemeId}
-            hideLabel
-          />
-        )}
       </Stack>
     );
   },

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -1,3 +1,4 @@
+import { ApolloClient } from '@apollo/client';
 import {
   RadioGroup,
   RadioItem,
@@ -9,11 +10,15 @@ import React, { ComponentProps, forwardRef, useState } from 'react';
 
 import type {
   JobCategory,
+  JobCategoryAttributesFragment,
   JobCategorySuggestionChoiceAttributesFragment,
 } from '../../types/seek.graphql';
 import { flattenResourceByKey } from '../../utils';
+import { JobCategorySelect } from '../JobCategorySelect/JobCategorySelect';
 
 interface Props {
+  client?: ApolloClient<unknown>;
+  schemeId: string;
   choices: JobCategorySuggestionChoiceAttributesFragment[];
   name?: string;
   onSelect?: (
@@ -31,7 +36,7 @@ const getJobCategoryName = (jobCategory: JobCategory): string =>
 
 const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
   (
-    { choices, name, onSelect, showConfidence = false, ...restProps },
+    { client, schemeId, choices, name, onSelect, showConfidence = false, ...restProps },
     forwardedRef,
   ) => {
     const simpleChoices = choices.map((choice) => {
@@ -73,7 +78,7 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
         <RadioGroup
           {...restProps}
           id="job-category-suggest-select"
-          name={name}
+          name={selectedJobCategory === 'Other' ? '' : name}
           onChange={handleChoiceSelect}
           value={selectedJobCategory ?? ''}
         >
@@ -96,6 +101,24 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
             );
           })}
         </RadioGroup>
+        {selectedJobCategory === 'Other' && (
+          <JobCategorySelect
+            client={client}
+            name={name}
+            id="jobCategoryId"
+            onSelect={(jobCategory: JobCategoryAttributesFragment) => {
+              const jobCategorySuggest = choices.find(
+                (choice) => choice.jobCategory.id.value === jobCategory.id.value,
+              );
+
+              if (onSelect && jobCategorySuggest) {
+                onSelect(jobCategorySuggest);
+              }
+            }}
+            schemeId={schemeId}
+            hideLabel={true}
+          />
+        )}
       </Stack>
     );
   },

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -17,13 +17,13 @@ import { flattenResourceByKey } from '../../utils';
 import { JobCategorySelect } from '../JobCategorySelect/JobCategorySelect';
 
 interface Props {
-  client?: ApolloClient<unknown>;
   schemeId: string;
   choices: JobCategorySuggestionChoiceAttributesFragment[];
-  name?: string;
-  onSelect?: (
+  onSelect: (
     jobCategorySuggestionChoice: JobCategorySuggestionChoiceAttributesFragment,
   ) => void;
+  client?: ApolloClient<unknown>;
+  name?: string;
   showConfidence?: boolean;
   tone?: ComponentProps<typeof RadioGroup>['tone'];
 }
@@ -70,7 +70,7 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
 
       setSelectedJobCategory(choiceId);
 
-      if (onSelect && jobCategorySuggest) {
+      if (jobCategorySuggest) {
         onSelect(jobCategorySuggest);
       }
     };
@@ -81,8 +81,8 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
 
         <RadioGroup
           {...restProps}
+          name={name}
           id="job-category-suggest-select"
-          name={selectedJobCategory === 'Other' ? '' : name}
           onChange={handleChoiceSelect}
           value={selectedJobCategory ?? ''}
         >
@@ -103,11 +103,10 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
         {selectedJobCategory === 'Other' && (
           <JobCategorySelect
             client={client}
-            name={name}
             id="jobCategoryId"
-            onSelect={(jobCategory: JobCategoryAttributesFragment) =>
-              onSelect?.({ jobCategory, confidence: 100 })
-            }
+            onSelect={(jobCategory: JobCategoryAttributesFragment) => {
+              onSelect({ jobCategory, confidence: 1 });
+            }}
             schemeId={schemeId}
             hideLabel={true}
           />

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -99,10 +99,10 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
             })}
           </>
           <RadioItem
-            key={'Other'}
-            label={'Other'}
+            key="Other"
+            label="Other"
             ref={forwardedRef}
-            value={'Other'}
+            value="Other"
           >
             {selectedJobCategory === 'Other' && (
               <JobCategorySelect

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -103,12 +103,12 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
         {selectedJobCategory === 'Other' && (
           <JobCategorySelect
             client={client}
-            id="jobCategoryId"
+            id="job-category-suggest-select-other"
             onSelect={(jobCategory: JobCategoryAttributesFragment) => {
               onSelect({ jobCategory, confidence: 1 });
             }}
             schemeId={schemeId}
-            hideLabel={true}
+            hideLabel
           />
         )}
       </Stack>

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -98,18 +98,19 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
               );
             })}
           </>
-          <RadioItem
-            key="Other"
-            label="Other"
-            ref={forwardedRef}
-            value="Other"
-          >
+          <RadioItem key="Other" label="Other" ref={forwardedRef} value="Other">
             {selectedJobCategory === 'Other' && (
               <JobCategorySelect
                 client={client}
                 id="job-category-suggest-select-other"
-                onSelect={(jobCategory) => {
-                  onSelect({ jobCategory, confidence: 1 });
+                onSelect={(jobCategory, type) => {
+                  /**
+                   * Only child job categories are suitable for job posting
+                   */
+                  if (type === 'child') {
+                    console.log(jobCategory);
+                    onSelect({ jobCategory, confidence: 1 });
+                  }
                 }}
                 schemeId={schemeId}
                 hideLabel

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -108,7 +108,6 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
                    * Only child job categories are suitable for job posting
                    */
                   if (type === 'child') {
-                    console.log(jobCategory);
                     onSelect({ jobCategory, confidence: 1 });
                   }
                 }}

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -36,22 +36,26 @@ const getJobCategoryName = (jobCategory: JobCategory): string =>
 
 const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
   (
-    { client, schemeId, choices, name, onSelect, showConfidence = false, ...restProps },
+    {
+      client,
+      schemeId,
+      choices,
+      name,
+      onSelect,
+      showConfidence = false,
+      ...restProps
+    },
     forwardedRef,
   ) => {
-    const simpleChoices = choices.map((choice) => {
-      return {
-        key: choice.jobCategory.id.value,
-        label: getJobCategoryName(choice.jobCategory),
-        value: choice.jobCategory.id.value,
-        confidence: choice.confidence,
-      };
-    });
+    const suggestions = choices.map((choice) => ({
+      key: choice.jobCategory.id.value,
+      label: getJobCategoryName(choice.jobCategory),
+      confidence: choice.confidence,
+    }));
 
-    simpleChoices.push({
+    suggestions.push({
       key: 'Other',
       label: 'Other',
-      value: 'Other',
       confidence: 0,
     });
 
@@ -82,15 +86,10 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
           onChange={handleChoiceSelect}
           value={selectedJobCategory ?? ''}
         >
-          {simpleChoices.map((choice) => {
-            const { label, confidence, key, value } = choice;
+          {suggestions.map((choice) => {
+            const { label, confidence, key } = choice;
             return (
-              <RadioItem
-                key={key}
-                label={label}
-                ref={forwardedRef}
-                value={value}
-              >
+              <RadioItem key={key} label={label} ref={forwardedRef} value={key}>
                 {showConfidence && (
                   <Text tone="secondary" size="small">
                     <Strong>Confidence score:</Strong>{' '}
@@ -106,15 +105,9 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
             client={client}
             name={name}
             id="jobCategoryId"
-            onSelect={(jobCategory: JobCategoryAttributesFragment) => {
-              const jobCategorySuggest = choices.find(
-                (choice) => choice.jobCategory.id.value === jobCategory.id.value,
-              );
-
-              if (onSelect && jobCategorySuggest) {
-                onSelect(jobCategorySuggest);
-              }
-            }}
+            onSelect={(jobCategory: JobCategoryAttributesFragment) =>
+              onSelect?.({ jobCategory, confidence: 100 })
+            }
             schemeId={schemeId}
             hideLabel={true}
           />

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -34,8 +34,23 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
     { choices, name, onSelect, showConfidence = false, ...restProps },
     forwardedRef,
   ) => {
-    const [selectedJobCategory, setSelectedJobCategory] =
-      useState<JobCategory>();
+    const simpleChoices = choices.map((choice) => {
+      return {
+        key: choice.jobCategory.id.value,
+        label: getJobCategoryName(choice.jobCategory),
+        value: choice.jobCategory.id.value,
+        confidence: choice.confidence,
+      };
+    });
+
+    simpleChoices.push({
+      key: 'Other',
+      label: 'Other',
+      value: 'Other',
+      confidence: 0,
+    });
+
+    const [selectedJobCategory, setSelectedJobCategory] = useState<string>();
 
     const handleChoiceSelect = (event: React.FormEvent<HTMLInputElement>) => {
       const choiceId = event.currentTarget.value;
@@ -44,7 +59,7 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
         (choice) => choice.jobCategory.id.value === choiceId,
       );
 
-      setSelectedJobCategory(jobCategorySuggest?.jobCategory);
+      setSelectedJobCategory(choiceId);
 
       if (onSelect && jobCategorySuggest) {
         onSelect(jobCategorySuggest);
@@ -60,17 +75,16 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
           id="job-category-suggest-select"
           name={name}
           onChange={handleChoiceSelect}
-          value={selectedJobCategory?.id.value ?? ''}
+          value={selectedJobCategory ?? ''}
         >
-          {choices.map((choice) => {
-            const { jobCategory, confidence } = choice;
-            const { id } = jobCategory;
+          {simpleChoices.map((choice) => {
+            const { label, confidence, key, value } = choice;
             return (
               <RadioItem
-                key={id.value}
-                label={getJobCategoryName(jobCategory)}
+                key={key}
+                label={label}
                 ref={forwardedRef}
-                value={id.value}
+                value={value}
               >
                 {showConfidence && (
                   <Text tone="secondary" size="small">

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -10,7 +10,6 @@ import React, { ComponentProps, forwardRef, useState } from 'react';
 
 import type {
   JobCategory,
-  JobCategoryAttributesFragment,
   JobCategorySuggestionChoiceAttributesFragment,
 } from '../../types/seek.graphql';
 import { flattenResourceByKey } from '../../utils';
@@ -109,7 +108,7 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
               <JobCategorySelect
                 client={client}
                 id="job-category-suggest-select-other"
-                onSelect={(jobCategory: JobCategoryAttributesFragment) => {
+                onSelect={(jobCategory) => {
                   onSelect({ jobCategory, confidence: 1 });
                 }}
                 schemeId={schemeId}


### PR DESCRIPTION
**What is this change:**
This PR adds a `Other` option to the list of suggested job categories. 

**Why do we need this change:**
This is so RyanAir create flow follows UX recommendations and shows a full list of categories if the suggested list doesn't contain the category the hirer wants.


**Note:**
- We have added JobCategorySelect in the JobCategorySuggest component as suggested [here](https://github.com/seek-oss/wingman/pull/484#issuecomment-885247390).

Current UI:
![image](https://user-images.githubusercontent.com/17308998/127099585-1b82ea3b-d322-4684-87a6-4ecaccec5469.png)
