### PR TITLE
Make questionnaire builder's GraphQL dump optional

### DIFF
--- a/.changeset/poor-zoos-play.md
+++ b/.changeset/poor-zoos-play.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': minor
+---
+
+**QuestionnaireBuilder**: Make questionnaire builder's GraphQL dump optional

--- a/fe/lib/components/Questionnaire/QuestionnaireBuilder/QuestionnaireBuilder.tsx
+++ b/fe/lib/components/Questionnaire/QuestionnaireBuilder/QuestionnaireBuilder.tsx
@@ -25,12 +25,20 @@ interface QuestionnaireBuilderProps {
   hirerId: string;
   graphqlInput?: GraphqlComponentInput[];
   onChange?: (mutationVariables: QuestionnaireCreateInput) => void;
+
+  /**
+   * Controls if the raw GraphQL mutation & variables should be shown
+   *
+   * Defaults to `true`
+   */
+  showGraphqlOutput?: boolean;
 }
 
 export const QuestionnaireBuilder = ({
   hirerId,
   graphqlInput,
   onChange,
+  showGraphqlOutput,
 }: QuestionnaireBuilderProps) => {
   const [formBuilderState, setFormBuilderState] = useState<FormComponent[]>([]);
 
@@ -65,16 +73,18 @@ export const QuestionnaireBuilder = ({
           </Column>
         </Columns>
 
-        <Card>
-          <Stack space="large">
-            <Heading level="3">GraphQL Output</Heading>
+        {showGraphqlOutput !== false && (
+          <Card>
+            <Stack space="large">
+              <Heading level="3">GraphQL Output</Heading>
 
-            <GraphqlQueryRenderer
-              components={formBuilderState}
-              hirerId={hirerId}
-            />
-          </Stack>
-        </Card>
+              <GraphqlQueryRenderer
+                components={formBuilderState}
+                hirerId={hirerId}
+              />
+            </Stack>
+          </Card>
+        )}
       </Stack>
     </ContentBlock>
   );

--- a/fe/lib/components/Questionnaire/app.stories.tsx
+++ b/fe/lib/components/Questionnaire/app.stories.tsx
@@ -1,5 +1,6 @@
 import 'braid-design-system/reset';
 
+import { boolean } from '@storybook/addon-knobs';
 import { Box, BraidLoadableProvider } from 'braid-design-system';
 import React from 'react';
 import { storiesOf } from 'sku/@storybook/react';
@@ -8,7 +9,10 @@ import { QuestionnaireBuilder } from './QuestionnaireBuilder/QuestionnaireBuilde
 
 storiesOf('QuestionnaireBuilder', module)
   .add('Builder', () => (
-    <QuestionnaireBuilder hirerId="seekAnzPublicTest:organization:seek:93WyyF1h" />
+    <QuestionnaireBuilder
+      hirerId="seekAnzPublicTest:organization:seek:93WyyF1h"
+      showGraphqlOutput={boolean('showGraphqlOutput', true)}
+    />
   ))
   .addDecorator((story) => (
     <BraidLoadableProvider themeName="apac">


### PR DESCRIPTION
This lets us hide our raw GraphQL output from the questionnaire builder.

This is useful for when the questionnaire builder is embedded in a job posting flow versus being used for developer documentation.
