### PR TITLE
Require `label` prop in JobCategorySelect

### DIFF
--- a/.changeset/small-garlics-join.md
+++ b/.changeset/small-garlics-join.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': minor
+---
+
+**JobCategorySelect:** Require `label` prop

--- a/fe/lib/components/JobCategorySelect/JobCategorySelect.stories.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelect.stories.tsx
@@ -37,6 +37,7 @@ storiesOf('JobCategories', module)
     return (
       <JobCategorySelect
         id="jobCategories"
+        label="Category"
         message={message}
         schemeId="seekAnz"
         reserveMessageSpace={boolean('reserveMessageSpace', false)}

--- a/fe/lib/components/JobCategorySelect/JobCategorySelect.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelect.tsx
@@ -21,6 +21,7 @@ type JobCategoryType = 'parent' | 'child';
 
 interface Props extends Omit<FieldProps, 'value' | 'onChange' | 'children'> {
   client?: ApolloClient<unknown>;
+  label: string;
   onSelect?: (
     jobCategory: JobCategoryAttributesFragment,
     type: JobCategoryType,
@@ -40,7 +41,6 @@ export const JobCategorySelect = forwardRef<HTMLInputElement, Props>(
       name,
       reserveMessageSpace,
       tone,
-      hideLabel,
       ...restProps
     },
     forwardedRef,
@@ -86,7 +86,6 @@ export const JobCategorySelect = forwardRef<HTMLInputElement, Props>(
                 jobCategories={categoriesData.jobCategories}
                 onSelect={handleJobCategoriesSelect}
                 tone={tone}
-                hideLabel={hideLabel}
               />
             )
           )}

--- a/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
@@ -61,6 +61,7 @@ const JobCategorySelectInput = ({
       <Column>
         <Dropdown
           {...restProps}
+          aria-label={hideLabel ? 'Category' : undefined}
           id="jobCategoriesSelect"
           label={hideLabel ? undefined : 'Category'}
           onChange={(event) =>

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -105,6 +105,7 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
             {selectedJobCategory === 'Other' && (
               <JobCategorySelect
                 client={client}
+                label="Category"
                 id="job-category-suggest-select-other"
                 onSelect={(jobCategory, type) => {
                   /**


### PR DESCRIPTION
The inherited props from Braid 30.3 are a bit tricky because they use a union of possible label props. This component already has a `hideLabel` concept so it should be fine to require the plain `label` prop here.