### PR TITLE
Drop Storybook knobs

### DIFF
--- a/fe/lib/components/JobCategorySelect/JobCategorySelect.stories.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelect.stories.tsx
@@ -2,10 +2,14 @@ import 'braid-design-system/reset';
 
 import React, { ComponentProps } from 'react';
 
-import { defaultArgTypes, defaultArgs } from '../../storybook/controls';
 import {
+  BraidArgs,
+  defaultArgTypes,
+  defaultArgs,
+} from '../../storybook/controls';
+import {
+  BraidStorybookProvider,
   createWithApolloProvider,
-  withBraidProvider,
 } from '../../storybook/decorators';
 
 import { JobCategorySelect as Component } from './JobCategorySelect';
@@ -13,6 +17,7 @@ import { mockJobCategories } from './__fixtures__/jobCategories';
 
 export default {
   args: {
+    braidThemeName: defaultArgs.braidThemeName,
     id: 'jobCategories',
     label: 'Category',
     message: 'undefined',
@@ -21,6 +26,7 @@ export default {
     tone: defaultArgs.tone,
   },
   argTypes: {
+    braidThemeName: defaultArgTypes.braidThemeName,
     message: {
       control: { type: 'radio' },
       mapping: { undefined, requiredValidation: 'Please select a category.' },
@@ -35,12 +41,15 @@ export default {
         jobCategories: () => mockJobCategories,
       },
     }),
-    withBraidProvider,
   ],
   title: 'Job Posting/Job categories/JobCategorySelect',
 };
 
-type Args = ComponentProps<typeof Component>;
+type Args = ComponentProps<typeof Component> & BraidArgs;
 
-export const JobCategorySelect = (args: Args) => <Component {...args} />;
+export const JobCategorySelect = ({ braidThemeName, ...args }: Args) => (
+  <BraidStorybookProvider braidThemeName={braidThemeName}>
+    <Component {...args} />
+  </BraidStorybookProvider>
+);
 JobCategorySelect.storyName = 'JobCategorySelect';

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.stories.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.stories.tsx
@@ -2,10 +2,14 @@ import 'braid-design-system/reset';
 
 import React, { ComponentProps } from 'react';
 
-import { defaultArgTypes, defaultArgs } from '../../storybook/controls';
 import {
+  BraidArgs,
+  defaultArgTypes,
+  defaultArgs,
+} from '../../storybook/controls';
+import {
+  BraidStorybookProvider,
   createWithApolloProvider,
-  withBraidProvider,
 } from '../../storybook/decorators';
 import { mockJobCategories } from '../JobCategorySelect/__fixtures__/jobCategories';
 
@@ -14,6 +18,7 @@ import { mockJobCategorySuggest } from './__fixtures__/jobCategorySuggest';
 
 export default {
   args: {
+    braidThemeName: defaultArgs.braidThemeName,
     message: 'undefined',
     onSelect: () => {},
     positionProfile: {
@@ -25,6 +30,7 @@ export default {
     tone: defaultArgs.tone,
   },
   argTypes: {
+    braidThemeName: defaultArgTypes.braidThemeName,
     message: {
       control: { type: 'radio' },
       mapping: { undefined, requiredValidation: 'Please select a category.' },
@@ -40,12 +46,15 @@ export default {
         jobCategories: () => mockJobCategories,
       },
     }),
-    withBraidProvider,
   ],
   title: 'Job Posting/Job categories/JobCategorySuggest',
 };
 
-type Args = ComponentProps<typeof Component>;
+type Args = ComponentProps<typeof Component> & BraidArgs;
 
-export const JobCategorySuggest = (args: Args) => <Component {...args} />;
+export const JobCategorySuggest = ({ braidThemeName, ...args }: Args) => (
+  <BraidStorybookProvider braidThemeName={braidThemeName}>
+    <Component {...args} />
+  </BraidStorybookProvider>
+);
 JobCategorySuggest.storyName = 'JobCategorySuggest';

--- a/fe/lib/components/LocationSuggest/LocationSuggest.stories.tsx
+++ b/fe/lib/components/LocationSuggest/LocationSuggest.stories.tsx
@@ -2,8 +2,12 @@ import 'braid-design-system/reset';
 
 import React, { ComponentProps } from 'react';
 
-import { defaultArgTypes, defaultArgs } from '../../storybook/controls';
-import { withBraidProvider } from '../../storybook/decorators';
+import {
+  BraidArgs,
+  defaultArgTypes,
+  defaultArgs,
+} from '../../storybook/controls';
+import { BraidStorybookProvider } from '../../storybook/decorators';
 import { createApolloMockClient } from '../../testing/ApolloMockProvider';
 
 import { LocationSuggest as Component } from './LocationSuggest';
@@ -12,6 +16,7 @@ import { mockNearestLocations } from './__fixtures__/nearestLocations';
 
 export default {
   args: {
+    braidThemeName: defaultArgs.braidThemeName,
     id: 'locationSuggest',
     label: 'Location',
     message: 'undefined',
@@ -20,6 +25,7 @@ export default {
     tone: defaultArgs.tone,
   },
   argTypes: {
+    braidThemeName: defaultArgTypes.braidThemeName,
     message: {
       control: { type: 'radio' },
       mapping: { undefined, requiredValidation: 'Please select a location.' },
@@ -28,13 +34,16 @@ export default {
     tone: defaultArgTypes.tone,
   },
   component: Component,
-  decorators: [withBraidProvider],
   title: 'Job Posting/Locations/LocationSuggest',
 };
 
-type Args = ComponentProps<typeof Component>;
+type Args = ComponentProps<typeof Component> & BraidArgs;
 
-export const LocationSuggest = ({ client: _client, ...args }: Args) => {
+export const LocationSuggest = ({
+  braidThemeName,
+  client: _client,
+  ...args
+}: Args) => {
   const client = createApolloMockClient({
     Query: {
       nearestLocations: () => mockNearestLocations,
@@ -42,6 +51,10 @@ export const LocationSuggest = ({ client: _client, ...args }: Args) => {
     },
   });
 
-  return <Component {...args} client={client} />;
+  return (
+    <BraidStorybookProvider braidThemeName={braidThemeName}>
+      <Component {...args} client={client} />
+    </BraidStorybookProvider>
+  );
 };
 LocationSuggest.storyName = 'LocationSuggest';

--- a/fe/lib/components/Person/SpecifiedPersonForm.stories.tsx
+++ b/fe/lib/components/Person/SpecifiedPersonForm.stories.tsx
@@ -4,12 +4,18 @@ import { Stack, Text } from 'braid-design-system';
 import React, { ComponentProps, useState } from 'react';
 import { CodeBlock, InlineCode } from 'scoobie';
 
-import { withBraidProvider } from '../../storybook/decorators';
+import {
+  BraidArgs,
+  defaultArgTypes,
+  defaultArgs,
+} from '../../storybook/controls';
+import { BraidStorybookProvider } from '../../storybook/decorators';
 
 import { SpecifiedPersonForm as Component } from './SpecifiedPersonForm';
 
 export default {
   args: {
+    braidThemeName: defaultArgs.braidThemeName,
     initialValues: {
       roleCode: 'HiringManager',
       givenName: 'Andrew',
@@ -18,33 +24,41 @@ export default {
       phoneNumber: '1900 654 321',
     },
   },
+  argTypes: {
+    braidThemeName: defaultArgTypes.braidThemeName,
+  },
   component: Component,
-  decorators: [withBraidProvider],
   title: 'Job Posting/Position openings/SpecifiedPersonForm',
 };
 
-type Args = ComponentProps<typeof Component>;
+type Args = ComponentProps<typeof Component> & BraidArgs;
 
-export const SpecifiedPersonForm = ({ onCreate: _onCreate, ...args }: Args) => {
+export const SpecifiedPersonForm = ({
+  braidThemeName,
+  onCreate: _onCreate,
+  ...args
+}: Args) => {
   const [count, setCount] = useState(0);
   const [json, setJson] = useState('');
 
   return (
-    <Stack space="large">
-      <Component
-        {...args}
-        onCreate={(values) => {
-          setCount((c) => c + 1);
-          setJson(JSON.stringify(values, null, 2));
-        }}
-      />
+    <BraidStorybookProvider braidThemeName={braidThemeName}>
+      <Stack space="large">
+        <Component
+          {...args}
+          onCreate={(values) => {
+            setCount((c) => c + 1);
+            setJson(JSON.stringify(values, null, 2));
+          }}
+        />
 
-      <Text>
-        <InlineCode>onCreate</InlineCode>: {String(count)}
-      </Text>
+        <Text>
+          <InlineCode>onCreate</InlineCode>: {String(count)}
+        </Text>
 
-      <CodeBlock language="json">{json}</CodeBlock>
-    </Stack>
+        <CodeBlock language="json">{json}</CodeBlock>
+      </Stack>
+    </BraidStorybookProvider>
   );
 };
 SpecifiedPersonForm.storyName = 'SpecifiedPersonForm';

--- a/fe/lib/components/Questionnaire/QuestionnaireBuilder.stories.tsx
+++ b/fe/lib/components/Questionnaire/QuestionnaireBuilder.stories.tsx
@@ -2,21 +2,33 @@ import 'braid-design-system/reset';
 
 import React, { ComponentProps } from 'react';
 
-import { withBraidProvider } from '../../storybook/decorators';
+import {
+  BraidArgs,
+  defaultArgTypes,
+  defaultArgs,
+} from '../../storybook/controls';
+import { BraidStorybookProvider } from '../../storybook/decorators';
 
 import { QuestionnaireBuilder as Component } from './QuestionnaireBuilder/QuestionnaireBuilder';
 
 export default {
   args: {
+    braidThemeName: defaultArgs.braidThemeName,
     hirerId: 'seekAnzPublicTest:organization:seek:93WyyF1h',
     showGraphqlOutput: true,
   },
+  argTypes: {
+    braidThemeName: defaultArgTypes.braidThemeName,
+  },
   component: Component,
-  decorators: [withBraidProvider],
   title: 'Job Posting/Questionnaires/QuestionnaireBuilder',
 };
 
-type Args = ComponentProps<typeof Component>;
+type Args = ComponentProps<typeof Component> & BraidArgs;
 
-export const QuestionnaireBuilder = (args: Args) => <Component {...args} />;
+export const QuestionnaireBuilder = ({ braidThemeName, ...args }: Args) => (
+  <BraidStorybookProvider braidThemeName={braidThemeName}>
+    <Component {...args} />
+  </BraidStorybookProvider>
+);
 QuestionnaireBuilder.storyName = 'QuestionnaireBuilder';

--- a/fe/lib/components/Questionnaire/components/GraphqlQueryRenderer/GraphqlQueryRenderer.stories.tsx
+++ b/fe/lib/components/Questionnaire/components/GraphqlQueryRenderer/GraphqlQueryRenderer.stories.tsx
@@ -1,7 +1,12 @@
 import 'braid-design-system/reset';
 import React, { ComponentProps } from 'react';
 
-import { withBraidProvider } from '../../../../storybook/decorators';
+import {
+  BraidArgs,
+  defaultArgTypes,
+  defaultArgs,
+} from '../../../../storybook/controls';
+import { BraidStorybookProvider } from '../../../../storybook/decorators';
 import type { FormComponent } from '../../types';
 
 import { GraphqlQueryRenderer as Component } from './GraphqlQueryRenderer';
@@ -35,15 +40,22 @@ const sampleQuestions: FormComponent[] = [
 
 export default {
   args: {
+    braidThemeName: defaultArgs.braidThemeName,
     components: sampleQuestions,
     hirerId: 'seekAnzPublicTest:organization:seek:93WyyF1h',
   },
+  argTypes: {
+    braidThemeName: defaultArgTypes.braidThemeName,
+  },
   component: Component,
-  decorators: [withBraidProvider],
   title: 'Job Posting/Questionnaires/GraphqlQueryRenderer',
 };
 
-type Args = ComponentProps<typeof Component>;
+type Args = ComponentProps<typeof Component> & BraidArgs;
 
-export const GraphqlQueryRenderer = (args: Args) => <Component {...args} />;
+export const GraphqlQueryRenderer = ({ braidThemeName, ...args }: Args) => (
+  <BraidStorybookProvider braidThemeName={braidThemeName}>
+    <Component {...args} />
+  </BraidStorybookProvider>
+);
 GraphqlQueryRenderer.storyName = 'GraphqlQueryRenderer';

--- a/fe/lib/storybook/controls.tsx
+++ b/fe/lib/storybook/controls.tsx
@@ -1,8 +1,18 @@
+export interface BraidArgs {
+  braidThemeName: string;
+}
+
 export const defaultArgs = {
+  braidThemeName: 'docs',
   tone: 'undefined',
 };
 
 export const defaultArgTypes = {
+  braidThemeName: {
+    control: { type: 'radio' },
+    name: 'Braid theme',
+    options: ['apac', 'docs', 'wireframe'],
+  },
   tone: {
     control: { type: 'radio' },
     mapping: {

--- a/fe/lib/storybook/decorators.tsx
+++ b/fe/lib/storybook/decorators.tsx
@@ -1,9 +1,3 @@
-/**
- * `@storybook/addon-controls` is not currently usable in decorators.
- *
- * {@link https://github.com/storybookjs/storybook/issues/11984}
- */
-import { select } from '@storybook/addon-knobs';
 import { Box, BraidLoadableProvider, ContentBlock } from 'braid-design-system';
 import React, { ComponentProps, ReactNode } from 'react';
 import { addDecorator } from 'sku/@storybook/react';
@@ -11,42 +5,24 @@ import { addDecorator } from 'sku/@storybook/react';
 import { ApolloMockProvider } from '../testing/ApolloMockProvider';
 
 interface ProviderProps {
+  braidThemeName: string;
   children: ReactNode;
 }
 
-const BraidStorybookProvider = ({ children }: ProviderProps) => (
-  <BraidLoadableProvider
-    themeName={select(
-      'BraidLoadableProvider.themeName',
-      [
-        'apac',
-        'catho',
-        'docs',
-        'jobsDb',
-        'jobStreet',
-        'occ',
-        'seekAnz',
-        'seekBusiness',
-        'wireframe',
-      ],
-      'apac',
-    )}
-  >
-    {children}
+export const BraidStorybookProvider = ({
+  braidThemeName,
+  children,
+}: ProviderProps) => (
+  <BraidLoadableProvider themeName={braidThemeName}>
+    <ContentBlock>
+      <Box paddingX="gutter" paddingY="large">
+        {children}
+      </Box>
+    </ContentBlock>
   </BraidLoadableProvider>
 );
 
 type DecoratorFn = Parameters<typeof addDecorator>[0];
-
-export const withBraidProvider: DecoratorFn = (story) => (
-  <BraidStorybookProvider>
-    <ContentBlock>
-      <Box paddingX="gutter" paddingY="large">
-        {story()}
-      </Box>
-    </ContentBlock>
-  </BraidStorybookProvider>
-);
 
 export const createWithApolloProvider =
   (

--- a/fe/package.json
+++ b/fe/package.json
@@ -15,7 +15,6 @@
   "devDependencies": {
     "@graphql-tools/schema": "8.1.2",
     "@storybook/addon-essentials": "6.3.7",
-    "@storybook/addon-knobs": "6.3.0",
     "@testing-library/react": "12.0.0",
     "@types/content-disposition": "0.5.4",
     "@types/faker": "5.5.8",

--- a/fe/sku.config.js
+++ b/fe/sku.config.js
@@ -25,7 +25,7 @@ module.exports = {
   compilePackages: ['scoobie'],
   orderImports: true,
   rootResolution: false,
-  storybookAddons: ['@storybook/addon-essentials', '@storybook/addon-knobs'],
+  storybookAddons: ['@storybook/addon-essentials'],
 
   dangerouslySetESLintConfig: (skuEslintConfig) => ({
     ...skuEslintConfig,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1182,7 +1182,7 @@
     core-js-pure "^3.16.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.8", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.7.7", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.8", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.7.7", "@babel/runtime@^7.8.4":
   version "7.15.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.3.tgz#2e1c2880ca118e5b2f9988322bd8a7656a32502b"
   integrity sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==
@@ -1428,7 +1428,7 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@emotion/cache@^10.0.27", "@emotion/cache@^10.0.9":
+"@emotion/cache@^10.0.27":
   version "10.0.29"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
   integrity sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==
@@ -1438,7 +1438,7 @@
     "@emotion/utils" "0.11.3"
     "@emotion/weak-memoize" "0.2.5"
 
-"@emotion/core@^10.0.9", "@emotion/core@^10.1.1":
+"@emotion/core@^10.1.1":
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.1.1.tgz#c956c1365f2f2481960064bcb8c4732e5fb612c3"
   integrity sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==
@@ -1450,7 +1450,7 @@
     "@emotion/sheet" "0.9.4"
     "@emotion/utils" "0.11.3"
 
-"@emotion/css@^10.0.27", "@emotion/css@^10.0.9":
+"@emotion/css@^10.0.27":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.27.tgz#3a7458198fbbebb53b01b2b87f64e5e21241e14c"
   integrity sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==
@@ -3112,22 +3112,6 @@
     regenerator-runtime "^0.13.7"
     storybook-addon-outline "^1.4.1"
     ts-dedent "^2.0.0"
-
-"@storybook/addon-knobs@6.3.0":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-knobs/-/addon-knobs-6.3.0.tgz#f289c072729651150a27a163371df20922c24f93"
-  integrity sha512-wsZZ1t38KHdaxzrc9oPyiIJDihJnjHRRabrENQbylktJwETEjb2z3eX0iBRJGiz/YCHO+tGd0ItyZArOdijT6g==
-  dependencies:
-    core-js "^3.8.2"
-    escape-html "^1.0.3"
-    fast-deep-equal "^3.1.3"
-    global "^4.4.0"
-    lodash "^4.17.20"
-    prop-types "^15.7.2"
-    qs "^6.10.0"
-    react-colorful "^5.1.2"
-    react-lifecycles-compat "^3.0.4"
-    react-select "^3.2.0"
 
 "@storybook/addon-measure@^2.0.0":
   version "2.0.0"
@@ -8722,14 +8706,6 @@ dom-converter@^0.2.0:
   dependencies:
     utila "~0.4"
 
-dom-helpers@^5.0.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
-  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
-  dependencies:
-    "@babel/runtime" "^7.8.7"
-    csstype "^3.0.2"
-
 dom-serializer@0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
@@ -14275,11 +14251,6 @@ memfs@^3.1.2, memfs@^3.2.2:
   dependencies:
     fs-monkey "1.0.3"
 
-memoize-one@^5.0.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
-  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
-
 memoizee@^0.4.15:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/memoizee/-/memoizee-0.4.15.tgz#e6f3d2da863f318d02225391829a6c5956555b72"
@@ -16866,7 +16837,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.0.0, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.0.0, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -17253,13 +17224,6 @@ react-hook-form@^7.0.0:
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.12.2.tgz#2660afbf03c4ef360a9314ebf46ce3d972296c77"
   integrity sha512-cpxocjrgpMAJCMJQR51BQhMoEx80/EQqePNihMTgoTYTqCRbd2GExi+N4GJIr+cFqrmbwNj9wxk5oLWYQsUefg==
 
-react-input-autosize@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-3.0.0.tgz#6b5898c790d4478d69420b55441fcc31d5c50a85"
-  integrity sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==
-  dependencies:
-    prop-types "^15.5.8"
-
 react-inspector@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-5.1.1.tgz#58476c78fde05d5055646ed8ec02030af42953c8"
@@ -17382,20 +17346,6 @@ react-router@5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-select@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.2.0.tgz#de9284700196f5f9b5277c5d850a9ce85f5c72fe"
-  integrity sha512-B/q3TnCZXEKItO0fFN/I0tWOX3WJvi/X2wtdffmwSQVRwg5BpValScTO1vdic9AxlUgmeSzib2hAZAwIUQUZGQ==
-  dependencies:
-    "@babel/runtime" "^7.4.4"
-    "@emotion/cache" "^10.0.9"
-    "@emotion/core" "^10.0.9"
-    "@emotion/css" "^10.0.9"
-    memoize-one "^5.0.0"
-    prop-types "^15.6.0"
-    react-input-autosize "^3.0.0"
-    react-transition-group "^4.3.0"
-
 react-sizeme@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-3.0.1.tgz#4d12f4244e0e6a0fb97253e7af0314dc7c83a5a0"
@@ -17434,16 +17384,6 @@ react-textarea-autosize@^8.3.0:
     "@babel/runtime" "^7.10.2"
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
-
-react-transition-group@^4.3.0:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
-  integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    dom-helpers "^5.0.1"
-    loose-envify "^1.4.0"
-    prop-types "^15.6.2"
 
 react-treat@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
We can't place controls on decorators, so we instead propagate a `braidThemeName` arg through each story into the provider directly.

This should make it easier to use the Component Story Format files without requiring Storybook dependencies.