### PR TITLE
Remove divider between QuestionnaireBuilder components

### DIFF
--- a/.changeset/pink-eagles-exist.md
+++ b/.changeset/pink-eagles-exist.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': patch
+---
+
+**QuestionnaireBuilder:** Remove divider between components

--- a/fe/lib/components/QuestionnaireBuilder/FormBuilder/FormBuilder.tsx
+++ b/fe/lib/components/QuestionnaireBuilder/FormBuilder/FormBuilder.tsx
@@ -164,7 +164,7 @@ export const FormBuilder = ({
 
   return (
     <StateContext.Provider value={{ dispatch, state }}>
-      <Stack space="large" dividers>
+      <Stack space="large">
         {state.map((component) => renderEntries(component))}
         {displayFormOrAddButton()}
         {displayPrivacyConsentAddButton()}


### PR DESCRIPTION
This should be the last of the churn for now. This looked overly noisy when the builder was rendered within a single card with a bunch of other dividers.