### PR TITLE
Support overriding SEEK API URLs

### DIFF
--- a/.changeset/gold-grapes-fix.md
+++ b/.changeset/gold-grapes-fix.md
@@ -1,0 +1,8 @@
+---
+'wingman-be': minor
+---
+
+**middleware**: Support overriding SEEK API URLs
+
+This is to support resurrecting some of SEEK's internal staging environment.
+External consumers should be able to ignore this.

--- a/be/src/browserToken/types.ts
+++ b/be/src/browserToken/types.ts
@@ -19,6 +19,14 @@ export interface BrowserTokenMiddlewareOptions {
   callback?: (ctx: Context, event: BrowserTokenEvent) => void | Promise<void>;
   getPartnerToken: GetPartnerToken<{ hirerId: string; partnerToken: string }>;
   userAgent: string;
+
+  /**
+   * Override for the browser token authentication endpoint
+   *
+   * This is used by SEEK for internal testing. External consumers should omit
+   * this option.
+   */
+  browserTokenUrlOverride?: string;
 }
 
 export const BrowserTokenRequest = t.Record({

--- a/be/src/seekGraph/schema.ts
+++ b/be/src/seekGraph/schema.ts
@@ -10,11 +10,15 @@ import { SeekGraphMiddlewareOptions } from './types';
 
 type Options = Pick<
   SeekGraphMiddlewareOptions,
-  'getPartnerToken' | 'userAgent'
+  'getPartnerToken' | 'userAgent' | 'seekApiUrlOverride'
 >;
 
 const createExecutor =
-  ({ getPartnerToken, userAgent }: Options): AsyncExecutor =>
+  ({
+    getPartnerToken,
+    userAgent,
+    seekApiUrlOverride,
+  }: Options): AsyncExecutor =>
   async ({ document, variables, context }) => {
     // The shape of context depends on framework and Apollo Server configuration.
     // We perform runtime validation in the `createContext` function.
@@ -30,7 +34,9 @@ const createExecutor =
 
     const query = print(document);
 
-    const fetchResult = await fetch(SEEK_API_URL, {
+    const seekApiUrl = seekApiUrlOverride ?? SEEK_API_URL;
+
+    const fetchResult = await fetch(seekApiUrl, {
       body: JSON.stringify({ query, variables }),
       headers: {
         ...authHeaders,

--- a/be/src/seekGraph/types.ts
+++ b/be/src/seekGraph/types.ts
@@ -5,4 +5,12 @@ export interface SeekGraphMiddlewareOptions {
   getPartnerToken: GetPartnerToken;
   path: string;
   userAgent: string;
+
+  /**
+   * Override for the SEEK API GraphQL endpoint
+   *
+   * This is used by SEEK for internal testing. External consumers should omit
+   * this option.
+   */
+  seekApiUrlOverride?: string;
 }


### PR DESCRIPTION
This is to support resurrecting some of SEEK's internal staging environment. External consumers should be able to ignore this.
