### PR TITLE
Add MockAdSelectionFallback

### DIFF
--- a/.changeset/lucky-moons-return.md
+++ b/.changeset/lucky-moons-return.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': patch
+---
+
+**AdSelectionFallback:** Forward ref

--- a/.changeset/tidy-plants-speak.md
+++ b/.changeset/tidy-plants-speak.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': minor
+---
+
+**MockAdSelectionFallback:** Add component

--- a/fe/lib/components/AdSelectionFallback/AdSelectionFallback.mock.tsx
+++ b/fe/lib/components/AdSelectionFallback/AdSelectionFallback.mock.tsx
@@ -1,0 +1,27 @@
+import React, { forwardRef } from 'react';
+
+import { MockComponentActions } from '../../private/MockComponentActions/MockComponentActions';
+
+import {
+  AdSelectionFallback,
+  AdSelectionFallbackProps,
+} from './AdSelectionFallback';
+
+interface Props extends AdSelectionFallbackProps {
+  showStorybookAction?: boolean;
+}
+
+export const MockAdSelectionFallback = forwardRef<HTMLSelectElement, Props>(
+  ({ showStorybookAction, ...props }, ref) => (
+    <MockComponentActions
+      space="medium"
+      storybookPath={
+        showStorybookAction
+          ? '/story/job-posting-ad-selection-adselectionfallback--ad-selection-fallback'
+          : undefined
+      }
+    >
+      <AdSelectionFallback {...props} ref={ref} />
+    </MockComponentActions>
+  ),
+);

--- a/fe/lib/components/AdSelectionFallback/AdSelectionFallback.stories.tsx
+++ b/fe/lib/components/AdSelectionFallback/AdSelectionFallback.stories.tsx
@@ -2,18 +2,25 @@ import 'braid-design-system/reset';
 
 import React, { ComponentProps } from 'react';
 
-import { BraidArgs, defaultArgTypes } from '../../storybook/controls';
+import {
+  BraidArgs,
+  defaultArgTypes,
+  defaultArgs,
+} from '../../storybook/controls';
 import { BraidStorybookProvider } from '../../storybook/decorators';
 
 import { AdSelectionFallback as Component } from './AdSelectionFallback';
+import { MockAdSelectionFallback } from './AdSelectionFallback.mock';
 
 export default {
   args: {
+    braidThemeName: defaultArgs.braidThemeName,
     id: 'seek-advertisement-type',
   },
   argTypes: {
     braidThemeName: defaultArgTypes.braidThemeName,
     onSelect: { action: 'onSelect' },
+    showStorybookAction: defaultArgTypes.showStorybookAction,
   },
   component: Component,
   title: 'Job Posting/Ad selection/AdSelectionFallback',
@@ -23,7 +30,7 @@ type Args = ComponentProps<typeof Component> & BraidArgs;
 
 export const AdSelectionFallback = ({ braidThemeName, ...args }: Args) => (
   <BraidStorybookProvider braidThemeName={braidThemeName}>
-    <Component {...args} />
+    <MockAdSelectionFallback {...args} />
   </BraidStorybookProvider>
 );
 AdSelectionFallback.storyName = 'AdSelectionFallback';

--- a/fe/lib/components/AdSelectionFallback/AdSelectionFallback.tsx
+++ b/fe/lib/components/AdSelectionFallback/AdSelectionFallback.tsx
@@ -1,15 +1,18 @@
 import { Dropdown } from 'braid-design-system';
-import React, { useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 
 type AdvertisementType = 'Classic' | 'StandOut' | 'Premium';
 
-interface Props {
+export interface AdSelectionFallbackProps {
   hideLabel?: boolean;
   id: string;
   onSelect: (type: AdvertisementType) => void;
 }
 
-export const AdSelectionFallback = ({ hideLabel, id, onSelect }: Props) => {
+export const AdSelectionFallback = forwardRef<
+  HTMLSelectElement,
+  AdSelectionFallbackProps
+>(({ hideLabel, id, onSelect }, ref) => {
   const [advertisementType, setAdvertisementType] =
     useState<AdvertisementType>();
 
@@ -23,6 +26,7 @@ export const AdSelectionFallback = ({ hideLabel, id, onSelect }: Props) => {
         setAdvertisementType(selection);
         onSelect(selection);
       }}
+      ref={ref}
       placeholder="Select an ad type"
       value={advertisementType ?? ''}
     >
@@ -31,4 +35,4 @@ export const AdSelectionFallback = ({ hideLabel, id, onSelect }: Props) => {
       <option>Premium</option>
     </Dropdown>
   );
-};
+});

--- a/fe/lib/index.ts
+++ b/fe/lib/index.ts
@@ -1,6 +1,7 @@
 export { ApolloMockProvider } from './components/ApolloMockProvider/ApolloMockProvider';
 
 export { AdSelectionFallback } from './components/AdSelectionFallback/AdSelectionFallback';
+export { MockAdSelectionFallback } from './components/AdSelectionFallback/AdSelectionFallback.mock';
 
 export { JobCategorySelect } from './components/JobCategorySelect/JobCategorySelect';
 export { MockJobCategorySelect } from './components/JobCategorySelect/JobCategorySelect.mock';


### PR DESCRIPTION
This is a simple Storybook action wrapper around the AdSelectionFallback component. There's nothing particularly exciting to see in Storybook, but it was easy enough to include this for alignment with other widgets.