### PR TITLE
Fix rendering GraphQL query input validation error

### DIFF
--- a/.changeset/smooth-starfishes-smash.md
+++ b/.changeset/smooth-starfishes-smash.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': patch
+---
+
+**QuestionnaireQueryInput**: Fix rendering GraphQL query input validation errors

--- a/.changeset/smooth-starfishes-smash.md
+++ b/.changeset/smooth-starfishes-smash.md
@@ -2,4 +2,4 @@
 'wingman-fe': patch
 ---
 
-**QuestionnaireQueryInput**: Fix rendering GraphQL query input validation errors
+**QuestionnaireQueryInput:** Fix rendering GraphQL query input validation errors

--- a/fe/lib/components/QuestionnaireQueryInput/QuestionnaireQueryInput.tsx
+++ b/fe/lib/components/QuestionnaireQueryInput/QuestionnaireQueryInput.tsx
@@ -35,10 +35,11 @@ export const QuestionnaireQueryInput = ({
       setShowError(false);
     } catch (err) {
       setShowError(true);
-      if (err.name === 'ValidationError') {
-        setQueryInputError(`${err.name}: ${err.key} is invalid`);
-      } else {
+
+      if (err instanceof Error) {
         setQueryInputError(`${err.name}: ${err.message}`);
+      } else {
+        throw err;
       }
     }
   };


### PR DESCRIPTION
This was caught by TypeScript 4.4. It looks like we're expecting a `ValidationError` from our internal `indie-api-types` library which has `key` property. However, we're actually receiving a Runtypes `ValidationError` which results in this zen message:

> ValidationError: undefined is invalid

This just dumps the full Runtypes validation error as part of the normal Error handling.
