### PR TITLE
Move `graphql` to a peer dependency

### DIFF
--- a/.changeset/shiny-pillows-lay.md
+++ b/.changeset/shiny-pillows-lay.md
@@ -1,0 +1,7 @@
+---
+'wingman-fe': major
+---
+
+**deps:** Move `graphql` to a peer dependency
+
+If your project does not already include `graphql@15` as a direct dependency it needs to be added.

--- a/fe/package.json
+++ b/fe/package.json
@@ -7,7 +7,6 @@
     "@graphql-tools/schema": "^8.1.2",
     "@types/uuid": "^8.3.1",
     "autosuggest-highlight": "^3.1.1",
-    "graphql": "^15.5.1",
     "react-hook-form": "^7.0.0",
     "runtypes": "^6.3.2",
     "use-debounce": "^7.0.0",
@@ -46,6 +45,7 @@
   "name": "wingman-fe",
   "peerDependencies": {
     "braid-design-system": ">= 30.4",
+    "graphql": ">= 15 < 16",
     "react": ">= 17 < 18",
     "scoobie": ">= 9"
   },


### PR DESCRIPTION
Having multiple copies of `graphql` can cause unexpected behaviour. Trying to add this as a dependency to an existing internal repo caused GraphQL codegen to fail due to duplicate instances.

We already have `graphql` as a dev dependency on the top level we can use for our tests.
