### PR TITLE
Add Apollo type policy for ontologies

### DIFF
--- a/.changeset/famous-boats-cheat.md
+++ b/.changeset/famous-boats-cheat.md
@@ -1,0 +1,7 @@
+---
+'wingman-fe': patch
+---
+
+**apolloTypePolicies**: Add Apollo type policies for ontologies
+
+This enables safely caching locations & job categories when they're directly queried.

--- a/fe/lib/types/apolloTypePolicies.ts
+++ b/fe/lib/types/apolloTypePolicies.ts
@@ -216,6 +216,10 @@ export const apolloTypePolicies: TypedTypePolicies = {
   HiringOrganizationEdge: seekApiEdge('id'),
   HiringOrganizationsConnection: seekApiConnection('id'),
 
+  JobCategory: seekApiObject('id'),
+
+  Location: seekApiObject('id'),
+
   PositionOpening: seekApiObject('documentId'),
   PositionOpeningEdge: seekApiEdge('documentId'),
   PositionOpeningsConnection: seekApiConnection('documentId'),


### PR DESCRIPTION
These aren't available from normal pagination queries but can be queried directly from a browser.
