### PR TITLE
Remove no-op client spreads

### DIFF
--- a/.changeset/early-phones-remember.md
+++ b/.changeset/early-phones-remember.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': patch
+---
+
+**LocationSuggest:** Remove no-op client spreads

--- a/fe/lib/components/LocationSuggest/LocationSuggest.tsx
+++ b/fe/lib/components/LocationSuggest/LocationSuggest.tsx
@@ -67,7 +67,7 @@ export const LocationSuggest = forwardRef<
       useLazyQuery<SuggestLocationsQuery, SuggestLocationsQueryVariables>(
         LOCATION_SUGGEST,
         {
-          ...(client && { client }),
+          client,
           fetchPolicy: 'no-cache',
           onCompleted: (data) => {
             if (
@@ -92,7 +92,7 @@ export const LocationSuggest = forwardRef<
     ] = useLazyQuery<NearestLocationsQuery, NearestLocationsQueryVariables>(
       NEAREST_LOCATIONS,
       {
-        ...(client && { client }),
+        client,
         fetchPolicy: 'no-cache',
       },
     );
@@ -162,7 +162,6 @@ export const LocationSuggest = forwardRef<
         LocationQuery,
         LocationQueryVariables
       >({
-        ...(client && { client }),
         fetchPolicy: 'no-cache',
         query: LOCATION,
         variables: { id: initialValue },


### PR DESCRIPTION
In two cases the `client` in non-null. In the third case we're using `client.query` which doesn't accept a `client` property.
