### PR TITLE
Rationalise fetch policies

### DIFF
--- a/.changeset/poor-eggs-dress.md
+++ b/.changeset/poor-eggs-dress.md
@@ -1,0 +1,10 @@
+---
+'wingman-fe': patch
+---
+
+**JobCategorySelect, JobCategorySuggest, LocationSuggest:** Rationalise fetch policies
+
+This removes an explicit fetch policy except for the realtime suggestion queries.
+
+This can cause problems if you're not using an appropriate cache policy for the SEEK API.
+You can either use our `apolloTypePolicies` or set a default cache policy of `no-fetch` for the `client` you pass to the component.

--- a/fe/lib/components/JobCategorySelect/JobCategorySelect.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelect.tsx
@@ -57,7 +57,6 @@ export const JobCategorySelect = forwardRef<
       error: categoriesError,
     } = useQuery<JobCategoriesQuery>(JOB_CATEGORIES, {
       ...(client && { client }),
-      fetchPolicy: 'no-cache',
       variables: {
         schemeId,
       },

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
@@ -61,6 +61,7 @@ export const JobCategorySuggest = forwardRef<
       { data: suggestData, error: suggestError, loading: suggestLoading },
     ] = useLazyQuery<JobCategorySuggestQuery>(JOB_CATEGORY_SUGGEST, {
       client,
+      // Avoid polluting the Apollo cache with partial searches
       fetchPolicy: 'no-cache',
     });
 

--- a/fe/lib/components/LocationSuggest/LocationSuggest.tsx
+++ b/fe/lib/components/LocationSuggest/LocationSuggest.tsx
@@ -68,6 +68,7 @@ export const LocationSuggest = forwardRef<
         LOCATION_SUGGEST,
         {
           client,
+          // Avoid polluting the Apollo cache with partial searches
           fetchPolicy: 'no-cache',
           onCompleted: (data) => {
             if (
@@ -93,7 +94,6 @@ export const LocationSuggest = forwardRef<
       NEAREST_LOCATIONS,
       {
         client,
-        fetchPolicy: 'no-cache',
       },
     );
 
@@ -162,7 +162,6 @@ export const LocationSuggest = forwardRef<
         LocationQuery,
         LocationQueryVariables
       >({
-        fetchPolicy: 'no-cache',
         query: LOCATION,
         variables: { id: initialValue },
       });


### PR DESCRIPTION
Remove `fetchPolicy: 'no-cache`' from all queries except for our realtime suggest queries. By default Apollo doesn't limit its cache size so we could slowly leak memory with repeated suggestions.
