### PR TITLE
Add additional Apollo type policies

### DIFF
--- a/.changeset/late-dancers-cross.md
+++ b/.changeset/late-dancers-cross.md
@@ -4,4 +4,4 @@
 
 **apolloTypePolicies:** Add additional Apollo type policies
 
-This adds a policy `ApplicationQuestionnaire` and objects that are only accessible with a partner token.
+This adds a policy for `ApplicationQuestionnaire` and objects that are only accessible with a partner token.

--- a/.changeset/late-dancers-cross.md
+++ b/.changeset/late-dancers-cross.md
@@ -1,0 +1,7 @@
+---
+'wingman-fe': patch
+---
+
+**apolloTypePolicies:** Add additional Apollo type policies
+
+This adds a policy `ApplicationQuestionnaire` and objects that are only accessible with a partner token.

--- a/fe/lib/types/apolloTypePolicies.ts
+++ b/fe/lib/types/apolloTypePolicies.ts
@@ -154,9 +154,9 @@ const seekApiObject = (
 });
 
 /**
- * Custom Apollo cache type policies to support paginated lists of objects.
+ * Custom Apollo cache type policies to support SEEK API conventions.
  *
- * These lists support bidirectional pagination, creates, edits and deletes.
+ * For pagination queries this supports bidirectional pagination, creates, edits and deletes.
  * Some implementation specifics are detailed below.
  *
  * ---
@@ -195,6 +195,10 @@ export const apolloTypePolicies: TypedTypePolicies = {
   AdvertisementBrandingEdge: seekApiEdge('id'),
   AdvertisementBrandingsConnection: seekApiConnection('id'),
 
+  ApplicationQuestionnaire: seekApiObject('id'),
+
+  Candidate: seekApiObject('documentId'),
+
   CandidateProcessHistoryItem: seekApiObject('id'),
   CandidateProcessHistoryItemEdge: seekApiEdge('id'),
   CandidateProcessHistoryItemConnection: seekApiConnection('id'),
@@ -224,6 +228,8 @@ export const apolloTypePolicies: TypedTypePolicies = {
   PositionOpeningEdge: seekApiEdge('documentId'),
   PositionOpeningsConnection: seekApiConnection('documentId'),
 
+  PositionProfile: seekApiObject('profileId'),
+
   Query: {
     fields: {
       advertisementBrandings: {
@@ -249,6 +255,8 @@ export const apolloTypePolicies: TypedTypePolicies = {
       },
     },
   },
+
+  WebhookAttempt: seekApiObject('id'),
 
   WebhookRequest: seekApiObject(['requestId']),
   WebhookRequestEdge: seekApiEdge(['requestId']),


### PR DESCRIPTION
This is based on a review of objects that have an queryable primary object identifier. I was avoiding parts of the schema only accessible with a partner token but Apollo client can also be used server-to-server.
