### PR TITLE
Add `acceptedScopes` browser token option

### DIFF
--- a/.changeset/forty-goats-bow.md
+++ b/.changeset/forty-goats-bow.md
@@ -1,0 +1,8 @@
+---
+'wingman-be': minor
+---
+
+**createBrowserTokenMiddleware:** Add `acceptedScopes` browser token option
+
+This allows the backend to filter out the scopes it will request from the SEEK API.
+If this option isn't specified then the existing behaviour of accepting all scopes is preserved.

--- a/be/README.md
+++ b/be/README.md
@@ -106,6 +106,13 @@ const createApp = () => {
   const middleware = createBrowserTokenMiddleware({
     getPartnerToken,
     userAgent: 'my-service/1.2.3',
+
+    acceptedScopes: [
+      'query:advertisement-brandings',
+      'query:ad-products',
+      'query:ontologies',
+      'query:organizations',
+    ],
   });
 
   return new Koa().use(middleware);

--- a/be/src/browserToken/types.ts
+++ b/be/src/browserToken/types.ts
@@ -21,6 +21,16 @@ export interface BrowserTokenMiddlewareOptions {
   userAgent: string;
 
   /**
+   * List of scope names the frontend can request
+   *
+   * This can be used to prevent users from requesting browser tokens with more
+   * permissions than required by your frontend. This check is in addition to
+   * the access control checks performed by the SEEK API based on hirer
+   * relationships.
+   */
+  acceptedScopes?: string[];
+
+  /**
    * Override for the browser token authentication endpoint
    *
    * This is used by SEEK for internal testing. External consumers should omit


### PR DESCRIPTION
This allows the backend to filter out the scopes it will request from the SEEK API.
