### PR TITLE
Make question choice input value non-null

### DIFF
--- a/.changeset/clever-bottles-return.md
+++ b/.changeset/clever-bottles-return.md
@@ -1,0 +1,9 @@
+---
+'wingman-fe': patch
+---
+
+**QuestionnaireBuilder:** Make question choice input value non-null
+
+In the SEEK API `ApplicationQuestionChoiceInput.value` is non-null while `ApplicationQuestionChoice.value` is nullable.
+    
+Our choice input Runtype had this as nullable which is incorrect.

--- a/fe/lib/private/questionnaires/types.ts
+++ b/fe/lib/private/questionnaires/types.ts
@@ -50,7 +50,7 @@ const FreeTextQuestion = t.Record({
 
 const ResponseChoice = t.Record({
   text: t.String,
-  value: t.String.nullable().optional(),
+  value: t.String,
   preferredIndicator: t.Boolean,
 });
 


### PR DESCRIPTION
In the SEEK API `ApplicationQuestionChoiceInput.value` is non-null while `ApplicationQuestionChoice.value` is nullable.

Our choice input Runtype had this as nullable which is incorrect. This was found via type errors in an internal repository.
