### PR TITLE
Ignore `node-fetch` Renovates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,3 +1,16 @@
 {
   extends: ['github>seek-oss/rynovate'],
+  packageRules: [
+    {
+      matchManagers: ['npm'],
+      matchPackageNames: [
+        // `node-fetch@3` is ESM-only
+        '@types/node-fetch',
+        'node-fetch',
+      ],
+      matchUpdateTypes: ['major'],
+
+      enabled: false,
+    },
+  ],
 }


### PR DESCRIPTION
`node-fetch@3` is ESM-only
