### PR TITLE
Tweak homepage to reflect current state

### DIFF
--- a/fe/example/src/App/Router.tsx
+++ b/fe/example/src/App/Router.tsx
@@ -6,6 +6,7 @@ import { Redirect, Route, Switch } from 'react-router-dom';
 import { AdminPage } from '../pages/Admin/Admin';
 import { CandidateDetailPage } from '../pages/Candidates/Detail';
 import { CandidateListPage } from '../pages/Candidates/List';
+import { HomePage } from '../pages/Home';
 import { OopsPage } from '../pages/Oops';
 import { PositionDetailPage } from '../pages/Positions/Detail';
 import { PositionListPage } from '../pages/Positions/List';
@@ -14,6 +15,9 @@ import { PositionQuestionnairePage } from '../pages/Positions/Questionnaires';
 
 export const Router = () => (
   <Switch>
+    <Route exact path="/">
+      <HomePage />
+    </Route>
     <Route exact path="/admin">
       <AdminPage />
     </Route>

--- a/fe/example/src/App/Sidebar.tsx
+++ b/fe/example/src/App/Sidebar.tsx
@@ -1,21 +1,14 @@
 import {
   Box,
-  Checkbox,
   Heading,
-  IconAdd,
-  IconDocument,
   IconEducation,
   IconHome,
-  IconImage,
   IconNewWindow,
-  IconPeople,
-  IconSecurity,
-  IconShare,
   IconSocialGitHub,
-  IconWorkExperience,
   Link,
   Stack,
   Text,
+  Toggle,
 } from 'braid-design-system';
 import React, { Fragment, ReactNode } from 'react';
 import { NavLink } from 'react-router-dom';
@@ -95,7 +88,8 @@ export const Sidebar = () => (
           </SidebarLink>
         </Box>
 
-        <Box paddingY="gutter">
+        {/* TODO: rebuild from shared components. */}
+        {/* <Box paddingY="gutter">
           <SidebarLink to="/positions">
             <IconWorkExperience /> Positions
           </SidebarLink>
@@ -120,16 +114,16 @@ export const Sidebar = () => (
           <SidebarLink to="/accounts">
             <IconShare /> Switch account
           </SidebarLink>
-        </Box>
-
+        </Box> */}
         <ClientOnly>
           {({ preferences, setPreferences }) => (
             <Box paddingY="gutter">
               <Box padding="gutter">
-                <Checkbox
-                  checked={preferences.devTools}
+                <Toggle
+                  align="justify"
                   id="devTools"
                   label="Dev tools"
+                  on={preferences.devTools}
                   onChange={() =>
                     setPreferences({
                       devTools: !preferences.devTools,
@@ -139,9 +133,10 @@ export const Sidebar = () => (
               </Box>
               {preferences.devTools ? (
                 <Fragment>
-                  <SidebarLink to="/admin">
+                  {/* TODO: rebuild from shared components. */}
+                  {/* <SidebarLink to="/admin">
                     <IconSecurity /> Admin
-                  </SidebarLink>
+                  </SidebarLink> */}
 
                   <SidebarLink to="https://seek-oss.github.io/wingman/storybook/index.html">
                     <IconEducation /> Storybook

--- a/fe/example/src/hooks/user.tsx
+++ b/fe/example/src/hooks/user.tsx
@@ -34,7 +34,7 @@ export interface ServerContext {
 const DEFAULT_CLIENT_CONTEXT: UserContext = {
   server: false,
   preferences: {
-    devTools: false,
+    devTools: true,
   },
   user: USERS[0],
 };

--- a/fe/example/src/pages/Home.tsx
+++ b/fe/example/src/pages/Home.tsx
@@ -1,0 +1,46 @@
+import { Box, ContentBlock, Heading, Stack, Text } from 'braid-design-system';
+import React from 'react';
+import { SmartTextLink } from 'scoobie';
+
+import { Header } from '../components/Header';
+
+export const HomePage = () => (
+  <Stack dividers space="none">
+    <Header>
+      <Heading level="3">🚧</Heading>
+    </Header>
+
+    <ContentBlock>
+      <Box padding="gutter">
+        <Box
+          background="card"
+          borderRadius="xlarge"
+          boxShadow="borderInfoLight"
+          paddingX="gutter"
+          paddingY="large"
+        >
+          <Stack space="medium">
+            <Text>
+              We’re still constructing publicly-accessible sample site for
+              recruitment software providers to reference when developing
+              against the SEEK API.
+            </Text>
+
+            <Text>
+              In the meantime, check out our{' '}
+              <SmartTextLink href="https://developer.seek.com">
+                Developer Site
+              </SmartTextLink>{' '}
+              and standalone interactive components in{' '}
+              <SmartTextLink href="https://seek-oss.github.io/wingman/storybook/index.html">
+                Storybook
+              </SmartTextLink>
+              . You can also ask your SEEK contact for guidance from our UXers
+              and a demo of our internal sample site.
+            </Text>
+          </Stack>
+        </Box>
+      </Box>
+    </ContentBlock>
+  </Stack>
+);


### PR DESCRIPTION
We've had one partner get confused by all the placeholder pages we scrounged together on the Wingman site. To avoid this, strip down the homepage to link to the Developer Site and Storybook, at least until we have more finalised components to rebuild the individual pages from.