### PR TITLE
Using error.message

### DIFF
--- a/.changeset/itchy-vans-provide.md
+++ b/.changeset/itchy-vans-provide.md
@@ -1,5 +1,5 @@
 ---
-'wingman-fe': major
+'wingman-fe': patch
 ---
 
 **LocationSuggest:** Fix location suggest and nearest location error messages

--- a/.changeset/itchy-vans-provide.md
+++ b/.changeset/itchy-vans-provide.md
@@ -2,4 +2,4 @@
 'wingman-fe': major
 ---
 
-Fix location suggest and nearest location error messages
+**LocationSuggest:** Fix location suggest and nearest location error messages

--- a/.changeset/itchy-vans-provide.md
+++ b/.changeset/itchy-vans-provide.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': major
+---
+
+Fix location suggest and nearest location error messages

--- a/fe/lib/components/LocationSuggest/LocationSuggest.tsx
+++ b/fe/lib/components/LocationSuggest/LocationSuggest.tsx
@@ -245,7 +245,7 @@ export const LocationSuggest = forwardRef<
         {suggestError && (
           <FieldMessage
             id="locationSuggestError"
-            message={suggestError}
+            message={suggestError.message}
             tone="critical"
           />
         )}
@@ -253,7 +253,7 @@ export const LocationSuggest = forwardRef<
         {nearestLocationsError && (
           <FieldMessage
             id="locationSuggestNearestLocationsError"
-            message={nearestLocationsError}
+            message={nearestLocationsError.message}
             tone="critical"
           />
         )}


### PR DESCRIPTION
- ApolloError is an object and can not be used as a string error message. Extract the ApollowError.message to fix the render error.

This issue related to ->  https://trello.com/c/S7Dqon0c/29-improve-ryanair-error-handling-eg-during-job-posting-using-suggestlocations

![image](https://user-images.githubusercontent.com/13049564/133945324-7ee7e434-c551-4ddd-af14-cea9f2d3bab9.png)
