### PR TITLE
Align category select styling

### DIFF
--- a/.changeset/blue-bottles-type.md
+++ b/.changeset/blue-bottles-type.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': minor
+---
+
+Align job category select component to UX guide

--- a/fe/lib/components/JobCategorySelect/JobCategorySelect.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelect.tsx
@@ -30,11 +30,6 @@ export interface JobCategorySelectProps
   schemeId: string;
   initialValue?: string;
   hideLabel?: boolean;
-
-  /**
-   * Whether job category select component is embedded in the job category suggest component.
-   */
-  embedded?: boolean;
 }
 
 export const JobCategorySelect = forwardRef<
@@ -52,7 +47,6 @@ export const JobCategorySelect = forwardRef<
       name,
       reserveMessageSpace,
       tone,
-      embedded,
       ...restProps
     },
     forwardedRef,

--- a/fe/lib/components/JobCategorySelect/JobCategorySelect.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelect.tsx
@@ -30,6 +30,11 @@ export interface JobCategorySelectProps
   schemeId: string;
   initialValue?: string;
   hideLabel?: boolean;
+
+  /**
+   * Whether job category select component is embedded in the job category suggest component.
+   */
+  embedded?: boolean;
 }
 
 export const JobCategorySelect = forwardRef<
@@ -47,6 +52,7 @@ export const JobCategorySelect = forwardRef<
       name,
       reserveMessageSpace,
       tone,
+      embedded,
       ...restProps
     },
     forwardedRef,

--- a/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
@@ -88,44 +88,41 @@ const JobCategorySelectInput = ({
 
   let height = '0px';
   if (dropDownHeight) {
-    const stackSpacing = calc.multiply(vars.space.xsmall, 2);
-    const dropdownPaddingTopSpacing = vars.space.xsmall;
-
     height = calc.add(
-      `${dropDownHeight}px`,
-      stackSpacing,
-      dropdownPaddingTopSpacing,
-      `${dropDownHeight! / 2}px`,
+      vars.space.small, // Top padding allocated to wrapping `Box`
+      vars.space.xsmall, // Top padding allocated to Dropdown
+      '10px',
+      `${dropDownHeight / 2}px`,
     );
   }
 
   return (
-    <Box position="relative">
-      <Stack space="xsmall">
-        <Dropdown
-          {...restProps}
-          ref={parentRef}
-          aria-label="Category"
-          id="jobCategoriesSelect"
-          label={hideLabel ? undefined : 'Category'}
-          onChange={(event) =>
-            handleParentCategorySelect(event.currentTarget.value)
-          }
-          placeholder="Select a category"
-          value={selectedParentCategoryId}
-        >
-          {jobCategories.map(({ name, id }) => (
-            <option key={id.value} value={id.value}>
-              {name}
-            </option>
-          ))}
-        </Dropdown>
+    <Stack space="none">
+      <Dropdown
+        {...restProps}
+        ref={parentRef}
+        aria-label="Category"
+        id="jobCategoriesSelect"
+        label={hideLabel ? undefined : 'Category'}
+        onChange={(event) =>
+          handleParentCategorySelect(event.currentTarget.value)
+        }
+        placeholder="Select a category"
+        value={selectedParentCategoryId}
+      >
+        {jobCategories.map(({ name, id }) => (
+          <option key={id.value} value={id.value}>
+            {name}
+          </option>
+        ))}
+      </Dropdown>
+      <Box position="relative" paddingTop="small">
         {childCategories && Boolean(dropDownHeight) && (
           <React.Fragment>
             <Box
               className={categoryLink}
               style={{
-                width: calc.divide(dropDownWidth, 5),
+                width: calc.divide(dropDownWidth, 5), // Divide by 5 to minimise width a lot
                 height,
               }}
             />
@@ -134,7 +131,8 @@ const JobCategorySelectInput = ({
                 {...restProps}
                 aria-label="Subcategory"
                 id="subJobCategoriesSelect"
-                label={hideLabel ? undefined : 'Subcategory'}
+                label={undefined}
+                // label={hideLabel ? undefined : 'Subcategory'}
                 onChange={(event) =>
                   handleChildCategorySelect(event.currentTarget.value)
                 }
@@ -150,8 +148,8 @@ const JobCategorySelectInput = ({
             </Box>
           </React.Fragment>
         )}
-      </Stack>
-    </Box>
+      </Box>
+    </Stack>
   );
 };
 

--- a/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
@@ -1,11 +1,15 @@
-import { Column, Columns, Dropdown } from 'braid-design-system';
-import React, { ComponentProps, useEffect, useState } from 'react';
+import { calc } from '@vanilla-extract/css-utils';
+import { vars } from 'braid-design-system/css';
+import { Box, Dropdown, Stack } from 'braid-design-system';
+import React, { ComponentProps, useEffect, useRef, useState } from 'react';
 
 import type {
   JobCategoriesQuery,
   JobCategoryAttributesFragment,
 } from '../../types/seekApi.graphql';
 import { findObjectByOid } from '../../utils';
+
+import { wrapper } from './styles.css';
 
 type AllJobCategories = JobCategoriesQuery['jobCategories'];
 type AnyJobCategory = JobCategoryAttributesFragment;
@@ -28,6 +32,7 @@ const JobCategorySelectInput = ({
   const [selectedParentCategoryId, setSelectedParentCategoryId] = useState('');
   const [selectedChildCategoryId, setSelectedChildCategoryId] = useState('');
   const [childCategories, setChildCategories] = useState<AnyJobCategory[]>();
+  const parentRef = useRef<HTMLSelectElement>(null);
 
   const handleParentCategorySelect = (parentCategoryId: string) => {
     const parentCategory = findObjectByOid(jobCategories, parentCategoryId);
@@ -76,11 +81,14 @@ const JobCategorySelectInput = ({
     }
   }, [initialValue, jobCategories]);
 
+  const dropDownHeight = parentRef.current?.clientHeight;
+
   return (
-    <Columns collapseBelow="tablet" space="small">
-      <Column>
+    <Box position="relative">
+      <Stack space="xsmall">
         <Dropdown
           {...restProps}
+          ref={parentRef}
           aria-label="Category"
           id="jobCategoriesSelect"
           label={hideLabel ? undefined : 'Category'}
@@ -96,29 +104,44 @@ const JobCategorySelectInput = ({
             </option>
           ))}
         </Dropdown>
-      </Column>
-      <Column>
-        {childCategories && (
-          <Dropdown
-            {...restProps}
-            aria-label="Subcategory"
-            id="subJobCategoriesSelect"
-            label={hideLabel ? undefined : 'Subcategory'}
-            onChange={(event) =>
-              handleChildCategorySelect(event.currentTarget.value)
-            }
-            placeholder="Select a subcategory"
-            value={selectedChildCategoryId}
-          >
-            {childCategories.map(({ name, id }) => (
-              <option key={id.value} value={id.value}>
-                {name}
-              </option>
-            ))}
-          </Dropdown>
+        {childCategories && Boolean(dropDownHeight) && (
+          <React.Fragment>
+            <Box
+              className={wrapper}
+              style={{
+                width: parentRef.current?.clientWidth / 2 ?? 0,
+                height: calc.add(
+                  `${dropDownHeight}px`,
+                  vars.space.small,
+                  vars.space.xsmall,
+                  vars.space.xxsmall,
+                  `${dropDownHeight! / 2}px`,
+                ),
+              }}
+            />
+            <Box paddingLeft="xxlarge">
+              <Dropdown
+                {...restProps}
+                aria-label="Subcategory"
+                id="subJobCategoriesSelect"
+                label={hideLabel ? undefined : 'Subcategory'}
+                onChange={(event) =>
+                  handleChildCategorySelect(event.currentTarget.value)
+                }
+                placeholder="Select a subcategory"
+                value={selectedChildCategoryId}
+              >
+                {childCategories.map(({ name, id }) => (
+                  <option key={id.value} value={id.value}>
+                    {name}
+                  </option>
+                ))}
+              </Dropdown>
+            </Box>
+          </React.Fragment>
         )}
-      </Column>
-    </Columns>
+      </Stack>
+    </Box>
   );
 };
 

--- a/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
@@ -1,6 +1,6 @@
 import { calc } from '@vanilla-extract/css-utils';
-import { vars } from 'braid-design-system/css';
 import { Box, Dropdown, Stack } from 'braid-design-system';
+import { vars } from 'braid-design-system/css';
 import React, { ComponentProps, useEffect, useRef, useState } from 'react';
 
 import type {
@@ -9,7 +9,7 @@ import type {
 } from '../../types/seekApi.graphql';
 import { findObjectByOid } from '../../utils';
 
-import { wrapper } from './styles.css';
+import { categoryLink, childCategoryStyling } from './styles.css';
 
 type AllJobCategories = JobCategoriesQuery['jobCategories'];
 type AnyJobCategory = JobCategoryAttributesFragment;
@@ -82,6 +82,22 @@ const JobCategorySelectInput = ({
   }, [initialValue, jobCategories]);
 
   const dropDownHeight = parentRef.current?.clientHeight;
+  const dropDownWidth = parentRef.current?.clientWidth
+    ? `${parentRef.current?.clientWidth}px`
+    : '0px';
+
+  let height = '0px';
+  if (dropDownHeight) {
+    const stackSpacing = calc.multiply(vars.space.xsmall, 2);
+    const dropdownPaddingTopSpacing = vars.space.xsmall;
+
+    height = calc.add(
+      `${dropDownHeight}px`,
+      stackSpacing,
+      dropdownPaddingTopSpacing,
+      `${dropDownHeight! / 2}px`,
+    );
+  }
 
   return (
     <Box position="relative">
@@ -107,19 +123,13 @@ const JobCategorySelectInput = ({
         {childCategories && Boolean(dropDownHeight) && (
           <React.Fragment>
             <Box
-              className={wrapper}
+              className={categoryLink}
               style={{
-                width: parentRef.current?.clientWidth / 2 ?? 0,
-                height: calc.add(
-                  `${dropDownHeight}px`,
-                  vars.space.small,
-                  vars.space.xsmall,
-                  vars.space.xxsmall,
-                  `${dropDownHeight! / 2}px`,
-                ),
+                width: calc.divide(dropDownWidth, 5),
+                height,
               }}
             />
-            <Box paddingLeft="xxlarge">
+            <Box className={childCategoryStyling}>
               <Dropdown
                 {...restProps}
                 aria-label="Subcategory"

--- a/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
@@ -86,15 +86,14 @@ const JobCategorySelectInput = ({
     ? `${parentRef.current?.clientWidth}px`
     : '0px';
 
-  let height = '0px';
-  if (dropDownHeight) {
-    height = calc.add(
-      vars.space.small, // Top padding allocated to wrapping `Box`
-      vars.space.xsmall, // Top padding allocated to Dropdown
-      '10px',
-      `${dropDownHeight / 2}px`,
-    );
-  }
+  const categoryLinkHeight = dropDownHeight
+    ? calc.add(
+        vars.space.small, // Padding associated to parent `Box`
+        vars.space.xsmall, // Padding associated to Dropdown
+        '10px', // Arbitrary pixels used to hide the curvature of the border
+        `${dropDownHeight / 2}px`,
+      )
+    : '0px';
 
   return (
     <Stack space="none">
@@ -116,39 +115,36 @@ const JobCategorySelectInput = ({
           </option>
         ))}
       </Dropdown>
-      <Box position="relative" paddingTop="small">
-        {childCategories && Boolean(dropDownHeight) && (
-          <React.Fragment>
-            <Box
-              className={categoryLink}
-              style={{
-                width: calc.divide(dropDownWidth, 5), // Divide by 5 to minimise width a lot
-                height,
-              }}
-            />
-            <Box className={childCategoryStyling}>
-              <Dropdown
-                {...restProps}
-                aria-label="Subcategory"
-                id="subJobCategoriesSelect"
-                label={undefined}
-                // label={hideLabel ? undefined : 'Subcategory'}
-                onChange={(event) =>
-                  handleChildCategorySelect(event.currentTarget.value)
-                }
-                placeholder="Select a subcategory"
-                value={selectedChildCategoryId}
-              >
-                {childCategories.map(({ name, id }) => (
-                  <option key={id.value} value={id.value}>
-                    {name}
-                  </option>
-                ))}
-              </Dropdown>
-            </Box>
-          </React.Fragment>
-        )}
-      </Box>
+      {childCategories && (
+        <Box position="relative" paddingTop="small">
+          <Box
+            className={categoryLink}
+            style={{
+              width: calc.divide(dropDownWidth, 5), // Divide by an arbitrary number to minimise width
+              height: categoryLinkHeight,
+            }}
+          />
+          <Box className={childCategoryStyling}>
+            <Dropdown
+              {...restProps}
+              aria-label="Subcategory"
+              id="subJobCategoriesSelect"
+              label={undefined}
+              onChange={(event) =>
+                handleChildCategorySelect(event.currentTarget.value)
+              }
+              placeholder="Select a subcategory"
+              value={selectedChildCategoryId}
+            >
+              {childCategories.map(({ name, id }) => (
+                <option key={id.value} value={id.value}>
+                  {name}
+                </option>
+              ))}
+            </Dropdown>
+          </Box>
+        </Box>
+      )}
     </Stack>
   );
 };

--- a/fe/lib/components/JobCategorySelect/styles.css.ts
+++ b/fe/lib/components/JobCategorySelect/styles.css.ts
@@ -5,7 +5,7 @@ import { vars } from 'braid-design-system/css';
 export const categoryLink = style({
   position: 'absolute',
   marginLeft: vars.space.large,
-  top: vars.space.xsmall, // Parent dropdown has a `paddingTop` of xsmall
+  top: '-10px', // Arbitrary number to hide the curvature of the border
   zIndex: -1,
   borderLeftStyle: 'solid',
   borderLeftWidth: vars.borderWidth.standard,

--- a/fe/lib/components/JobCategorySelect/styles.css.ts
+++ b/fe/lib/components/JobCategorySelect/styles.css.ts
@@ -5,7 +5,7 @@ import { vars } from 'braid-design-system/css';
 export const categoryLink = style({
   position: 'absolute',
   marginLeft: vars.space.large,
-  top: '-10px', // Arbitrary number to hide the curvature of the border
+  top: '-10px', // Arbitrary pixels used to hide the curvature of the border
   zIndex: -1,
   borderLeftStyle: 'solid',
   borderLeftWidth: vars.borderWidth.standard,

--- a/fe/lib/components/JobCategorySelect/styles.css.ts
+++ b/fe/lib/components/JobCategorySelect/styles.css.ts
@@ -1,0 +1,15 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from 'braid-design-system/css';
+
+export const wrapper = style({
+  position: 'absolute',
+  marginLeft: vars.space.large,
+  top: vars.space.xsmall,
+  left: 0,
+  zIndex: -1,
+  borderLeftStyle: 'solid',
+  borderLeftWidth: vars.borderWidth.standard,
+  borderBottomStyle: 'solid',
+  borderBottomWidth: vars.borderWidth.standard,
+  borderRadius: vars.borderRadius.standard,
+});

--- a/fe/lib/components/JobCategorySelect/styles.css.ts
+++ b/fe/lib/components/JobCategorySelect/styles.css.ts
@@ -1,15 +1,21 @@
 import { style } from '@vanilla-extract/css';
+import { calc } from '@vanilla-extract/css-utils';
 import { vars } from 'braid-design-system/css';
 
-export const wrapper = style({
+export const categoryLink = style({
   position: 'absolute',
   marginLeft: vars.space.large,
-  top: vars.space.xsmall,
-  left: 0,
+  top: vars.space.xsmall, // Parent dropdown has a `paddingTop` of xsmall
   zIndex: -1,
   borderLeftStyle: 'solid',
   borderLeftWidth: vars.borderWidth.standard,
-  borderBottomStyle: 'solid',
+  borderLeftColor: vars.borderColor.field,
   borderBottomWidth: vars.borderWidth.standard,
+  borderBottomStyle: 'solid',
+  borderBottomColor: vars.borderColor.field,
   borderRadius: vars.borderRadius.standard,
+});
+
+export const childCategoryStyling = style({
+  paddingLeft: calc.add(vars.space.xlarge, vars.space.large),
 });

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -105,27 +105,32 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
               );
             })}
           </>
-          <RadioItem key="Other" label="Other" ref={forwardedRef} value="Other">
-            {selectedJobCategory === 'Other' && (
-              <JobCategorySelect
-                client={client}
-                label="Category"
-                id="job-category-suggest-select-other"
-                initialValue={initialValue}
-                onSelect={(jobCategory, type) => {
-                  /**
-                   * Only child job categories are suitable for job posting
-                   */
-                  if (type === 'child') {
-                    onSelect({ jobCategory, confidence: 1 });
-                  }
-                }}
-                schemeId={schemeId}
-                hideLabel
-              />
-            )}
-          </RadioItem>
+          <RadioItem
+            key="Other"
+            label="Choose a different category"
+            ref={forwardedRef}
+            value="Other"
+          />
         </RadioGroup>
+        {selectedJobCategory === 'Other' && (
+          <JobCategorySelect
+            client={client}
+            label="Category"
+            id="job-category-suggest-select-other"
+            initialValue={initialValue}
+            onSelect={(jobCategory, type) => {
+              /**
+               * Only child job categories are suitable for job posting
+               */
+              if (type === 'child') {
+                onSelect({ jobCategory, confidence: 1 });
+              }
+            }}
+            embedded
+            schemeId={schemeId}
+            hideLabel
+          />
+        )}
       </Stack>
     );
   },

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -126,7 +126,6 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
                 onSelect({ jobCategory, confidence: 1 });
               }
             }}
-            embedded
             schemeId={schemeId}
             hideLabel
           />


### PR DESCRIPTION
This PR does the following:
- Updates the text "Other" to "Choose a different category"
- Stack the sub category under the parent category with a linking line
- Removed the label for the sub category when using job category select (doesn't seem necessary anymore)

**Category Suggest:**
![Screen Shot 2021-09-20 at 4 17 25 pm](https://user-images.githubusercontent.com/22812702/133962857-f49d892f-5e80-4936-a4c1-29534c86fdca.png)

**Category Select:**
![Screen Shot 2021-09-20 at 4 17 34 pm](https://user-images.githubusercontent.com/22812702/133962868-3246c000-b263-4834-80c6-8b919c69927a.png)

