### PR TITLE
Fix linking line being hidden for job category select

### DIFF
--- a/.changeset/tall-files-glow.md
+++ b/.changeset/tall-files-glow.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': patch
+---
+
+Fix linking line being hidden for job category suggest

--- a/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelectInput.tsx
@@ -82,15 +82,11 @@ const JobCategorySelectInput = ({
   }, [initialValue, jobCategories]);
 
   const dropDownHeight = parentRef.current?.clientHeight;
-  const dropDownWidth = parentRef.current?.clientWidth
-    ? `${parentRef.current?.clientWidth}px`
-    : '0px';
 
   const categoryLinkHeight = dropDownHeight
     ? calc.add(
         vars.space.small, // Padding associated to parent `Box`
         vars.space.xsmall, // Padding associated to Dropdown
-        '10px', // Arbitrary pixels used to hide the curvature of the border
         `${dropDownHeight / 2}px`,
       )
     : '0px';
@@ -119,10 +115,7 @@ const JobCategorySelectInput = ({
         <Box position="relative" paddingTop="small">
           <Box
             className={categoryLink}
-            style={{
-              width: calc.divide(dropDownWidth, 5), // Divide by an arbitrary number to minimise width
-              height: categoryLinkHeight,
-            }}
+            style={{ height: categoryLinkHeight }}
           />
           <Box className={childCategoryStyling}>
             <Dropdown

--- a/fe/lib/components/JobCategorySelect/styles.css.ts
+++ b/fe/lib/components/JobCategorySelect/styles.css.ts
@@ -4,16 +4,16 @@ import { vars } from 'braid-design-system/css';
 
 export const categoryLink = style({
   position: 'absolute',
+  width: vars.space.xlarge,
   marginLeft: vars.space.large,
-  top: '-10px', // Arbitrary pixels used to hide the curvature of the border
-  zIndex: -1,
+  top: 0,
   borderLeftStyle: 'solid',
   borderLeftWidth: vars.borderWidth.standard,
   borderLeftColor: vars.borderColor.field,
   borderBottomWidth: vars.borderWidth.standard,
   borderBottomStyle: 'solid',
   borderBottomColor: vars.borderColor.field,
-  borderRadius: vars.borderRadius.standard,
+  borderBottomLeftRadius: vars.borderRadius.standard,
 });
 
 export const childCategoryStyling = style({


### PR DESCRIPTION
The linking line between the parent and child category were being hidden behind the card in Ryanair due to its `z-index`. I've gone and removed that and instead just calculated the correct height and width for it, as well as set the curvature to only occur to the bottom left of the border.