### PR TITLE
Upgrade to Node.js 14 in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
           fetch-depth: 0
           lfs: true
 
-      - name: Set up Node.js 12.x
+      - name: Set up Node.js 14.x
         uses: actions/setup-node@master
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@master
 
-      - name: Set up Node.js 12.x
+      - name: Set up Node.js 14.x
         uses: actions/setup-node@master
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
The release action was failing because it didn't understand `??`.

https://node.green/#ES2020-features--nullish-coalescing-operator-----