### PR TITLE
Add GitHub links to mock component actions

### DIFF
--- a/.changeset/ten-boats-invent.md
+++ b/.changeset/ten-boats-invent.md
@@ -1,0 +1,7 @@
+---
+'wingman-fe': minor
+---
+
+**MockComponents:** Add GitHub links to mock component actions
+
+The existence of Wingman is still a bit mysterious. This adds an explicit link from our `MockComponentActions` to the relevant directory on GitHub.

--- a/fe/lib/components/AdSelectionFallback/AdSelectionFallback.mock.tsx
+++ b/fe/lib/components/AdSelectionFallback/AdSelectionFallback.mock.tsx
@@ -20,6 +20,7 @@ export const MockAdSelectionFallback = forwardRef<HTMLSelectElement, Props>(
           ? '/story/job-posting-ad-selection-adselectionfallback--ad-selection-fallback'
           : undefined
       }
+      sourcePath="lib/components/AdSelectionFallback"
     >
       <AdSelectionFallback {...props} ref={ref} />
     </MockComponentActions>

--- a/fe/lib/components/BrandSelect/BrandSelect.mock.tsx
+++ b/fe/lib/components/BrandSelect/BrandSelect.mock.tsx
@@ -36,6 +36,7 @@ export const MockBrandSelect = ({
           ? '/story/job-posting-branding-brandselect--brand-select'
           : undefined
       }
+      sourcePath="lib/components/BrandSelect"
     >
       <BrandSelect {...props} pageSize={pageSize} />
     </MockComponentActions>

--- a/fe/lib/components/JobCategorySelect/JobCategorySelect.mock.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelect.mock.tsx
@@ -26,6 +26,7 @@ export const MockJobCategorySelect = forwardRef<HTMLInputElement, Props>(
             ? '/story/job-posting-job-categories-jobcategoryselect--job-category-select'
             : undefined
         }
+        sourcePath="lib/components/JobCategorySelect"
       >
         <JobCategorySelect {...props} ref={ref} />
       </MockComponentActions>

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.mock.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.mock.tsx
@@ -31,6 +31,7 @@ export const MockJobCategorySuggest = forwardRef<HTMLInputElement, Props>(
             ? '/story/job-posting-job-categories-jobcategorysuggest--job-category-suggest'
             : undefined
         }
+        sourcePath="lib/components/JobCategorySuggest"
       >
         <JobCategorySuggest {...props} ref={ref} />
       </MockComponentActions>

--- a/fe/lib/components/LocationSuggest/LocationSuggest.mock.tsx
+++ b/fe/lib/components/LocationSuggest/LocationSuggest.mock.tsx
@@ -41,6 +41,7 @@ export const MockLocationSuggest = forwardRef<HTMLInputElement, Props>(
             ? '/story/job-posting-locations-locationsuggest--location-suggest'
             : undefined
         }
+        sourcePath="lib/components/LocationSuggestion"
       >
         <Component {...props} ref={ref} />
       </MockComponentActions>

--- a/fe/lib/private/MockComponentActions/MockComponentActions.tsx
+++ b/fe/lib/private/MockComponentActions/MockComponentActions.tsx
@@ -1,33 +1,55 @@
-import { Actions, ButtonLink, IconEducation, Stack } from 'braid-design-system';
+import {
+  Actions,
+  ButtonLink,
+  IconEducation,
+  IconSocialGitHub,
+  Stack,
+} from 'braid-design-system';
 import React, { ComponentProps } from 'react';
 
 interface MockComponentActionsProps {
   children: ComponentProps<typeof Stack>['children'];
   space: ComponentProps<typeof Stack>['space'];
   storybookPath?: string;
+  sourcePath?: string;
 }
 
 export const MockComponentActions = ({
   children,
   space,
   storybookPath,
+  sourcePath,
 }: MockComponentActionsProps) => (
   <Stack space={space}>
     {children}
 
-    {storybookPath ? (
+    {storybookPath || sourcePath ? (
       <Actions size="small">
-        <ButtonLink
-          href={`https://seek-oss.github.io/wingman/storybook/?path=${encodeURIComponent(
-            storybookPath,
-          )}`}
-          rel="noreferrer"
-          target="_blank"
-          tone="brandAccent"
-          variant="ghost"
-        >
-          <IconEducation /> Open in Storybook
-        </ButtonLink>
+        {storybookPath ? (
+          <ButtonLink
+            href={`https://seek-oss.github.io/wingman/storybook/?path=${encodeURIComponent(
+              storybookPath,
+            )}`}
+            rel="noreferrer"
+            target="_blank"
+            tone="brandAccent"
+            variant="ghost"
+          >
+            <IconEducation /> Open in Storybook
+          </ButtonLink>
+        ) : null}
+
+        {sourcePath ? (
+          <ButtonLink
+            href={`https://github.com/seek-oss/wingman/tree/master/fe/${sourcePath}`}
+            rel="noreferrer"
+            target="_blank"
+            tone="brandAccent"
+            variant="soft"
+          >
+            <IconSocialGitHub /> View on GitHub
+          </ButtonLink>
+        ) : null}
       </Actions>
     ) : null}
   </Stack>

--- a/fe/lib/private/MockComponentActions/MockComponentActions.tsx
+++ b/fe/lib/private/MockComponentActions/MockComponentActions.tsx
@@ -45,7 +45,7 @@ export const MockComponentActions = ({
             rel="noreferrer"
             target="_blank"
             tone="brandAccent"
-            variant="soft"
+            variant="transparent"
           >
             <IconSocialGitHub /> View on GitHub
           </ButtonLink>


### PR DESCRIPTION
The existence of Wingman is still a bit mysterious. This adds an explicit link from our `MockComponentActions` to the relevant directory on GitHub. This will allow curious developers to go directly from the mock component on the Developer Site to the Wingman source.

<img width="887" alt="Screen Shot 2021-09-28 at 14 25 18" src="https://user-images.githubusercontent.com/687534/135023090-cb7f3d41-82d5-4644-8b3d-5e6d6f604f48.png">

