### PR TITLE
Control GitHub links with `showStorybookAction`

### DIFF
--- a/.changeset/six-spiders-smile.md
+++ b/.changeset/six-spiders-smile.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': patch
+---
+
+**Mock\*:** Control "View on GitHub" links with `showStorybookAction`

--- a/fe/lib/components/AdSelectionFallback/AdSelectionFallback.mock.tsx
+++ b/fe/lib/components/AdSelectionFallback/AdSelectionFallback.mock.tsx
@@ -15,10 +15,9 @@ export const MockAdSelectionFallback = forwardRef<HTMLSelectElement, Props>(
   ({ showStorybookAction, ...props }, ref) => (
     <MockComponentActions
       space="medium"
+      showStorybookAction={showStorybookAction}
       storybookPath={
-        showStorybookAction
-          ? '/story/job-posting-ad-selection-adselectionfallback--ad-selection-fallback'
-          : undefined
+        '/story/job-posting-ad-selection-adselectionfallback--ad-selection-fallback'
       }
       sourcePath="lib/components/AdSelectionFallback"
     >

--- a/fe/lib/components/AdSelectionFallback/AdSelectionFallback.mock.tsx
+++ b/fe/lib/components/AdSelectionFallback/AdSelectionFallback.mock.tsx
@@ -16,9 +16,7 @@ export const MockAdSelectionFallback = forwardRef<HTMLSelectElement, Props>(
     <MockComponentActions
       space="medium"
       showStorybookAction={showStorybookAction}
-      storybookPath={
-        '/story/job-posting-ad-selection-adselectionfallback--ad-selection-fallback'
-      }
+      storybookPath="/story/job-posting-ad-selection-adselectionfallback--ad-selection-fallback"
       sourcePath="lib/components/AdSelectionFallback"
     >
       <AdSelectionFallback {...props} ref={ref} />

--- a/fe/lib/components/BrandSelect/BrandSelect.mock.tsx
+++ b/fe/lib/components/BrandSelect/BrandSelect.mock.tsx
@@ -31,11 +31,8 @@ export const MockBrandSelect = ({
   >
     <MockComponentActions
       space="medium"
-      storybookPath={
-        showStorybookAction
-          ? '/story/job-posting-branding-brandselect--brand-select'
-          : undefined
-      }
+      showStorybookAction={showStorybookAction}
+      storybookPath={'/story/job-posting-branding-brandselect--brand-select'}
       sourcePath="lib/components/BrandSelect"
     >
       <BrandSelect {...props} pageSize={pageSize} />

--- a/fe/lib/components/BrandSelect/BrandSelect.mock.tsx
+++ b/fe/lib/components/BrandSelect/BrandSelect.mock.tsx
@@ -32,7 +32,7 @@ export const MockBrandSelect = ({
     <MockComponentActions
       space="medium"
       showStorybookAction={showStorybookAction}
-      storybookPath={'/story/job-posting-branding-brandselect--brand-select'}
+      storybookPath="/story/job-posting-branding-brandselect--brand-select"
       sourcePath="lib/components/BrandSelect"
     >
       <BrandSelect {...props} pageSize={pageSize} />

--- a/fe/lib/components/JobCategorySelect/JobCategorySelect.mock.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelect.mock.tsx
@@ -22,9 +22,7 @@ export const MockJobCategorySelect = forwardRef<HTMLInputElement, Props>(
       <MockComponentActions
         space="medium"
         showStorybookAction={showStorybookAction}
-        storybookPath={
-          '/story/job-posting-job-categories-jobcategoryselect--job-category-select'
-        }
+        storybookPath="/story/job-posting-job-categories-jobcategoryselect--job-category-select"
         sourcePath="lib/components/JobCategorySelect"
       >
         <JobCategorySelect {...props} ref={ref} />

--- a/fe/lib/components/JobCategorySelect/JobCategorySelect.mock.tsx
+++ b/fe/lib/components/JobCategorySelect/JobCategorySelect.mock.tsx
@@ -21,10 +21,9 @@ export const MockJobCategorySelect = forwardRef<HTMLInputElement, Props>(
     >
       <MockComponentActions
         space="medium"
+        showStorybookAction={showStorybookAction}
         storybookPath={
-          showStorybookAction
-            ? '/story/job-posting-job-categories-jobcategoryselect--job-category-select'
-            : undefined
+          '/story/job-posting-job-categories-jobcategoryselect--job-category-select'
         }
         sourcePath="lib/components/JobCategorySelect"
       >

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.mock.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.mock.tsx
@@ -26,10 +26,9 @@ export const MockJobCategorySuggest = forwardRef<HTMLInputElement, Props>(
     >
       <MockComponentActions
         space="medium"
+        showStorybookAction={showStorybookAction}
         storybookPath={
-          showStorybookAction
-            ? '/story/job-posting-job-categories-jobcategorysuggest--job-category-suggest'
-            : undefined
+          '/story/job-posting-job-categories-jobcategorysuggest--job-category-suggest'
         }
         sourcePath="lib/components/JobCategorySuggest"
       >

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.mock.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.mock.tsx
@@ -27,9 +27,7 @@ export const MockJobCategorySuggest = forwardRef<HTMLInputElement, Props>(
       <MockComponentActions
         space="medium"
         showStorybookAction={showStorybookAction}
-        storybookPath={
-          '/story/job-posting-job-categories-jobcategorysuggest--job-category-suggest'
-        }
+        storybookPath="/story/job-posting-job-categories-jobcategorysuggest--job-category-suggest"
         sourcePath="lib/components/JobCategorySuggest"
       >
         <JobCategorySuggest {...props} ref={ref} />

--- a/fe/lib/components/LocationSuggest/LocationSuggest.mock.tsx
+++ b/fe/lib/components/LocationSuggest/LocationSuggest.mock.tsx
@@ -37,9 +37,7 @@ export const MockLocationSuggest = forwardRef<HTMLInputElement, Props>(
       <MockComponentActions
         space="medium"
         showStorybookAction={showStorybookAction}
-        storybookPath={
-          '/story/job-posting-locations-locationsuggest--location-suggest'
-        }
+        storybookPath="/story/job-posting-locations-locationsuggest--location-suggest"
         sourcePath="lib/components/LocationSuggestion"
       >
         <Component {...props} ref={ref} />

--- a/fe/lib/components/LocationSuggest/LocationSuggest.mock.tsx
+++ b/fe/lib/components/LocationSuggest/LocationSuggest.mock.tsx
@@ -36,10 +36,9 @@ export const MockLocationSuggest = forwardRef<HTMLInputElement, Props>(
     >
       <MockComponentActions
         space="medium"
+        showStorybookAction={showStorybookAction}
         storybookPath={
-          showStorybookAction
-            ? '/story/job-posting-locations-locationsuggest--location-suggest'
-            : undefined
+          '/story/job-posting-locations-locationsuggest--location-suggest'
         }
         sourcePath="lib/components/LocationSuggestion"
       >

--- a/fe/lib/components/SalaryDetails/SalaryDetails.mock.tsx
+++ b/fe/lib/components/SalaryDetails/SalaryDetails.mock.tsx
@@ -12,9 +12,7 @@ export const MockSalaryDetails = ({ showStorybookAction, ...props }: Props) => (
   <MockComponentActions
     space="medium"
     showStorybookAction={showStorybookAction}
-    storybookPath={
-      '/story/job-posting-salary-details-salarydetails--salary-details'
-    }
+    storybookPath="/story/job-posting-salary-details-salarydetails--salary-details"
     sourcePath="lib/components/SalaryDetails"
   >
     <SalaryDetails {...props} />

--- a/fe/lib/components/SalaryDetails/SalaryDetails.mock.tsx
+++ b/fe/lib/components/SalaryDetails/SalaryDetails.mock.tsx
@@ -11,10 +11,9 @@ interface Props extends SalaryDetailsProps {
 export const MockSalaryDetails = ({ showStorybookAction, ...props }: Props) => (
   <MockComponentActions
     space="medium"
+    showStorybookAction={showStorybookAction}
     storybookPath={
-      showStorybookAction
-        ? '/story/job-posting-salary-details-salarydetails--salary-details'
-        : undefined
+      '/story/job-posting-salary-details-salarydetails--salary-details'
     }
     sourcePath="lib/components/SalaryDetails"
   >

--- a/fe/lib/private/MockComponentActions/MockComponentActions.tsx
+++ b/fe/lib/private/MockComponentActions/MockComponentActions.tsx
@@ -10,20 +10,24 @@ import React, { ComponentProps } from 'react';
 interface MockComponentActionsProps {
   children: ComponentProps<typeof Stack>['children'];
   space: ComponentProps<typeof Stack>['space'];
-  storybookPath?: string;
-  sourcePath?: string;
+
+  showStorybookAction: boolean | undefined;
+  storybookPath: string;
+  sourcePath: string;
 }
 
 export const MockComponentActions = ({
   children,
   space,
+
+  showStorybookAction,
   storybookPath,
   sourcePath,
 }: MockComponentActionsProps) => (
   <Stack space={space}>
     {children}
 
-    {storybookPath || sourcePath ? (
+    {showStorybookAction && (storybookPath || sourcePath) ? (
       <Actions size="small">
         {storybookPath ? (
           <ButtonLink

--- a/fe/lib/private/MockComponentActions/MockComponentActions.tsx
+++ b/fe/lib/private/MockComponentActions/MockComponentActions.tsx
@@ -27,7 +27,7 @@ export const MockComponentActions = ({
   <Stack space={space}>
     {children}
 
-    {showStorybookAction ? (
+    {showStorybookAction && (
       <Actions size="small">
         <ButtonLink
           href={`https://seek-oss.github.io/wingman/storybook/?path=${encodeURIComponent(
@@ -51,6 +51,6 @@ export const MockComponentActions = ({
           <IconSocialGitHub /> View on GitHub
         </ButtonLink>
       </Actions>
-    ) : null}
+    )}
   </Stack>
 );

--- a/fe/lib/private/MockComponentActions/MockComponentActions.tsx
+++ b/fe/lib/private/MockComponentActions/MockComponentActions.tsx
@@ -27,33 +27,29 @@ export const MockComponentActions = ({
   <Stack space={space}>
     {children}
 
-    {showStorybookAction && (storybookPath || sourcePath) ? (
+    {showStorybookAction ? (
       <Actions size="small">
-        {storybookPath ? (
-          <ButtonLink
-            href={`https://seek-oss.github.io/wingman/storybook/?path=${encodeURIComponent(
-              storybookPath,
-            )}`}
-            rel="noreferrer"
-            target="_blank"
-            tone="brandAccent"
-            variant="ghost"
-          >
-            <IconEducation /> Open in Storybook
-          </ButtonLink>
-        ) : null}
+        <ButtonLink
+          href={`https://seek-oss.github.io/wingman/storybook/?path=${encodeURIComponent(
+            storybookPath,
+          )}`}
+          rel="noreferrer"
+          target="_blank"
+          tone="brandAccent"
+          variant="ghost"
+        >
+          <IconEducation /> Open in Storybook
+        </ButtonLink>
 
-        {sourcePath ? (
-          <ButtonLink
-            href={`https://github.com/seek-oss/wingman/tree/master/fe/${sourcePath}`}
-            rel="noreferrer"
-            target="_blank"
-            tone="brandAccent"
-            variant="transparent"
-          >
-            <IconSocialGitHub /> View on GitHub
-          </ButtonLink>
-        ) : null}
+        <ButtonLink
+          href={`https://github.com/seek-oss/wingman/tree/master/fe/${sourcePath}`}
+          rel="noreferrer"
+          target="_blank"
+          tone="brandAccent"
+          variant="transparent"
+        >
+          <IconSocialGitHub /> View on GitHub
+        </ButtonLink>
       </Actions>
     ) : null}
   </Stack>


### PR DESCRIPTION
When this is `false`/`undefined` we still show the "View on GitHub" link which is unlikely what the consumer wants. This repurposes the flag to control both the storybook & GitHub links as a group.

This also lets us tighten the types on our internal `MockComponentActions` to ensure the mock component is providing all the relevant links.
