### PR TITLE
Increase spacing on `MockSalaryDetails` actions

### DIFF
--- a/.changeset/big-mice-camp.md
+++ b/.changeset/big-mice-camp.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': patch
+---
+
+**MockSalaryDetails:** Increase spacing on mock component actions

--- a/fe/lib/components/SalaryDetails/SalaryDetails.mock.tsx
+++ b/fe/lib/components/SalaryDetails/SalaryDetails.mock.tsx
@@ -10,7 +10,7 @@ interface Props extends SalaryDetailsProps {
 
 export const MockSalaryDetails = ({ showStorybookAction, ...props }: Props) => (
   <MockComponentActions
-    space="medium"
+    space="large"
     showStorybookAction={showStorybookAction}
     storybookPath="/story/job-posting-salary-details-salarydetails--salary-details"
     sourcePath="lib/components/SalaryDetails"


### PR DESCRIPTION
This consists of a multiple controls which makes the `medium` spacing look a bit crowded.
