### PR TITLE
Show `SpecifiedPerson` name components on same row

### DIFF
--- a/.changeset/purple-eggs-wave.md
+++ b/.changeset/purple-eggs-wave.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': patch
+---
+
+**SpecifiedPersonForm:** Show name components on the same row on desktop

--- a/fe/lib/components/SpecifiedPersonForm/SpecifiedPersonForm.tsx
+++ b/fe/lib/components/SpecifiedPersonForm/SpecifiedPersonForm.tsx
@@ -1,6 +1,8 @@
 import {
   Box,
   Button,
+  Column,
+  Columns,
   Stack,
   Strong,
   Text,
@@ -119,8 +121,16 @@ export const SpecifiedPersonForm = ({
           />
         </Text>
       </Box>
-      <TextField {...fieldProps('specifiedPersonGivenName')} />
-      <TextField {...fieldProps('specifiedPersonFamilyName')} />
+
+      <Columns collapseBelow="desktop" space="medium">
+        <Column>
+          <TextField {...fieldProps('specifiedPersonGivenName')} />
+        </Column>
+        <Column>
+          <TextField {...fieldProps('specifiedPersonFamilyName')} />
+        </Column>
+      </Columns>
+
       <TextField {...fieldProps('specifiedPersonEmailAddress')} />
       <TextField {...fieldProps('specifiedPersonPhoneNumber')} />
 


### PR DESCRIPTION
We have lots of horizontal space on desktop to display the names beside each other. This should free up some precious vertical space on Ryanair.
