### PR TITLE
Set input type for SpecifiedPersonForm email/phone

### DIFF
--- a/.changeset/healthy-readers-sneeze.md
+++ b/.changeset/healthy-readers-sneeze.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': patch
+---
+
+**SpecifiedPersonForm:** Set input types for email & phone fields

--- a/fe/lib/components/SpecifiedPersonForm/SpecifiedPersonForm.tsx
+++ b/fe/lib/components/SpecifiedPersonForm/SpecifiedPersonForm.tsx
@@ -133,8 +133,8 @@ export const SpecifiedPersonForm = ({
         </Column>
       </Columns>
 
-      <TextField {...fieldProps('specifiedPersonEmailAddress')} />
-      <TextField {...fieldProps('specifiedPersonPhoneNumber')} />
+      <TextField type="email" {...fieldProps('specifiedPersonEmailAddress')} />
+      <TextField type="tel" {...fieldProps('specifiedPersonPhoneNumber')} />
 
       <Actions>
         <Button onClick={addContact}>


### PR DESCRIPTION
This makes little difference on desktop browsers, but causes mobile software keyboards to customise their layout.
