### PR TITLE
Separate JobCategorySuggest positionProfile prop

### DIFF
--- a/.changeset/serious-rivers-attack.md
+++ b/.changeset/serious-rivers-attack.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': major
+---
+
+**JobCategorySuggest:** Change props to accept separated positionTitle and positionLocation

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.stories.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.stories.tsx
@@ -17,10 +17,8 @@ export default {
     braidThemeName: defaultArgs.braidThemeName,
     message: 'undefined',
     onSelect: () => {},
-    positionProfile: {
-      positionTitle: `Senior Developer`,
-      positionLocation: ['seekAnzPublicTest:location:seek:2FqwWaaMV'],
-    },
+    positionTitle: `Senior Developer`,
+    positionLocation: ['seekAnzPublicTest:location:seek:2FqwWaaMV'],
     reserveMessageSpace: false,
     schemeId: 'seekAnz',
     tone: defaultArgs.tone,

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
@@ -12,7 +12,6 @@ import { useDebounce } from 'use-debounce';
 import type {
   JobCategorySuggestQuery,
   JobCategorySuggestionChoiceAttributesFragment,
-  JobCategorySuggestionPositionProfileInput,
 } from '../../types/seekApi.graphql';
 
 import JobCategorySuggestChoices from './JobCategorySuggestChoices';
@@ -22,7 +21,8 @@ type RadioProps = ComponentPropsWithRef<typeof RadioGroup>;
 
 export interface JobCategorySuggestProps
   extends Partial<Omit<RadioProps, 'id'>> {
-  positionProfile: JobCategorySuggestionPositionProfileInput;
+  positionTitle: string;
+  positionLocation: string[];
   schemeId: string;
   onSelect: (
     jobCategorySuggestionChoice: JobCategorySuggestionChoiceAttributesFragment,
@@ -42,7 +42,8 @@ export const JobCategorySuggest = forwardRef<
       client,
       debounceDelay = 250,
       onSelect,
-      positionProfile,
+      positionTitle,
+      positionLocation,
       schemeId,
       showConfidence,
       initialValue,
@@ -65,23 +66,28 @@ export const JobCategorySuggest = forwardRef<
       fetchPolicy: 'no-cache',
     });
 
-    const [debounceJobCategorySuggestInput] = useDebounce(
-      positionProfile,
+    const [debouncePositionTitle] = useDebounce(positionTitle, debounceDelay);
+
+    const [debouncePositionLocation] = useDebounce(
+      positionLocation,
       debounceDelay,
     );
 
     useEffect(() => {
-      if (debounceJobCategorySuggestInput) {
+      if (debouncePositionTitle && debouncePositionLocation) {
         getCategorySuggestion({
           variables: {
-            positionProfile: debounceJobCategorySuggestInput,
+            positionProfile: {
+              positionTitle: debouncePositionTitle,
+              positionLocation: debouncePositionLocation,
+            },
             schemeId,
             first: 5,
           },
         });
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [schemeId, debounceJobCategorySuggestInput]);
+    }, [schemeId, debouncePositionTitle, debouncePositionLocation]);
 
     return (
       <Stack space="small">

--- a/fe/lib/components/JobCategorySuggest/README.md
+++ b/fe/lib/components/JobCategorySuggest/README.md
@@ -46,7 +46,11 @@ const positionProfile = {
 }
 
 // Higher component in tree wraps children in apollo provider
-<JobCategorySuggest schemeId="seekAnz" positionProfile={positionProfile} />;
+<JobCategorySuggest
+  schemeId="seekAnz"
+  positionTitle={positionTitle}
+  positionLocation={positionLocation}
+/>;
 ```
 
 #### Default usage with Apollo Client
@@ -76,7 +80,8 @@ const positionProfile = {
 <JobCategorySuggest
   schemeId="seekAnz"
   client={client}
-  positionProfile={positionProfile}
+  positionTitle={positionTitle}
+  positionLocation={positionLocation}
 />;
 ```
 
@@ -97,7 +102,8 @@ const JobCategoryForm = () => {
         schemeId="seekAnz"
         client={client}
         onSelect={jobCategorySuggest}
-        positionProfile={positionProfile}
+        positionTitle={positionTitle}
+        positionLocation={positionLocation}
       />
       <p>
         Your selected job category is: {jobCategorySuggest.JobCategory.name}
@@ -142,7 +148,8 @@ const JobCategoryForm = () => {
                 shouldValidate: true,
               })
             }
-            positionProfile={positionProfile}
+            positionTitle={positionTitle}
+            positionLocation={positionLocation}
             schemeId="seekAnz"
           />
         )}


### PR DESCRIPTION
Using an object here was confusing React's equality checking into reloading the widget.

You're now required to pass two props (`positionTitle` and `positionLocation`) instead of one `positionProfile`.