### PR TITLE
Refactor LocationSuggest to use functional queries

### DIFF
--- a/.changeset/quick-eagles-fail.md
+++ b/.changeset/quick-eagles-fail.md
@@ -1,0 +1,7 @@
+---
+'wingman-fe': patch
+---
+
+**LocationSuggest:** Refactor to use functional queries
+
+This avoids throwing `AbortError` while using `LocationSuggest` in development mode


### PR DESCRIPTION
We were driving a lot of Apollo's logic using a series of `useEffect`s. That style is:

- Hard to follow

- Fragile in the case of re-renders (similar to the problems `JobCategorySuggest` had)

- Caused "The user aborted a request" errors to be throw in dev mode

This switches us to `useQuery` instead of `useEffect` + `useState` + `useLazyQuery`.
