### PR TITLE
Stop JobCategorySuggest auto-selecting highly-recommended categories

### DIFF
--- a/.changeset/quick-eagles-ring.md
+++ b/.changeset/quick-eagles-ring.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': minor
+---
+
+Stop auto-selecting a highly-recommended category in JobCategorySuggest

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggestChoices.tsx
@@ -6,7 +6,7 @@ import {
   Strong,
   Text,
 } from 'braid-design-system';
-import React, { ComponentProps, forwardRef, useEffect, useState } from 'react';
+import React, { ComponentProps, forwardRef, useState } from 'react';
 
 import type {
   JobCategory,
@@ -57,14 +57,6 @@ const JobCategorySuggestChoices = forwardRef<HTMLInputElement, Props>(
     const [selectedJobCategory, setSelectedJobCategory] = useState<
       string | undefined
     >(initialValue ? 'Other' : undefined);
-
-    useEffect(() => {
-      const [firstChoice] = choices;
-      if (!selectedJobCategory && firstChoice.confidence > 0.5) {
-        setSelectedJobCategory(firstChoice.jobCategory.id.value);
-        onSelect(firstChoice);
-      }
-    }, [choices, selectedJobCategory, onSelect]);
 
     const handleChoiceSelect = (event: React.FormEvent<HTMLInputElement>) => {
       const choiceId = event.currentTarget.value;


### PR DESCRIPTION
https://trello.com/c/F3JHJ63H/1600-do-not-prefill-jobcategoryselect-in-jobcategorysuggest

We got feedback from Acendre via the implementation squads that preselecting a category was not ideal in a UX sense.

Have a look for anything else that can be simplified or removed now that this feature is gone. I couldn't see any, but a second pair of eyes might find something.