### PR TITLE
Remove unused 'value' prop from JobCategorySuggest

### DIFF
--- a/.changeset/many-items-cheer.md
+++ b/.changeset/many-items-cheer.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': major
+---
+
+Remove unused 'value' prop from JobCategorySuggest

--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
@@ -22,7 +22,7 @@ import { JOB_CATEGORY_SUGGEST } from './queries';
 type RadioProps = ComponentPropsWithRef<typeof RadioGroup>;
 
 export interface JobCategorySuggestProps
-  extends Partial<Omit<RadioProps, 'id'>> {
+  extends Partial<Omit<RadioProps, 'id' | 'value'>> {
   positionProfile: JobCategorySuggestionPositionProfileInput;
   schemeId: string;
   onSelect: (


### PR DESCRIPTION
The `JobCategorySuggest` component had both `initialValue`, and `value` props which made understanding correct usage unintuitive. I've removed the `value` prop because it wasn't wired up to anything internally, and was the simpler fix.

I believe this will require a small change in Ryanair [here](https://github.com/SEEK-Jobs/indie-ryanair-frontend/blob/3b172761fe2f8c3451927ad41b186ad38a11cfbe/src/pages/Posting/positionPosting/PositionPosting.tsx#L534), but this should not require any refactoring, because this prop wasn't wired up to anything.

I've made this a semver major, because it _technically_ breaks the public interface of the component.