### PR TITLE
Update JobCategorySuggest documentation

### DIFF
--- a/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
+++ b/fe/lib/components/JobCategorySuggest/JobCategorySuggest.tsx
@@ -23,15 +23,15 @@ type RadioProps = ComponentPropsWithRef<typeof RadioGroup>;
 
 export interface JobCategorySuggestProps
   extends Partial<Omit<RadioProps, 'id' | 'value'>> {
-  positionProfile: JobCategorySuggestionPositionProfileInput;
-  schemeId: string;
+  client?: ApolloClient<unknown>;
+  debounceDelay?: number;
+  initialValue?: string;
   onSelect: (
     jobCategorySuggestionChoice: JobCategorySuggestionChoiceAttributesFragment,
   ) => void;
-  client?: ApolloClient<unknown>;
-  debounceDelay?: number;
+  positionProfile: JobCategorySuggestionPositionProfileInput;
+  schemeId: string;
   showConfidence?: boolean;
-  initialValue?: string;
 }
 
 export const JobCategorySuggest = React.memo(

--- a/fe/lib/components/JobCategorySuggest/README.md
+++ b/fe/lib/components/JobCategorySuggest/README.md
@@ -27,7 +27,7 @@ Optional:
 - `client`: An `ApolloClient` instance. By default `JobCategorySuggest` uses the client passed down via context, but a different client can be passed in.
 - `debounceDelay`: The delay in milliseconds between job category suggest calls to reduce overhead. Defaults to `250`.
 - `initialValue`: The id of a jobCategory to pre-select in the component - for example 'seekAnz:jobCategory:seek:vpzp83Sf'. This is useful when editing an existing entity with a saved Job Category that has been loaded from a data store.
-- `onSelect`: Callback function that is supplied a [SEEK JobCategorySuggestionChoice](https://developer.seek.com/schema/#/definitions/JobCategorySuggestionChoice) on job category selection.
+- `onSelect`: Callback function that is supplied a [SEEK JobCategorySuggestionChoice](https://developer.seek.com/schema/#/named-type/JobCategorySuggestionChoice) on job category selection.
 - `showConfidence`: Boolean toggle that enables to the associated confidence score of the suggested job category to be displayed on selection. Defaults to `false`.
 
 Extends:

--- a/fe/lib/components/JobCategorySuggest/README.md
+++ b/fe/lib/components/JobCategorySuggest/README.md
@@ -26,7 +26,7 @@ Optional:
 
 - `client`: An `ApolloClient` instance. By default `JobCategorySuggest` uses the client passed down via context, but a different client can be passed in.
 - `debounceDelay`: The delay in milliseconds between job category suggest calls to reduce overhead. Defaults to `250`.
-- `initialValue`: The id of a jobCategory to pre-select in the component - for example 'seekAnz:jobCategory:seek:vpzp83Sf'. This is useful when editing an existing entity with a saved Job Category that has been loaded from a data store.
+- `initialValue`: The ID of a job category to pre-select in the component - for example 'seekAnz:jobCategory:seek:vpzp83Sf'. This is useful when editing an existing entity with a saved job category that has been loaded from a data store.
 - `onSelect`: Callback function that is supplied a [SEEK JobCategorySuggestionChoice](https://developer.seek.com/schema/#/named-type/JobCategorySuggestionChoice) on job category selection.
 - `showConfidence`: Boolean toggle that enables to the associated confidence score of the suggested job category to be displayed on selection. Defaults to `false`.
 

--- a/fe/lib/components/JobCategorySuggest/README.md
+++ b/fe/lib/components/JobCategorySuggest/README.md
@@ -32,7 +32,7 @@ Optional:
 
 Extends:
 
-- You may pass through various HTML input field props including: `id`, `name`, `label`
+- You may pass through the standard HTML input fields `name` and `required`.
 
 ### Usage
 
@@ -101,7 +101,7 @@ const JobCategoryForm = () => {
         positionProfile={positionProfile}
       />
       <p>
-        Your selected job category is: {jobCategorySuggest.JobCategory.name}
+        Your selected job category is: {jobCategorySuggest.jobCategory.name}
       </p>
       <p>
         The confidence score of this category is {jobCategorySuggest.confidence}

--- a/fe/lib/components/JobCategorySuggest/README.md
+++ b/fe/lib/components/JobCategorySuggest/README.md
@@ -26,6 +26,7 @@ Optional:
 
 - `client`: An `ApolloClient` instance. By default `JobCategorySuggest` uses the client passed down via context, but a different client can be passed in.
 - `debounceDelay`: The delay in milliseconds between job category suggest calls to reduce overhead. Defaults to `250`.
+- `initialValue`: The id of a jobCategory to pre-select in the component - for example 'seekAnz:jobCategory:seek:vpzp83Sf'. This is useful when editing an existing entity with a saved Job Category that has been loaded from a data store.
 - `onSelect`: Callback function that is supplied a [SEEK JobCategorySuggestionChoice](https://developer.seek.com/schema/#/definitions/JobCategorySuggestionChoice) on job category selection.
 - `showConfidence`: Boolean toggle that enables to the associated confidence score of the suggested job category to be displayed on selection. Defaults to `false`.
 

--- a/fe/lib/components/JobCategorySuggest/README.md
+++ b/fe/lib/components/JobCategorySuggest/README.md
@@ -19,8 +19,8 @@ Read more about underlying [`jobCategorySuggestions` query](https://developer.se
 
 Required
 
-- `schemeId`: The scheme for the job category dataset to query.
 - `positionProfile`: Matches the shape of [`JobCategorySuggestionPositionProfileInput`](https://developer.seek.com/schema/#/definitions/JobCategorySuggestionPositionProfileInput). Including a `positionFormattedDescriptions` with `descriptionId` of `AdvertisementDetails` will increase the accuracy of the suggested job categories.
+- `schemeId`: The scheme for the job category dataset to query.
 
 Optional:
 


### PR DESCRIPTION
https://trello.com/c/TFl6rqmQ/1551-document-initialvalue-prop-of-jobcategorysuggest-component-from-wingman

These docs have slowly drifted out of date and needed a few updates to line them up with the changes we've made to the JobCategorySuggest component.

I've not added a changeset because this is only documentation and reorderings.