### PR TITLE
Limit question response choices to 99

### DIFF
--- a/.changeset/rotten-mugs-develop.md
+++ b/.changeset/rotten-mugs-develop.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': patch
+---
+
+QuestionnaireBuilder: Limit response choices to 99

--- a/fe/lib/components/QuestionnaireBuilder/FormBuilder/components/NewQuestionForm/components/SelectOptions.tsx
+++ b/fe/lib/components/QuestionnaireBuilder/FormBuilder/components/NewQuestionForm/components/SelectOptions.tsx
@@ -5,6 +5,7 @@ import {
   Columns,
   FieldMessage,
   Stack,
+  Text,
   TextField,
 } from 'braid-design-system';
 import React, { useMemo, useRef } from 'react';
@@ -14,6 +15,11 @@ import type { ResponseChoice } from '../../../../../../private/questionnaires/ty
 import { createResolver } from '../../../../../../utils';
 
 import DisplayOption from './DisplayOption';
+
+/**
+ * https://developer.seek.com/schema/#/named-type/ApplicationQuestionInput/field/responseChoice
+ */
+const RESPONSE_CHOICE_LIMIT = 99;
 
 interface FormValues {
   option: string;
@@ -99,39 +105,45 @@ export default ({ options, setOptionList }: SelectOptionsProps) => {
 
   return (
     <Stack space="medium">
-      <Stack space="small">
-        <Columns alignY="bottom" space="small">
-          <Column>
-            <Controller
-              control={control}
-              name="option"
-              render={({ field }) => (
-                <TextField
-                  {...field}
-                  id="questionnaireBuilderAddOption"
-                  label="Options"
-                  onClear={() => setValue('option', '')}
-                  ref={optionInputRef}
-                  tone={errors.option ? 'critical' : undefined}
-                />
-              )}
-            />
-          </Column>
-          <Column width="content">
-            <Actions>
-              <Button onClick={handleSubmit(addOption)}>Add</Button>
-            </Actions>
-          </Column>
-        </Columns>
+      {options.length >= RESPONSE_CHOICE_LIMIT ? (
+        <Text tone="secondary">
+          You can’t provide more than {RESPONSE_CHOICE_LIMIT} options.
+        </Text>
+      ) : (
+        <Stack space="small">
+          <Columns alignY="bottom" space="small">
+            <Column>
+              <Controller
+                control={control}
+                name="option"
+                render={({ field }) => (
+                  <TextField
+                    {...field}
+                    id="questionnaireBuilderAddOption"
+                    label="Options"
+                    onClear={() => setValue('option', '')}
+                    ref={optionInputRef}
+                    tone={errors.option ? 'critical' : undefined}
+                  />
+                )}
+              />
+            </Column>
+            <Column width="content">
+              <Actions>
+                <Button onClick={handleSubmit(addOption)}>Add</Button>
+              </Actions>
+            </Column>
+          </Columns>
 
-        {errors.option?.message ? (
-          <FieldMessage
-            id="questionnaireBuilderAddOptionMessage"
-            message={errors.option.message}
-            tone="critical"
-          />
-        ) : null}
-      </Stack>
+          {errors.option?.message ? (
+            <FieldMessage
+              id="questionnaireBuilderAddOptionMessage"
+              message={errors.option.message}
+              tone="critical"
+            />
+          ) : null}
+        </Stack>
+      )}
 
       <Stack dividers space="small">
         {options.map(({ text, preferredIndicator }) => (


### PR DESCRIPTION
You'd have to try really hard to do this in the UI, but this should also serve as documentation.

---

Example with the limit artificially reduced to 3:

| Below limit | At limit
| :-: | :-:
| <img width="457" alt="Screen Shot 2021-12-21 at 8 00 47 am" src="https://user-images.githubusercontent.com/25572311/146832255-05d0ea58-c516-4068-b891-73cafeff45c9.png"> | <img width="457" alt="Screen Shot 2021-12-21 at 8 01 17 am" src="https://user-images.githubusercontent.com/25572311/146832265-c7413233-0426-4f11-9d3c-b765dfe9d0b0.png">
