### PR TITLE
Trigger onSelect function for preselecting first brand

### DIFF
--- a/.changeset/two-cherries-guess.md
+++ b/.changeset/two-cherries-guess.md
@@ -2,4 +2,4 @@
 'wingman-fe': patch
 ---
 
-Fix branding preselect
+BrandSelect: Trigger `onSelect` when preselecting the first brand

--- a/.changeset/two-cherries-guess.md
+++ b/.changeset/two-cherries-guess.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': patch
+---
+
+Fix branding preselect

--- a/fe/lib/components/BrandSelect/BrandSelect.tsx
+++ b/fe/lib/components/BrandSelect/BrandSelect.tsx
@@ -80,8 +80,12 @@ export const BrandSelect = ({
 
       // Preselect the first brand from the query.
       setSelectedBrandId(firstBrandId);
+
+      if (onSelect) {
+        onSelect(firstBrandId);
+      }
     }
-  }, [firstBrandId, hasPreselected]);
+  }, [firstBrandId, hasPreselected, onSelect]);
 
   const handleBrandSelect = (brand: AdvertisementBrandingFieldsFragment) => {
     const nextBrandId =

--- a/fe/lib/components/BrandSelect/BrandSelect.tsx
+++ b/fe/lib/components/BrandSelect/BrandSelect.tsx
@@ -81,9 +81,7 @@ export const BrandSelect = ({
       // Preselect the first brand from the query.
       setSelectedBrandId(firstBrandId);
 
-      if (onSelect) {
-        onSelect(firstBrandId);
-      }
+      onSelect?.(firstBrandId);
     }
   }, [firstBrandId, hasPreselected, onSelect]);
 


### PR DESCRIPTION
Need to trigger the onSelect function to send the preselected brand id to the form.
> When you are on the position posting page, fill in required details, then select Standout for the ad type, the UI will preselect the first brand for you. This selected brand is not sent as part of the payload for posting a position or previewing the job ad.

