### PR TITLE
Drop `uuid` dep

### DIFF
--- a/.changeset/little-queens-know.md
+++ b/.changeset/little-queens-know.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': patch
+---
+
+deps: Drop `uuid` dependency

--- a/fe/lib/components/QuestionnaireBuilder/FormBuilder/state/formBuilderState.ts
+++ b/fe/lib/components/QuestionnaireBuilder/FormBuilder/state/formBuilderState.ts
@@ -1,5 +1,4 @@
 import React from 'react';
-import { v4 as uuid } from 'uuid';
 
 import type {
   FormComponent,
@@ -35,7 +34,7 @@ const createAddPrivacyConsentAction =
   (dispatch: React.Dispatch<AddComponentAction>) =>
   (descriptionHtml: string, url: string) => {
     const newValue: PrivacyConsent = {
-      value: uuid(),
+      value: self.crypto.randomUUID(),
       privacyPolicyUrl: {
         url,
       },
@@ -48,7 +47,7 @@ const createAddPrivacyConsentAction =
 const createAddFreeTextQuestionAction =
   (dispatch: React.Dispatch<AddComponentAction>) => (questionText: string) => {
     const newValue: FreeTextQuestion = {
-      value: uuid(),
+      value: self.crypto.randomUUID(),
       questionHtml: questionText,
       responseTypeCode: 'FreeText',
       componentTypeCode: 'Question',
@@ -66,7 +65,7 @@ const createAddSelectQuestionAction =
       value: text.replace(/ /g, '').toLowerCase(),
     }));
     const newValue: SelectionQuestion = {
-      value: uuid(),
+      value: self.crypto.randomUUID(),
       componentTypeCode: 'Question',
       questionHtml: questionText,
       responseTypeCode: questionType,

--- a/fe/package.json
+++ b/fe/package.json
@@ -5,13 +5,11 @@
   "dependencies": {
     "@apollo/client": "^3.5.6",
     "@graphql-tools/schema": "^9.0.2",
-    "@types/uuid": "^8.3.3",
     "autosuggest-highlight": "^3.2.0",
     "react-fast-compare": "^3.2.0",
     "react-hook-form": "^7.0.0",
     "runtypes": "^6.5.0",
-    "use-debounce": "^8.0.0",
-    "uuid": "^8.3.2"
+    "use-debounce": "^8.0.0"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "6.4.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5544,11 +5544,6 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
-"@types/uuid@^8.3.3":
-  version "8.3.4"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
-  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
-
 "@types/webpack-env@^1.16.0":
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.18.0.tgz#ed6ecaa8e5ed5dfe8b2b3d00181702c9925f13fb"


### PR DESCRIPTION
We're pretty aggressive on our browser policy and this appears to be supported by all major browsers.

https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID#browser_compatibility