### PR TITLE
fix: LocationSelectMap dismiss/show suggestions behaviour

### DIFF
--- a/.changeset/curvy-laws-drive.md
+++ b/.changeset/curvy-laws-drive.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': patch
+---
+
+LocationSelectMap: Dismiss suggestions on select

--- a/fe/lib/components/LocationSelectMap/LocationSelectMap.tsx
+++ b/fe/lib/components/LocationSelectMap/LocationSelectMap.tsx
@@ -164,7 +164,10 @@ export const LocationSelectMap = ({
         <Marker
           color={color.foreground.formAccentLight}
           anchor={latLong}
-          onClick={() => setLatLong(latLong)}
+          onClick={() => {
+            setLatLong(latLong);
+            setShowSuggestions(true);
+          }}
         />
         {/* View for desktops and above */}
         {showSuggestions && isDesktopOrAbove && (

--- a/fe/lib/components/LocationSelectMap/LocationSelectMap.tsx
+++ b/fe/lib/components/LocationSelectMap/LocationSelectMap.tsx
@@ -120,7 +120,10 @@ export const LocationSelectMap = ({
             paddingX={{ desktop: 'medium', tablet: 'none', mobile: 'none' }}
             paddingY="medium"
             key={location.id.value}
-            onClick={() => onLocationSelected(location)}
+            onClick={() => {
+              onLocationSelected(location);
+              setShowSuggestions(false);
+            }}
           >
             <Stack space="small">
               <Text size="small">{location.contextualName}</Text>


### PR DESCRIPTION
After using the `LocationSelectMap` outside of a modal I realised that we would likely want the suggestions panel to dismiss when a location is selected. Furthermore, now when a marker is selected after the suggestions have been dismissed, the suggestions will be shown again.