### PR TITLE
fix: Pass LocationSuggest Apollo client to LocationSelectMap

### DIFF
--- a/.changeset/curvy-kings-change.md
+++ b/.changeset/curvy-kings-change.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': patch
+---
+
+Pass Apollo client to LocationSelectMap in LocationSuggest

--- a/fe/lib/components/LocationSuggest/LocationSuggest.tsx
+++ b/fe/lib/components/LocationSuggest/LocationSuggest.tsx
@@ -182,6 +182,7 @@ export const LocationSuggest = forwardRef<
             tone={tone}
             initialLocation={initialLocation?.location ?? undefined}
             schemeId={schemeId}
+            client={client}
           />
 
           <input

--- a/fe/lib/components/LocationSuggest/LocationSuggestInput.tsx
+++ b/fe/lib/components/LocationSuggest/LocationSuggestInput.tsx
@@ -1,3 +1,4 @@
+import { ApolloClient } from '@apollo/client';
 import matchHighlights from 'autosuggest-highlight/match';
 import {
   Autosuggest,
@@ -59,6 +60,7 @@ interface Props {
   tone: ComponentProps<typeof TextField>['tone'];
   initialLocation?: Location;
   schemeId: string;
+  client?: ApolloClient<unknown>;
 }
 
 const LocationSuggestInput = ({
@@ -73,6 +75,7 @@ const LocationSuggestInput = ({
   tone,
   initialLocation,
   schemeId,
+  client,
   ...restProps
 }: Props) => {
   const initialLocationSuggest = {
@@ -215,6 +218,7 @@ const LocationSuggestInput = ({
               tablet: 600,
               mobile: 600,
             }}
+            client={client}
           />
         </Dialog>
       </Column>


### PR DESCRIPTION
This PR ensures that the same Apollo client is provided to the `LocationSelectMap` component that is used in the `LocationSuggest` components other queries