### PR TITLE
Update mock location query data to include currencies

### DIFF
--- a/.changeset/dirty-nails-jump.md
+++ b/.changeset/dirty-nails-jump.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': minor
+---
+
+fix: Add currency data to mock location queries

--- a/fe/lib/components/LocationLookup/__fixtures__/location.ts
+++ b/fe/lib/components/LocationLookup/__fixtures__/location.ts
@@ -5,6 +5,11 @@ export const mockLocation = {
   name: 'Melbourne',
   contextualName: 'Melbourne VIC 3000 AU',
   countryCode: 'AU',
+  currencies: [
+    {
+      code: 'AUD',
+    },
+  ],
   parent: {
     id: {
       value: 'seekAnz:location:seek:2m81wybwV',
@@ -12,6 +17,11 @@ export const mockLocation = {
     name: 'CBD & Inner Suburbs',
     contextualName: 'CBD & Inner Suburbs, Melbourne VIC AU',
     countryCode: 'AU',
+    currencies: [
+      {
+        code: 'AUD',
+      },
+    ],
     parent: {
       id: {
         value: 'seekAnz:location:seek:31XoHiay5',
@@ -19,6 +29,11 @@ export const mockLocation = {
       name: 'Melbourne',
       contextualName: 'Melbourne VIC AU',
       countryCode: 'AU',
+      currencies: [
+        {
+          code: 'AUD',
+        },
+      ],
       parent: {
         id: {
           value: 'seekAnz:location:seek:HxMS1gfR',
@@ -26,6 +41,11 @@ export const mockLocation = {
         name: 'Victoria',
         contextualName: 'Victoria AU',
         countryCode: 'AU',
+        currencies: [
+          {
+            code: 'AUD',
+          },
+        ],
         parent: {
           id: {
             value: 'seekAnz:location:seek:2aeax6diF',
@@ -33,6 +53,11 @@ export const mockLocation = {
           name: 'Australia',
           contextualName: 'Australia',
           countryCode: 'AU',
+          currencies: [
+            {
+              code: 'AUD',
+            },
+          ],
           parent: null,
         },
       },

--- a/fe/lib/components/LocationSelectMap/__fixtures__/nearestLocations.ts
+++ b/fe/lib/components/LocationSelectMap/__fixtures__/nearestLocations.ts
@@ -6,6 +6,11 @@ export const mockNearestLocations = [
     name: 'Melbourne',
     contextualName: 'Melbourne VIC 3000 AU',
     countryCode: 'AU',
+    currencies: [
+      {
+        code: 'AUD',
+      },
+    ],
     parent: {
       id: {
         value: 'seekAnz:location:seek:2m81wybwV',
@@ -13,6 +18,11 @@ export const mockNearestLocations = [
       name: 'CBD & Inner Suburbs',
       contextualName: 'CBD & Inner Suburbs, Melbourne VIC AU',
       countryCode: 'AU',
+      currencies: [
+        {
+          code: 'AUD',
+        },
+      ],
       parent: {
         id: {
           value: 'seekAnz:location:seek:31XoHiay5',
@@ -20,6 +30,11 @@ export const mockNearestLocations = [
         name: 'Melbourne',
         contextualName: 'Melbourne VIC AU',
         countryCode: 'AU',
+        currencies: [
+          {
+            code: 'AUD',
+          },
+        ],
         parent: {
           id: {
             value: 'seekAnz:location:seek:HxMS1gfR',
@@ -27,6 +42,11 @@ export const mockNearestLocations = [
           name: 'Victoria',
           contextualName: 'Victoria AU',
           countryCode: 'AU',
+          currencies: [
+            {
+              code: 'AUD',
+            },
+          ],
           parent: {
             id: {
               value: 'seekAnz:location:seek:2aeax6diF',
@@ -34,6 +54,11 @@ export const mockNearestLocations = [
             name: 'Australia',
             contextualName: 'Australia',
             countryCode: 'AU',
+            currencies: [
+              {
+                code: 'AUD',
+              },
+            ],
             parent: null,
           },
         },
@@ -47,6 +72,11 @@ export const mockNearestLocations = [
     name: 'Sydney',
     contextualName: 'Sydney NSW 1001 AU',
     countryCode: 'AU',
+    currencies: [
+      {
+        code: 'AUD',
+      },
+    ],
     parent: {
       id: {
         value: 'seekAnz:location:seek:2QCxeiwmR',
@@ -54,6 +84,11 @@ export const mockNearestLocations = [
       name: 'CBD, Inner West & Eastern Suburbs',
       contextualName: 'CBD, Inner West & Eastern Suburbs, Sydney NSW AU',
       countryCode: 'AU',
+      currencies: [
+        {
+          code: 'AUD',
+        },
+      ],
       parent: {
         id: {
           value: 'seekAnz:location:seek:2zY2wZbuq',
@@ -61,6 +96,11 @@ export const mockNearestLocations = [
         name: 'Sydney',
         contextualName: 'Sydney NSW AU',
         countryCode: 'AU',
+        currencies: [
+          {
+            code: 'AUD',
+          },
+        ],
         parent: {
           id: {
             value: 'seekAnz:location:seek:FTwZdE2K',
@@ -68,6 +108,11 @@ export const mockNearestLocations = [
           name: 'New South Wales',
           contextualName: 'New South Wales AU',
           countryCode: 'AU',
+          currencies: [
+            {
+              code: 'AUD',
+            },
+          ],
           parent: {
             id: {
               value: 'seekAnz:location:seek:2aeax6diF',
@@ -75,6 +120,11 @@ export const mockNearestLocations = [
             name: 'Australia',
             contextualName: 'Australia',
             countryCode: 'AU',
+            currencies: [
+              {
+                code: 'AUD',
+              },
+            ],
             parent: null,
           },
         },

--- a/fe/lib/components/LocationSuggest/__fixtures__/locationSuggest.ts
+++ b/fe/lib/components/LocationSuggest/__fixtures__/locationSuggest.ts
@@ -7,6 +7,11 @@ export const mockLocationSuggest = [
       name: 'Melbourne',
       contextualName: 'Melbourne VIC 3000 AU',
       countryCode: 'AU',
+      currencies: [
+        {
+          code: 'AUD',
+        },
+      ],
       parent: {
         id: {
           value: 'seekAnz:location:seek:2m81wybwV',
@@ -14,6 +19,11 @@ export const mockLocationSuggest = [
         name: 'CBD & Inner Suburbs',
         contextualName: 'CBD & Inner Suburbs, Melbourne VIC AU',
         countryCode: 'AU',
+        currencies: [
+          {
+            code: 'AUD',
+          },
+        ],
         parent: {
           id: {
             value: 'seekAnz:location:seek:31XoHiay5',
@@ -21,6 +31,11 @@ export const mockLocationSuggest = [
           name: 'Melbourne',
           contextualName: 'Melbourne VIC AU',
           countryCode: 'AU',
+          currencies: [
+            {
+              code: 'AUD',
+            },
+          ],
           parent: {
             id: {
               value: 'seekAnz:location:seek:HxMS1gfR',
@@ -28,6 +43,11 @@ export const mockLocationSuggest = [
             name: 'Victoria',
             contextualName: 'Victoria AU',
             countryCode: 'AU',
+            currencies: [
+              {
+                code: 'AUD',
+              },
+            ],
             parent: {
               id: {
                 value: 'seekAnz:location:seek:2aeax6diF',
@@ -35,6 +55,11 @@ export const mockLocationSuggest = [
               name: 'Australia',
               contextualName: 'Australia',
               countryCode: 'AU',
+              currencies: [
+                {
+                  code: 'AUD',
+                },
+              ],
               parent: null,
             },
           },
@@ -50,6 +75,11 @@ export const mockLocationSuggest = [
       name: 'Sydney',
       contextualName: 'Sydney NSW 1001 AU',
       countryCode: 'AU',
+      currencies: [
+        {
+          code: 'AUD',
+        },
+      ],
       parent: {
         id: {
           value: 'seekAnz:location:seek:2QCxeiwmR',
@@ -57,6 +87,11 @@ export const mockLocationSuggest = [
         name: 'CBD, Inner West & Eastern Suburbs',
         contextualName: 'CBD, Inner West & Eastern Suburbs, Sydney NSW AU',
         countryCode: 'AU',
+        currencies: [
+          {
+            code: 'AUD',
+          },
+        ],
         parent: {
           id: {
             value: 'seekAnz:location:seek:2zY2wZbuq',
@@ -64,6 +99,11 @@ export const mockLocationSuggest = [
           name: 'Sydney',
           contextualName: 'Sydney NSW AU',
           countryCode: 'AU',
+          currencies: [
+            {
+              code: 'AUD',
+            },
+          ],
           parent: {
             id: {
               value: 'seekAnz:location:seek:FTwZdE2K',
@@ -71,6 +111,11 @@ export const mockLocationSuggest = [
             name: 'New South Wales',
             contextualName: 'New South Wales AU',
             countryCode: 'AU',
+            currencies: [
+              {
+                code: 'AUD',
+              },
+            ],
             parent: {
               id: {
                 value: 'seekAnz:location:seek:2aeax6diF',
@@ -78,6 +123,11 @@ export const mockLocationSuggest = [
               name: 'Australia',
               contextualName: 'Australia',
               countryCode: 'AU',
+              currencies: [
+                {
+                  code: 'AUD',
+                },
+              ],
               parent: null,
             },
           },

--- a/fe/lib/components/LocationSuggest/__fixtures__/nearestLocations.ts
+++ b/fe/lib/components/LocationSuggest/__fixtures__/nearestLocations.ts
@@ -6,6 +6,11 @@ export const mockNearestLocations = [
     name: 'Melbourne',
     contextualName: 'Melbourne VIC 3000 AU',
     countryCode: 'AU',
+    currencies: [
+      {
+        code: 'AUD',
+      },
+    ],
     parent: {
       id: {
         value: 'seekAnz:location:seek:2m81wybwV',
@@ -13,6 +18,11 @@ export const mockNearestLocations = [
       name: 'CBD & Inner Suburbs',
       contextualName: 'CBD & Inner Suburbs, Melbourne VIC AU',
       countryCode: 'AU',
+      currencies: [
+        {
+          code: 'AUD',
+        },
+      ],
       parent: {
         id: {
           value: 'seekAnz:location:seek:31XoHiay5',
@@ -20,6 +30,11 @@ export const mockNearestLocations = [
         name: 'Melbourne',
         contextualName: 'Melbourne VIC AU',
         countryCode: 'AU',
+        currencies: [
+          {
+            code: 'AUD',
+          },
+        ],
         parent: {
           id: {
             value: 'seekAnz:location:seek:HxMS1gfR',
@@ -27,6 +42,11 @@ export const mockNearestLocations = [
           name: 'Victoria',
           contextualName: 'Victoria AU',
           countryCode: 'AU',
+          currencies: [
+            {
+              code: 'AUD',
+            },
+          ],
           parent: {
             id: {
               value: 'seekAnz:location:seek:2aeax6diF',
@@ -34,6 +54,11 @@ export const mockNearestLocations = [
             name: 'Australia',
             contextualName: 'Australia',
             countryCode: 'AU',
+            currencies: [
+              {
+                code: 'AUD',
+              },
+            ],
             parent: null,
           },
         },
@@ -47,6 +72,11 @@ export const mockNearestLocations = [
     name: 'Sydney',
     contextualName: 'Sydney NSW 1001 AU',
     countryCode: 'AU',
+    currencies: [
+      {
+        code: 'AUD',
+      },
+    ],
     parent: {
       id: {
         value: 'seekAnz:location:seek:2QCxeiwmR',
@@ -54,6 +84,11 @@ export const mockNearestLocations = [
       name: 'CBD, Inner West & Eastern Suburbs',
       contextualName: 'CBD, Inner West & Eastern Suburbs, Sydney NSW AU',
       countryCode: 'AU',
+      currencies: [
+        {
+          code: 'AUD',
+        },
+      ],
       parent: {
         id: {
           value: 'seekAnz:location:seek:2zY2wZbuq',
@@ -61,6 +96,11 @@ export const mockNearestLocations = [
         name: 'Sydney',
         contextualName: 'Sydney NSW AU',
         countryCode: 'AU',
+        currencies: [
+          {
+            code: 'AUD',
+          },
+        ],
         parent: {
           id: {
             value: 'seekAnz:location:seek:FTwZdE2K',
@@ -68,6 +108,11 @@ export const mockNearestLocations = [
           name: 'New South Wales',
           contextualName: 'New South Wales AU',
           countryCode: 'AU',
+          currencies: [
+            {
+              code: 'AUD',
+            },
+          ],
           parent: {
             id: {
               value: 'seekAnz:location:seek:2aeax6diF',
@@ -75,6 +120,11 @@ export const mockNearestLocations = [
             name: 'Australia',
             contextualName: 'Australia',
             countryCode: 'AU',
+            currencies: [
+              {
+                code: 'AUD',
+              },
+            ],
             parent: null,
           },
         },


### PR DESCRIPTION
Since our mock data does not include `currencies` for location queries, the mock versions of the components which we include in documentation are failing.