### PR TITLE
fix: Allow mutation to use the deprecated field in the input

### DIFF
--- a/.changeset/nasty-zebras-teach.md
+++ b/.changeset/nasty-zebras-teach.md
@@ -1,0 +1,5 @@
+---
+'wingman-be': minor
+---
+
+Add inputValueDeprecation true setting in createSeekGraphMiddleware

--- a/be/src/seekGraph/schema.ts
+++ b/be/src/seekGraph/schema.ts
@@ -66,7 +66,9 @@ export const createSchema = async ({
     seekApiUrlOverride,
   });
 
-  const schema = await schemaFromExecutor(executor);
+  const schema = await schemaFromExecutor(executor, undefined, {
+    inputValueDeprecation: true,
+  });
 
   return wrapSchema({
     executor,


### PR DESCRIPTION
The V1 panel in Ryanair is currently broken after I deprecate the `seekAnzAdvertisementType`.

We should be able to use the deprecated field in the mutation to demo the differnece between v1 and v3 panel.