### PR TITLE
Refactor useEffectfulState to cater reset input UI rerendering

### DIFF
--- a/.changeset/slimy-guests-melt.md
+++ b/.changeset/slimy-guests-melt.md
@@ -1,5 +1,5 @@
 ---
-'wingman-fe': minor
+'wingman-fe': patch
 ---
 
-feat: Refactor useEffectfulState hook to accept empty string
+SalaryDetails: Update state fields on empty strings

--- a/.changeset/slimy-guests-melt.md
+++ b/.changeset/slimy-guests-melt.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': minor
+---
+
+feat: Refactor useEffectfulState hook to accept empty string

--- a/fe/lib/components/SalaryDetails/SalaryDetails.tsx
+++ b/fe/lib/components/SalaryDetails/SalaryDetails.tsx
@@ -62,8 +62,9 @@ export interface SalaryDetailsProps {
 function useEffectfulState<T>(initialState: T) {
   const [state, setState] = useState(initialState);
 
+  // Make sure we rerender the input UI when the state value is reset
   useEffect(() => {
-    if (initialState) {
+    if (initialState || initialState === '') {
       setState(initialState);
     }
   }, [initialState]);


### PR DESCRIPTION
Right now, the minimum and maximum values are managed in the local useState input that is initialized from the props. 
This change is to ensure it got rerendered when the max & min values from the props values were reset