### PR TITLE
feat(LocationSuggest): Reset location on hirer change

### DIFF
--- a/.changeset/wise-wolves-hammer.md
+++ b/.changeset/wise-wolves-hammer.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': minor
+---
+
+feat(LocationSuggest): Reset on hirer change

--- a/.changeset/wise-wolves-hammer.md
+++ b/.changeset/wise-wolves-hammer.md
@@ -2,4 +2,4 @@
 'wingman-fe': minor
 ---
 
-feat(LocationSuggest): Reset on hirer change
+LocationSuggest: Reset on hirer change

--- a/fe/lib/components/LocationSuggest/LocationSuggest.stories.tsx
+++ b/fe/lib/components/LocationSuggest/LocationSuggest.stories.tsx
@@ -8,6 +8,7 @@ export default {
   args: {
     id: 'locationSuggest',
     label: 'Location',
+    hirerId: 'seekAnzPublicTest:organization:seek:93WyyF1h',
     message: 'undefined',
     reserveMessageSpace: false,
     showBreadcrumbs: false,

--- a/fe/lib/components/LocationSuggest/LocationSuggest.tsx
+++ b/fe/lib/components/LocationSuggest/LocationSuggest.tsx
@@ -115,7 +115,7 @@ export const LocationSuggest = forwardRef<
       setSelectedLocation(undefined);
       setPlaceholder('');
       onClear?.();
-    }, [hirerId, onClear])
+    }, [hirerId, onClear]);
 
     const { data: initialLocation } = useQuery<
       LocationQuery,

--- a/fe/lib/components/LocationSuggest/LocationSuggest.tsx
+++ b/fe/lib/components/LocationSuggest/LocationSuggest.tsx
@@ -118,7 +118,7 @@ export const LocationSuggest = forwardRef<
         setPlaceholder('');
         onClear?.();
       }
-    }, [hirerId, onClear]);
+    }, [hirerId, onClear, previousSuggestVariables, selectedLocation]);
 
     const { data: initialLocation } = useQuery<
       LocationQuery,

--- a/fe/lib/components/LocationSuggest/LocationSuggest.tsx
+++ b/fe/lib/components/LocationSuggest/LocationSuggest.tsx
@@ -107,6 +107,16 @@ export const LocationSuggest = forwardRef<
       },
     );
 
+    useEffect(() => {
+      /**
+       * Location suggestions vary depending on the hirer.
+       * Hence, we should clear the selected location when the hirer changes.
+       */
+      setSelectedLocation(undefined);
+      setPlaceholder('');
+      onClear?.();
+    }, [hirerId, onClear])
+
     const { data: initialLocation } = useQuery<
       LocationQuery,
       LocationQueryVariables

--- a/fe/lib/components/LocationSuggest/LocationSuggest.tsx
+++ b/fe/lib/components/LocationSuggest/LocationSuggest.tsx
@@ -80,6 +80,7 @@ export const LocationSuggest = forwardRef<
       data: suggestData,
       previousData: previousSuggestData,
       error: suggestError,
+      variables: previousSuggestVariables,
     } = useQuery<SuggestLocationsQuery, SuggestLocationsQueryVariables>(
       LOCATION_SUGGEST,
       {
@@ -112,9 +113,11 @@ export const LocationSuggest = forwardRef<
        * Location suggestions vary depending on the hirer.
        * Hence, we should clear the selected location when the hirer changes.
        */
-      setSelectedLocation(undefined);
-      setPlaceholder('');
-      onClear?.();
+      if (selectedLocation && hirerId !== previousSuggestVariables?.hirerId) {
+        setSelectedLocation(undefined);
+        setPlaceholder('');
+        onClear?.();
+      }
     }, [hirerId, onClear]);
 
     const { data: initialLocation } = useQuery<


### PR DESCRIPTION
Adds logic to `LocationSuggest` so that it clears when the `hirerId` changes. This is because the locations returned by the location suggestions query vary depending on the hirer.