### PR TITLE
Wrap `InlineCode` with `Text`

### DIFF
--- a/.changeset/dull-timers-change.md
+++ b/.changeset/dull-timers-change.md
@@ -1,0 +1,5 @@
+---
+'wingman-fe': patch
+---
+
+LocationSelectionMap: Fix location ID text styling

--- a/fe/lib/components/LocationSelectMap/LocationSelectMap.tsx
+++ b/fe/lib/components/LocationSelectMap/LocationSelectMap.tsx
@@ -134,7 +134,9 @@ export const LocationSelectMap = ({
             >
               <Stack space="small">
                 <Text size="small">{location.contextualName}</Text>
-                <InlineCode>{location.id.value}</InlineCode>
+                <Text size="small">
+                  <InlineCode>{location.id.value}</InlineCode>
+                </Text>
               </Stack>
             </Box>
           </React.Fragment>


### PR DESCRIPTION
`Text` sets the right color mode and stops the element from stretching to full width.