### PR TITLE
Revert "fix: @types/uuid"

### DIFF
--- a/.changeset/poor-steaks-shop.md
+++ b/.changeset/poor-steaks-shop.md
@@ -1,5 +1,0 @@
----
-'wingman-fe': minor
----
-
-Drop `uuid` dependency 

--- a/fe/lib/components/QuestionnaireBuilder/FormBuilder/state/formBuilderState.ts
+++ b/fe/lib/components/QuestionnaireBuilder/FormBuilder/state/formBuilderState.ts
@@ -1,6 +1,5 @@
-import { randomUUID } from 'crypto';
-
 import React from 'react';
+import { v4 as uuid } from 'uuid';
 
 import type {
   FormComponent,
@@ -36,7 +35,7 @@ const createAddPrivacyConsentAction =
   (dispatch: React.Dispatch<AddComponentAction>) =>
   (descriptionHtml: string, url: string) => {
     const newValue: PrivacyConsent = {
-      value: randomUUID(),
+      value: uuid(),
       privacyPolicyUrl: {
         url,
       },
@@ -49,7 +48,7 @@ const createAddPrivacyConsentAction =
 const createAddFreeTextQuestionAction =
   (dispatch: React.Dispatch<AddComponentAction>) => (questionText: string) => {
     const newValue: FreeTextQuestion = {
-      value: randomUUID(),
+      value: uuid(),
       questionHtml: questionText,
       responseTypeCode: 'FreeText',
       componentTypeCode: 'Question',
@@ -67,7 +66,7 @@ const createAddSelectQuestionAction =
       value: text.replace(/ /g, '').toLowerCase(),
     }));
     const newValue: SelectionQuestion = {
-      value: randomUUID(),
+      value: uuid(),
       componentTypeCode: 'Question',
       questionHtml: questionText,
       responseTypeCode: questionType,

--- a/fe/package.json
+++ b/fe/package.json
@@ -6,12 +6,14 @@
     "@apollo/client": "^4.0.0",
     "@graphql-tools/schema": "^10.0.0",
     "@types/autosuggest-highlight": "^3.2.3",
+    "@types/uuid": "^10.0.0",
     "autosuggest-highlight": "^3.2.0",
     "pigeon-maps": "^0.22.0",
     "react-fast-compare": "^3.2.0",
     "react-hook-form": "^7.0.0",
     "runtypes": "^7.0.0",
     "use-debounce": "^10.0.0",
+    "uuid": "^13.0.0",
     "rxjs": "^7.8.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@types/autosuggest-highlight':
         specifier: ^3.2.3
         version: 3.2.3
+      '@types/uuid':
+        specifier: ^10.0.0
+        version: 10.0.0
       autosuggest-highlight:
         specifier: ^3.2.0
         version: 3.3.4
@@ -78,6 +81,9 @@ importers:
       use-debounce:
         specifier: ^10.0.0
         version: 10.0.6(react@18.3.1)
+      uuid:
+        specifier: ^13.0.0
+        version: 13.0.0
     devDependencies:
       '@faker-js/faker':
         specifier: 9.9.0
@@ -2362,6 +2368,9 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -7067,6 +7076,10 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  uuid@13.0.0:
+    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+    hasBin: true
+
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
@@ -9533,7 +9546,7 @@ snapshots:
       lodash: 4.17.21
       react: 18.3.1
 
-  '@loadable/webpack-plugin@5.15.2(webpack@5.101.3(@swc/core@1.13.5)(esbuild@0.25.10))':
+  '@loadable/webpack-plugin@5.15.2(webpack@5.101.3(esbuild@0.25.10))':
     dependencies:
       make-dir: 3.1.0
       webpack: 5.101.3(@swc/core@1.13.5)(esbuild@0.25.10)
@@ -9634,7 +9647,7 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.6.1(react-refresh@0.17.0)(type-fest@0.21.3)(webpack-dev-server@5.2.0(debug@4.4.3)(webpack@5.101.3(esbuild@0.25.10)))(webpack-hot-middleware@2.26.1)(webpack@5.101.3(@swc/core@1.13.5)(esbuild@0.25.10))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.6.1(react-refresh@0.17.0)(type-fest@0.21.3)(webpack-dev-server@5.2.0(debug@4.4.3)(webpack@5.101.3(esbuild@0.25.10)))(webpack-hot-middleware@2.26.1)(webpack@5.101.3(esbuild@0.25.10))':
     dependencies:
       anser: 2.3.2
       core-js-pure: 3.45.1
@@ -10153,6 +10166,8 @@ snapshots:
 
   '@types/tough-cookie@4.0.5': {}
 
+  '@types/uuid@10.0.0': {}
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 24.5.2
@@ -10417,7 +10432,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@vanilla-extract/webpack-plugin@2.3.22(babel-plugin-macros@3.1.0)(webpack@5.101.3(@swc/core@1.13.5)(esbuild@0.25.10))':
+  '@vanilla-extract/webpack-plugin@2.3.22(babel-plugin-macros@3.1.0)(webpack@5.101.3(esbuild@0.25.10))':
     dependencies:
       '@vanilla-extract/integration': 8.0.4(babel-plugin-macros@3.1.0)
       debug: 4.4.3
@@ -10510,7 +10525,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vocab/webpack@1.2.12(webpack@5.101.3(@swc/core@1.13.5)(esbuild@0.25.10))':
+  '@vocab/webpack@1.2.12(webpack@5.101.3(esbuild@0.25.10))':
     dependencies:
       '@vocab/core': 1.6.4
       cjs-module-lexer: 2.1.0
@@ -10855,7 +10870,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.0.0(@babel/core@7.28.4)(webpack@5.101.3(@swc/core@1.13.5)(esbuild@0.25.10)):
+  babel-loader@10.0.0(@babel/core@7.28.4)(webpack@5.101.3(esbuild@0.25.10)):
     dependencies:
       '@babel/core': 7.28.4
       find-up: 5.0.0
@@ -11434,7 +11449,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.101.3(esbuild@0.25.10)
 
-  css-loader@7.1.2(webpack@5.101.3(@swc/core@1.13.5)(esbuild@0.25.10)):
+  css-loader@7.1.2(webpack@5.101.3(esbuild@0.25.10)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -13737,7 +13752,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.101.3(@swc/core@1.13.5)(esbuild@0.25.10)):
+  mini-css-extract-plugin@2.9.4(webpack@5.101.3(esbuild@0.25.10)):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.3
@@ -14199,7 +14214,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
-  postcss-loader@8.2.0(postcss@8.5.6)(typescript@5.8.3)(webpack@5.101.3(@swc/core@1.13.5)(esbuild@0.25.10)):
+  postcss-loader@8.2.0(postcss@8.5.6)(typescript@5.8.3)(webpack@5.101.3(esbuild@0.25.10)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 2.6.0
@@ -14998,8 +15013,8 @@ snapshots:
       '@loadable/babel-plugin': 5.16.1(@babel/core@7.28.4)
       '@loadable/component': 5.16.7(react@18.3.1)
       '@loadable/server': 5.16.7(@loadable/component@5.16.7(react@18.3.1))(react@18.3.1)
-      '@loadable/webpack-plugin': 5.15.2(webpack@5.101.3(@swc/core@1.13.5)(esbuild@0.25.10))
-      '@pmmmwh/react-refresh-webpack-plugin': 0.6.1(react-refresh@0.17.0)(type-fest@0.21.3)(webpack-dev-server@5.2.0(debug@4.4.3)(webpack@5.101.3(esbuild@0.25.10)))(webpack-hot-middleware@2.26.1)(webpack@5.101.3(@swc/core@1.13.5)(esbuild@0.25.10))
+      '@loadable/webpack-plugin': 5.15.2(webpack@5.101.3(esbuild@0.25.10))
+      '@pmmmwh/react-refresh-webpack-plugin': 0.6.1(react-refresh@0.17.0)(type-fest@0.21.3)(webpack-dev-server@5.2.0(debug@4.4.3)(webpack@5.101.3(esbuild@0.25.10)))(webpack-hot-middleware@2.26.1)(webpack@5.101.3(esbuild@0.25.10))
       '@sku-lib/utils': 0.0.0
       '@sku-lib/vite': 0.1.2(@types/react@18.3.25)(react@18.3.1)(vite@7.1.7(@types/node@24.5.2)(jiti@2.6.0)(terser@5.44.0)(yaml@2.8.1))
       '@swc/core': 1.13.5
@@ -15012,18 +15027,18 @@ snapshots:
       '@vanilla-extract/integration': 8.0.4(babel-plugin-macros@3.1.0)
       '@vanilla-extract/jest-transform': 1.1.17(babel-plugin-macros@3.1.0)
       '@vanilla-extract/vite-plugin': 5.1.1(@types/node@24.5.2)(babel-plugin-macros@3.1.0)(jiti@2.6.0)(terser@5.44.0)(vite@7.1.7(@types/node@24.5.2)(jiti@2.6.0)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1)
-      '@vanilla-extract/webpack-plugin': 2.3.22(babel-plugin-macros@3.1.0)(webpack@5.101.3(@swc/core@1.13.5)(esbuild@0.25.10))
+      '@vanilla-extract/webpack-plugin': 2.3.22(babel-plugin-macros@3.1.0)(webpack@5.101.3(esbuild@0.25.10))
       '@vitejs/plugin-basic-ssl': 2.1.0(vite@7.1.7(@types/node@24.5.2)(jiti@2.6.0)(terser@5.44.0)(yaml@2.8.1))
       '@vitejs/plugin-react': 4.7.0(vite@7.1.7(@types/node@24.5.2)(jiti@2.6.0)(terser@5.44.0)(yaml@2.8.1))
       '@vocab/core': 1.6.4
       '@vocab/phrase': 2.1.1
       '@vocab/pseudo-localize': 1.0.1
       '@vocab/vite': 0.2.4(vite@7.1.7(@types/node@24.5.2)(jiti@2.6.0)(terser@5.44.0)(yaml@2.8.1))
-      '@vocab/webpack': 1.2.12(webpack@5.101.3(@swc/core@1.13.5)(esbuild@0.25.10))
+      '@vocab/webpack': 1.2.12(webpack@5.101.3(esbuild@0.25.10))
       '@zendesk/babel-plugin-react-displayname': https://codeload.github.com/zendesk/babel-plugin-react-displayname/tar.gz/7a837f2(@babel/core@7.28.4)(@babel/preset-react@7.27.1(@babel/core@7.28.4))
       autoprefixer: 10.4.21(postcss@8.5.6)
       babel-jest: 30.1.2(@babel/core@7.28.4)
-      babel-loader: 10.0.0(@babel/core@7.28.4)(webpack@5.101.3(@swc/core@1.13.5)(esbuild@0.25.10))
+      babel-loader: 10.0.0(@babel/core@7.28.4)(webpack@5.101.3(esbuild@0.25.10))
       babel-plugin-macros: 3.1.0
       babel-plugin-module-resolver: 5.0.2
       babel-plugin-transform-react-remove-prop-types: 0.4.24
@@ -15035,7 +15050,7 @@ snapshots:
       commander: 12.1.0
       compression: 1.8.1
       cross-spawn: 7.0.6
-      css-loader: 7.1.2(webpack@5.101.3(@swc/core@1.13.5)(esbuild@0.25.10))
+      css-loader: 7.1.2(webpack@5.101.3(esbuild@0.25.10))
       cssnano: 7.1.1(postcss@8.5.6)
       death: 1.1.0
       debug: 4.4.3
@@ -15062,7 +15077,7 @@ snapshots:
       jiti: 2.6.0
       lint-staged: 16.2.0
       magicast: 0.3.5
-      mini-css-extract-plugin: 2.9.4(webpack@5.101.3(@swc/core@1.13.5)(esbuild@0.25.10))
+      mini-css-extract-plugin: 2.9.4(webpack@5.101.3(esbuild@0.25.10))
       nano-memoize: 3.0.16
       node-html-parser: 7.0.1
       open: 10.2.0
@@ -15070,7 +15085,7 @@ snapshots:
       path-to-regexp: 6.3.0
       picomatch: 4.0.3
       postcss: 8.5.6
-      postcss-loader: 8.2.0(postcss@8.5.6)(typescript@5.8.3)(webpack@5.101.3(@swc/core@1.13.5)(esbuild@0.25.10))
+      postcss-loader: 8.2.0(postcss@8.5.6)(typescript@5.8.3)(webpack@5.101.3(esbuild@0.25.10))
       prettier: 3.6.2
       pretty-ms: 9.3.0
       prompts: 2.4.2
@@ -15734,6 +15749,8 @@ snapshots:
   utility-types@3.11.0: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@13.0.0: {}
 
   uuid@8.3.2: {}
 


### PR DESCRIPTION
Reverts seek-oss/wingman#1333

Crypto is a Node.js library, we can use window.crypto.randomUUID() down the line but our browser support policy doesn't allow that yet: https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID#browser_compatibility